### PR TITLE
feat(cli): chorus init daemon-setup step + real cross-platform auto-start (A4)

### DIFF
--- a/cli/__tests__/daemon-lifecycle-dispatch.test.mjs
+++ b/cli/__tests__/daemon-lifecycle-dispatch.test.mjs
@@ -28,6 +28,7 @@ function fakeService(over = {}) {
     uninstallService: vi.fn(() => ({ platform: "linux", removed: true, unitPath: "/u", steps: ["removed /u"] })),
     systemctlUser: vi.fn(() => ({ status: 0, stdout: "", stderr: "" })),
     journalctlUser: vi.fn(() => ({ status: 0, stdout: "journal-body", stderr: "" })),
+    launchctl: vi.fn(() => ({ status: 0, stdout: "", stderr: "" })),
     resolveServicePaths: vi.fn(() => ({ nodePath: "/node", scriptPath: "/x/chorus.mjs", path: "/bin" })),
     // The install pre-config phase (credential preflight + cwd wizard). Default:
     // both succeed offline so the install dispatch tests never touch real
@@ -239,6 +240,108 @@ describe("runDaemon — supervisor (systemd) delegation", () => {
   });
 });
 
+describe("runDaemon — supervisor (launchd) delegation", () => {
+  // On macOS with a loaded LaunchAgent, the control verbs route to launchctl and
+  // ~/.chorus/daemon.log instead of the pidfile.
+  const loaded = (over = {}) => fakeService({
+    detectSupervisor: vi.fn(() => ({ kind: "launchd", installed: true, active: true, label: "com.chorus.daemon", plistPath: "/p.plist" })),
+    ...over,
+  });
+
+  it("status delegates to launchctl list and never touches the pidfile", async () => {
+    const logs = [];
+    const service = loaded();
+    service.launchctl = vi.fn(() => ({ status: 0, stdout: "{ \"PID\" = 123; };", stderr: "" }));
+    const lifecycle = fakeLifecycle();
+    const code = await runDaemon(
+      { action: "status" },
+      { lifecycle, service, log: (m) => logs.push(m), errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(0);
+    expect(logs.join("")).toMatch(/managed by launchd/);
+    expect(service.launchctl).toHaveBeenCalledWith(["list", "com.chorus.daemon"]);
+    expect(lifecycle.isRunning).not.toHaveBeenCalled();
+  });
+
+  it("status returns 1 when the agent is installed but NOT loaded", async () => {
+    const service = fakeService({
+      detectSupervisor: () => ({ kind: "launchd", installed: true, active: false, label: "com.chorus.daemon", plistPath: "/p.plist" }),
+    });
+    const logs = [];
+    const code = await runDaemon(
+      { action: "status" },
+      { lifecycle: fakeLifecycle(), service, log: (m) => logs.push(m), errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(1);
+    expect(logs.join("")).toMatch(/NOT loaded/);
+  });
+
+  it("stop delegates to launchctl unload and does not signal the pidfile", async () => {
+    const service = loaded();
+    const lifecycle = fakeLifecycle();
+    const logs = [];
+    const code = await runDaemon(
+      { action: "stop" },
+      { lifecycle, service, log: (m) => logs.push(m), errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(0);
+    expect(service.launchctl).toHaveBeenCalledWith(["unload", "/p.plist"]);
+    expect(lifecycle.stopDaemon).not.toHaveBeenCalled();
+    expect(logs.join("")).toMatch(/stopped the daemon service/);
+    expect(logs.join("")).toMatch(/load again at next login/);
+  });
+
+  it("restart delegates to launchctl unload then load and does not re-detach", async () => {
+    const service = loaded();
+    const lifecycle = fakeLifecycle();
+    const code = await runDaemon(
+      { action: "restart" },
+      { lifecycle, service, log: () => {}, errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(0);
+    expect(service.launchctl).toHaveBeenNthCalledWith(1, ["unload", "/p.plist"]);
+    expect(service.launchctl).toHaveBeenNthCalledWith(2, ["load", "/p.plist"]);
+    expect(lifecycle.startBackground).not.toHaveBeenCalled();
+  });
+
+  it("logs reads ~/.chorus/daemon.log via the log reader (launchd routes stdout there)", async () => {
+    const service = loaded();
+    const out = [];
+    const code = await runDaemon(
+      { action: "logs" },
+      { lifecycle: fakeLifecycle(), service, log: (m) => out.push(m), errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(0);
+    expect(out.join("")).toContain("log-body");
+    expect(service.journalctlUser).not.toHaveBeenCalled();
+  });
+
+  it("a stop failure under launchd surfaces the error and returns 1", async () => {
+    const service = loaded();
+    service.launchctl = vi.fn(() => ({ status: 1, stdout: "", stderr: "Unload failed" }));
+    const errs = [];
+    const code = await runDaemon(
+      { action: "stop" },
+      { lifecycle: fakeLifecycle(), service, log: () => {}, errLog: (m) => errs.push(m), env: {} }
+    );
+    expect(code).toBe(1);
+    expect(errs.join("")).toMatch(/failed to stop the service/i);
+  });
+
+  it("no launchd agent installed: status falls back to the pidfile path", async () => {
+    // detectSupervisor kind:none (default) → the pidfile probe is used, unchanged.
+    const lifecycle = fakeLifecycle({ isRunning: vi.fn(() => ({ running: true, pid: 55, stale: false })) });
+    const logs = [];
+    const code = await runDaemon(
+      { action: "status" },
+      { lifecycle, service: fakeService(), log: (m) => logs.push(m), errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(0);
+    expect(logs.join("")).toMatch(/running \(pid 55\)/);
+    expect(lifecycle.isRunning).toHaveBeenCalled();
+  });
+});
+
 describe("runDaemon — install / uninstall", () => {
   it("install runs the credential + cwd + agent config phase, passes --chorus-only into the spec (NOT --agent), and reports success", async () => {
     const service = fakeService();
@@ -329,9 +432,9 @@ describe("runDaemon — install / uninstall", () => {
     expect(errs.join("")).toMatch(/install failed: daemon-reload failed/);
   });
 
-  it("install on macOS prints the template + steps and exits 0 without failing", async () => {
+  it("install on macOS reports a real launchd install success (exit 0)", async () => {
     const service = fakeService({
-      installService: () => ({ platform: "darwin", installed: false, unitPath: "/p.plist", unitText: "<plist/>", steps: ["Save the plist below to /p.plist"] }),
+      installService: () => ({ platform: "darwin", installed: true, unitPath: "/p.plist", unitText: "<plist/>", steps: ["wrote /p.plist", "launchctl load -w /p.plist"] }),
     });
     const logs = [];
     const code = await runDaemon(
@@ -339,8 +442,37 @@ describe("runDaemon — install / uninstall", () => {
       { lifecycle: fakeLifecycle(), service, log: (m) => logs.push(m), errLog: () => {}, env: {} }
     );
     expect(code).toBe(0);
-    expect(logs.join("\n")).toMatch(/Linux-only/);
-    expect(logs.join("\n")).toContain("<plist/>");
+    expect(logs.join("\n")).toMatch(/installed and started the daemon service/);
+    expect(logs.join("\n")).toContain("launchctl load -w /p.plist");
+    // launchd needs no lingering — the Linux-only linger hint must not appear
+    expect(logs.join("\n")).not.toMatch(/enable-linger/);
+  });
+
+  it("install surfaces a macOS launchd failure as exit 1", async () => {
+    const service = fakeService({
+      installService: () => ({ platform: "darwin", installed: false, unitPath: "/p.plist", unitText: "<plist/>", steps: ["wrote /p.plist"], error: "launchctl load -w failed: Load failed: 5" }),
+    });
+    const errs = [];
+    const code = await runDaemon(
+      { action: "install" },
+      { lifecycle: fakeLifecycle(), service, log: () => {}, errLog: (m) => errs.push(m), env: {} }
+    );
+    expect(code).toBe(1);
+    expect(errs.join("")).toMatch(/install failed: launchctl load -w failed/);
+  });
+
+  it("install on Windows/other prints the template + steps and exits 0", async () => {
+    const service = fakeService({
+      installService: () => ({ platform: "other", installed: false, unitText: "node chorus.mjs daemon", steps: ["Automatic service install is only supported on Linux (systemd)."] }),
+    });
+    const logs = [];
+    const code = await runDaemon(
+      { action: "install" },
+      { lifecycle: fakeLifecycle(), service, log: (m) => logs.push(m), errLog: () => {}, env: {} }
+    );
+    expect(code).toBe(0);
+    expect(logs.join("\n")).toMatch(/not supported on this platform/);
+    expect(logs.join("\n")).toContain("node chorus.mjs daemon");
   });
 
   it("uninstall reports removal on Linux; 'nothing to remove' when absent", async () => {

--- a/cli/__tests__/daemon-service.test.mjs
+++ b/cli/__tests__/daemon-service.test.mjs
@@ -5,15 +5,18 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   SERVICE_NAME,
+  LAUNCHD_LABEL,
   systemdUnitPath,
   launchdPlistPath,
   buildServiceArgs,
   renderSystemdUnit,
   renderLaunchdPlist,
   detectSupervisor,
+  autostartCapability,
   installService,
   uninstallService,
   systemctlUser,
+  launchctl,
   resolveServicePaths,
 } from "../daemon-service.mjs";
 
@@ -138,9 +141,9 @@ describe("detectSupervisor", () => {
     };
   }
 
-  it("returns kind:none off Linux", () => {
-    expect(detectSupervisor(io({ platform: "darwin" }))).toEqual({ kind: "none" });
+  it("returns kind:none on unsupported platforms (win32/other)", () => {
     expect(detectSupervisor(io({ platform: "win32" }))).toEqual({ kind: "none" });
+    expect(detectSupervisor(io({ platform: "aix" }))).toEqual({ kind: "none" });
   });
 
   it("installed + active when the unit exists and is-active says active", () => {
@@ -164,6 +167,75 @@ describe("detectSupervisor", () => {
   it("still reports systemd when inactive but the unit file is present", () => {
     const r = detectSupervisor(io({ existsSync: () => true, spawnSync: () => ({ status: 3, stdout: "unknown\n", stderr: "" }) }));
     expect(r).toMatchObject({ kind: "systemd", installed: true, active: false });
+  });
+
+  it("darwin: reports launchd when the plist exists and launchctl lists it loaded", () => {
+    const r = detectSupervisor(io({
+      platform: "darwin",
+      existsSync: () => true,
+      spawnSync: () => ({ status: 0, stdout: "{ ... };\n", stderr: "" }), // launchctl list ok
+    }));
+    expect(r).toMatchObject({ kind: "launchd", installed: true, active: true, label: LAUNCHD_LABEL });
+    expect(r.plistPath).toBe(launchdPlistPath({ home: "/home/u" }));
+  });
+
+  it("darwin: launchd installed-but-not-loaded when plist exists but launchctl list fails", () => {
+    const r = detectSupervisor(io({
+      platform: "darwin",
+      existsSync: () => true,
+      spawnSync: () => ({ status: 1, stdout: "", stderr: "Could not find service" }),
+    }));
+    expect(r).toMatchObject({ kind: "launchd", installed: true, active: false });
+  });
+
+  it("darwin: kind:none when neither the plist nor a loaded agent exists", () => {
+    const r = detectSupervisor(io({
+      platform: "darwin",
+      existsSync: () => false,
+      spawnSync: () => ({ status: 1, stdout: "", stderr: "" }),
+    }));
+    expect(r).toEqual({ kind: "none" });
+  });
+});
+
+describe("autostartCapability", () => {
+  it("returns launchd on darwin (launchctl is always present)", () => {
+    expect(autostartCapability({ platform: "darwin", spawnSync: vi.fn() })).toBe("launchd");
+  });
+
+  it("returns systemd on linux when systemctl --user --version succeeds", () => {
+    const io = { platform: "linux", spawnSync: vi.fn(() => ({ status: 0, stdout: "systemd 255\n", stderr: "" })) };
+    expect(autostartCapability(io)).toBe("systemd");
+  });
+
+  it("returns unsupported on linux when systemctl is unavailable (status null)", () => {
+    // spawnSync sets .error / null status when the binary is missing.
+    const io = { platform: "linux", spawnSync: vi.fn(() => ({ status: null, error: new Error("ENOENT"), stdout: "", stderr: "" })) };
+    expect(autostartCapability(io)).toBe("unsupported");
+  });
+
+  it("returns unsupported on linux when systemctl --version exits non-zero", () => {
+    const io = { platform: "linux", spawnSync: vi.fn(() => ({ status: 1, stdout: "", stderr: "no user bus" })) };
+    expect(autostartCapability(io)).toBe("unsupported");
+  });
+
+  it("returns unsupported on win32 and other platforms", () => {
+    expect(autostartCapability({ platform: "win32", spawnSync: vi.fn() })).toBe("unsupported");
+    expect(autostartCapability({ platform: "aix", spawnSync: vi.fn() })).toBe("unsupported");
+  });
+});
+
+describe("launchctl helper", () => {
+  it("never throws when spawnSync throws", () => {
+    const r = launchctl(["list"], { spawnSync: () => { throw new Error("no launchctl"); } });
+    expect(r.status).toBe(null);
+    expect(r.stderr).toMatch(/no launchctl/);
+  });
+
+  it("maps a spawnSync ENOENT error to a null status", () => {
+    const r = launchctl(["list"], { spawnSync: () => ({ error: new Error("spawn launchctl ENOENT"), status: null, stdout: "", stderr: "" }) });
+    expect(r.status).toBe(null);
+    expect(r.stderr).toMatch(/ENOENT/);
   });
 });
 
@@ -233,14 +305,61 @@ describe("installService", () => {
     expect(r.error).toMatch(/enable --now failed: nope/);
   });
 
-  it("darwin: does not write, returns a plist template + manual steps", () => {
-    const io = { platform: "darwin", home: "/home/u", writeFileSync: vi.fn(), mkdirSync: vi.fn(), spawnSync: vi.fn() };
+  function darwinIO(over = {}) {
+    const calls = [];
+    return {
+      io: {
+        platform: "darwin",
+        home: "/home/u",
+        mkdirSync: vi.fn(),
+        writeFileSync: vi.fn(),
+        readFileSync: vi.fn(() => "old-plist"),
+        existsSync: vi.fn(() => false),
+        unlinkSync: vi.fn(),
+        spawnSync: vi.fn((cmd, args) => {
+          calls.push([cmd, ...args]);
+          return { status: 0, stdout: "", stderr: "" };
+        }),
+        ...over,
+      },
+      calls,
+    };
+  }
+
+  it("darwin: writes the plist and runs launchctl load -w (real install)", () => {
+    const { io, calls } = darwinIO();
     const r = installService({ ...BASE }, io);
-    expect(r).toMatchObject({ platform: "darwin", installed: false });
-    expect(io.writeFileSync).not.toHaveBeenCalled();
-    expect(r.unitText).toContain("<plist");
-    expect(r.unitPath).toBe(launchdPlistPath({ home: "/home/u" }));
-    expect(r.steps.join(" ")).toMatch(/launchctl load/);
+    expect(r).toMatchObject({ platform: "darwin", installed: true });
+    const plistPath = launchdPlistPath({ home: "/home/u" });
+    const writeCall = io.writeFileSync.mock.calls.find(([p]) => p === plistPath);
+    expect(writeCall).toBeTruthy();
+    expect(writeCall[1]).toContain("<plist");
+    // load -w on the plist, preceded by a best-effort unload
+    expect(calls).toContainEqual(["launchctl", "load", "-w", plistPath]);
+    expect(calls.some((c) => c[0] === "launchctl" && c[1] === "unload")).toBe(true);
+  });
+
+  it("darwin: backs up an existing plist before overwrite", () => {
+    const { io } = darwinIO({ existsSync: vi.fn(() => true) });
+    installService({ ...BASE }, io);
+    const bak = io.writeFileSync.mock.calls.find(([p]) => String(p).endsWith(".chorus-bak"));
+    expect(bak).toBeTruthy();
+  });
+
+  it("darwin: returns installed:false + error when launchctl load -w fails", () => {
+    const { io } = darwinIO({
+      spawnSync: vi.fn((_c, args) => (args.includes("load") ? { status: 1, stdout: "", stderr: "Load failed: 5" } : { status: 0, stdout: "", stderr: "" })),
+    });
+    const r = installService({ ...BASE }, io);
+    expect(r.installed).toBe(false);
+    expect(r.error).toMatch(/launchctl load -w failed: Load failed: 5/);
+  });
+
+  it("darwin: never bakes credentials into the plist", () => {
+    const { io } = darwinIO();
+    const r = installService({ ...BASE }, io);
+    expect(r.unitText).not.toContain("CHORUS_API_KEY");
+    expect(r.unitText).not.toContain("CHORUS_URL");
   });
 
   it("other platform: returns the foreground command with no -d and no write", () => {
@@ -289,10 +408,36 @@ describe("uninstallService", () => {
     expect(io.unlinkSync).not.toHaveBeenCalled();
   });
 
-  it("darwin: returns manual unload/rm steps", () => {
-    const r = uninstallService({ platform: "darwin", home: "/home/u" });
-    expect(r).toMatchObject({ platform: "darwin", removed: false });
-    expect(r.steps.join(" ")).toMatch(/launchctl unload/);
+  it("darwin: unloads and removes the plist (real uninstall)", () => {
+    const calls = [];
+    const io = {
+      platform: "darwin",
+      home: "/home/u",
+      existsSync: vi.fn(() => true),
+      unlinkSync: vi.fn(),
+      spawnSync: vi.fn((cmd, args) => {
+        calls.push([cmd, ...args]);
+        return { status: 0, stdout: "", stderr: "" };
+      }),
+    };
+    const r = uninstallService(io);
+    const plistPath = launchdPlistPath({ home: "/home/u" });
+    expect(r).toMatchObject({ platform: "darwin", removed: true });
+    expect(calls).toContainEqual(["launchctl", "unload", "-w", plistPath]);
+    expect(io.unlinkSync).toHaveBeenCalledWith(plistPath);
+  });
+
+  it("darwin: reports nothing-to-remove when the plist is absent", () => {
+    const io = {
+      platform: "darwin",
+      home: "/home/u",
+      existsSync: vi.fn(() => false),
+      unlinkSync: vi.fn(),
+      spawnSync: vi.fn(() => ({ status: 1, stdout: "", stderr: "Could not find" })),
+    };
+    const r = uninstallService(io);
+    expect(r.removed).toBe(false);
+    expect(io.unlinkSync).not.toHaveBeenCalled();
   });
 });
 

--- a/cli/__tests__/init-daemon-setup-integration.test.mjs
+++ b/cli/__tests__/init-daemon-setup-integration.test.mjs
@@ -1,0 +1,76 @@
+// cli/__tests__/init-daemon-setup-integration.test.mjs
+// End-to-end integration checkpoint for the daemon-setup step (proposal-review
+// BLOCKER-2): drive the REAL runInit orchestrator → the REAL daemon-setup step →
+// the REAL installService, with only the leaf IO faked (io.platform="linux" + a
+// fake spawnSync/writeFileSync, and hermetic credential resolve/validate + a
+// capturing writeConfig). Asserts the modules COMPOSE — a coherent systemd unit is
+// rendered, daemon.json receives creds + cwds + agent, and `enable --now` runs.
+import { describe, it, expect } from "vitest";
+import { runInit } from "../init.mjs";
+import { daemonSetupStep } from "../init/steps/daemon-setup.mjs";
+import { systemdUnitPath } from "../daemon-service.mjs";
+
+describe("chorus init → daemon-setup → installService (integration, linux)", () => {
+  it("installs a coherent systemd unit and persists creds+cwds+agent to daemon.json", async () => {
+    const spawnCalls = [];
+    const fileWrites = [];
+    const serviceIo = {
+      platform: "linux",
+      home: "/home/u",
+      mkdirSync: () => {},
+      writeFileSync: (p, t) => fileWrites.push([p, t]),
+      // unit not yet installed → detectSupervisor returns kind:none → not idempotent-skip
+      existsSync: () => false,
+      unlinkSync: () => {},
+      spawnSync: (cmd, args) => {
+        spawnCalls.push([cmd, ...(args ?? [])]);
+        // systemctl --version (capability probe) and all install verbs succeed.
+        return { status: 0, stdout: "systemd 255", stderr: "" };
+      },
+    };
+
+    const configWrites = [];
+    const deps = {
+      env: { PATH: "/usr/bin:/bin" },
+      io: { log: () => {}, isTTY: false }, // non-interactive
+      detectAgents: async () => [{ id: "claude", displayName: "Claude Code", binaryOnPath: false, configDirPresent: false, detected: false }],
+      resolveSelection: async () => ({ selectedIds: ["claude"] }),
+      // Run ONLY the real daemon-setup step through the real orchestrator.
+      orderedSteps: () => [daemonSetupStep],
+      ctxExtras: {
+        serviceIo,
+        // Hermetic preflight IO threaded into the REAL resolveInstall* resolvers.
+        writeConfig: (partial) => { configWrites.push(partial); return "/home/u/.chorus/daemon.json"; },
+        readJson: () => null, // unconfigured → cwds default to process cwd, agent → default
+        resolve: () => ({ url: "https://c.example", apiKey: "cho_k", source: "env" }),
+        validate: async () => ({ uuid: "agent-1", name: "Bot" }),
+        processCwd: "/proj",
+      },
+    };
+
+    // --daemon-autostart makes the non-interactive run actually install.
+    const code = await runInit(["--daemon-autostart", "--yes"], deps);
+    expect(code).toBe(0);
+
+    // 1. A coherent systemd unit was written to the right path.
+    const unitWrite = fileWrites.find(([p]) => p === systemdUnitPath({ home: "/home/u" }));
+    expect(unitWrite).toBeTruthy();
+    expect(unitWrite[1]).toMatch(/Type=simple/);
+    expect(unitWrite[1]).toMatch(/ExecStart=.*chorus\.mjs daemon/);
+
+    // 2. enable --now ran (start now + at boot).
+    expect(spawnCalls).toContainEqual(["systemctl", "--user", "daemon-reload"]);
+    expect(spawnCalls).toContainEqual(["systemctl", "--user", "enable", "--now", "chorus-daemon.service"]);
+
+    // 3. daemon.json received creds (from the credential gate) + cwds + agent.
+    const merged = Object.assign({}, ...configWrites);
+    expect(merged.url).toBe("https://c.example");
+    expect(merged.apiKey).toBe("cho_k");
+    expect(merged.agentUuid).toBe("agent-1");
+    expect(Array.isArray(merged.cwds) && merged.cwds.length > 0).toBe(true);
+    expect(merged.agent).toBe("claude-code");
+    // connection-only: never a provider-secret field.
+    expect(merged).not.toHaveProperty("ANTHROPIC_API_KEY");
+    expect(JSON.stringify(configWrites)).not.toMatch(/AWS_|BEDROCK/);
+  });
+});

--- a/cli/__tests__/init-daemon-setup.test.mjs
+++ b/cli/__tests__/init-daemon-setup.test.mjs
@@ -1,0 +1,172 @@
+// cli/__tests__/init-daemon-setup.test.mjs
+// Unit tests for the `chorus init` daemon-setup step (idea a7c2a3e8). All
+// collaborators (capability probe, supervisor detect, installService, and the
+// reused daemon-install preflight resolvers) are injected, so the step's decision
+// logic is exercised without real systemctl / launchctl / disk / network.
+import { describe, it, expect, vi } from "vitest";
+import { setupDaemon, daemonSetupStep } from "../init/steps/daemon-setup.mjs";
+import { OUTCOME_ACTIONS } from "../init/contracts.mjs";
+
+const { INSTALLED, SKIPPED, FAILED } = OUTCOME_ACTIONS;
+
+function ctx(over = {}) {
+  return {
+    env: {},
+    flags: {},
+    io: { log: vi.fn(), isTTY: false },
+    autostartCapability: vi.fn(() => "systemd"),
+    detectSupervisor: vi.fn(() => ({ kind: "none" })),
+    installService: vi.fn(() => ({ platform: "linux", installed: true, unitPath: "/u", unitText: "Type=simple", steps: ["wrote /u", "systemctl --user enable --now chorus-daemon.service"] })),
+    resolveServicePaths: vi.fn(() => ({ nodePath: "/node", scriptPath: "/x/chorus.mjs", path: "/bin" })),
+    resolveInstallCredentials: vi.fn(async () => ({ ok: true, creds: { url: "u", apiKey: "cho_k" }, identity: { uuid: "a", name: "Bot" } })),
+    resolveInstallCwds: vi.fn(async () => ({ cwds: ["/a"] })),
+    resolveInstallAgent: vi.fn(async () => ({ ok: true, agent: "claude-code", cliFound: true })),
+    processCwd: "/proj",
+    ...over,
+  };
+}
+
+describe("daemonSetupStep shape", () => {
+  it("is a once-scoped step ordered after plugin-install (20)", () => {
+    expect(daemonSetupStep.scope).toBe("once");
+    expect(daemonSetupStep.order).toBeGreaterThan(20);
+  });
+});
+
+describe("full preflight (always runs)", () => {
+  it("persists cwds + backend agent before any install decision", async () => {
+    const c = ctx({ flags: {} }); // non-interactive, no --daemon-autostart → will skip install
+    await setupDaemon(c);
+    expect(c.resolveInstallCwds).toHaveBeenCalledOnce();
+    expect(c.resolveInstallAgent).toHaveBeenCalledOnce();
+  });
+});
+
+describe("capability gate", () => {
+  it("unsupported platform: writes daemon.json + prints manual steps, never installs (even with --daemon-autostart)", async () => {
+    const c = ctx({
+      autostartCapability: vi.fn(() => "unsupported"),
+      flags: { daemonAutostart: true },
+    });
+    const r = await setupDaemon(c);
+    expect(r.action).toBe(SKIPPED);
+    expect(r.detail).toMatch(/unsupported/);
+    expect(c.installService).not.toHaveBeenCalled();
+    expect(c.resolveInstallCredentials).not.toHaveBeenCalled();
+    // manual start hint printed
+    expect(c.io.log.mock.calls.flat().join("\n")).toMatch(/chorus daemon/);
+  });
+});
+
+describe("non-interactive (non-TTY or --yes) decision", () => {
+  it("skips the service without --daemon-autostart and names the flag (never prompts)", async () => {
+    const ask = vi.fn();
+    const c = ctx({ io: { log: vi.fn(), isTTY: false, ask }, flags: {} });
+    const r = await setupDaemon(c);
+    expect(r.action).toBe(SKIPPED);
+    expect(r.detail).toMatch(/--daemon-autostart/);
+    expect(ask).not.toHaveBeenCalled();
+    expect(c.installService).not.toHaveBeenCalled();
+  });
+
+  it("installs with --daemon-autostart on a supported platform", async () => {
+    const c = ctx({ flags: { daemonAutostart: true } });
+    const r = await setupDaemon(c);
+    expect(r.action).toBe(INSTALLED);
+    expect(c.resolveInstallCredentials).toHaveBeenCalledOnce();
+    expect(c.installService).toHaveBeenCalledOnce();
+  });
+
+  it("treats --yes in a TTY as non-interactive (flag governs, no prompt)", async () => {
+    const ask = vi.fn();
+    const c = ctx({ io: { log: vi.fn(), isTTY: true, ask }, flags: { yes: true } });
+    const r = await setupDaemon(c);
+    expect(ask).not.toHaveBeenCalled();
+    expect(r.action).toBe(SKIPPED); // no --daemon-autostart
+  });
+});
+
+describe("interactive (TTY) decision — default No", () => {
+  it("declining (blank/Enter) writes daemon.json + manual steps, installs nothing", async () => {
+    const ask = vi.fn(async () => ""); // Enter = default No
+    const c = ctx({ io: { log: vi.fn(), isTTY: true, ask } });
+    const r = await setupDaemon(c);
+    expect(ask).toHaveBeenCalledOnce();
+    expect(r.action).toBe(SKIPPED);
+    expect(c.installService).not.toHaveBeenCalled();
+  });
+
+  it("accepting (y) runs the credential gate and installs", async () => {
+    const ask = vi.fn(async () => "y");
+    const c = ctx({ io: { log: vi.fn(), isTTY: true, ask } });
+    const r = await setupDaemon(c);
+    expect(r.action).toBe(INSTALLED);
+    expect(c.resolveInstallCredentials).toHaveBeenCalledOnce();
+    expect(c.installService).toHaveBeenCalledOnce();
+  });
+});
+
+describe("credential validate-or-abort gate", () => {
+  it("aborts installing nothing when credentials fail to resolve/validate", async () => {
+    const c = ctx({
+      flags: { daemonAutostart: true },
+      resolveInstallCredentials: vi.fn(async () => ({ ok: false })),
+    });
+    const r = await setupDaemon(c);
+    expect(r.action).toBe(FAILED);
+    expect(c.installService).not.toHaveBeenCalled();
+  });
+
+  it("does not lean on credential-seed — it calls the validating resolver itself", async () => {
+    const c = ctx({ flags: { daemonAutostart: true } });
+    await setupDaemon(c);
+    expect(c.resolveInstallCredentials).toHaveBeenCalledOnce();
+  });
+});
+
+describe("idempotency (report_skip_repair)", () => {
+  it("already-installed re-run skips WITHOUT re-validating creds or reinstalling", async () => {
+    const c = ctx({
+      flags: { daemonAutostart: true },
+      detectSupervisor: vi.fn(() => ({ kind: "systemd", installed: true, active: true, unitPath: "/u" })),
+    });
+    const r = await setupDaemon(c);
+    expect(r.action).toBe(SKIPPED);
+    expect(r.detail).toMatch(/already configured/);
+    expect(c.resolveInstallCredentials).not.toHaveBeenCalled();
+    expect(c.installService).not.toHaveBeenCalled();
+  });
+
+  it("launchd already-installed also short-circuits", async () => {
+    const c = ctx({
+      flags: { daemonAutostart: true },
+      autostartCapability: vi.fn(() => "launchd"),
+      detectSupervisor: vi.fn(() => ({ kind: "launchd", installed: true, active: true, label: "com.chorus.daemon", plistPath: "/p.plist" })),
+    });
+    const r = await setupDaemon(c);
+    expect(r.action).toBe(SKIPPED);
+    expect(c.installService).not.toHaveBeenCalled();
+  });
+});
+
+describe("install outcome", () => {
+  it("surfaces a failed install as FAILED (non-zero)", async () => {
+    const c = ctx({
+      flags: { daemonAutostart: true },
+      installService: vi.fn(() => ({ platform: "linux", installed: false, error: "systemctl enable --now failed: boom", steps: ["wrote /u"] })),
+    });
+    const r = await setupDaemon(c);
+    expect(r.action).toBe(FAILED);
+    expect(r.detail).toMatch(/systemctl enable --now failed: boom/);
+  });
+
+  it("never collects provider secrets — no AWS_/ANTHROPIC prompt or write path exists", async () => {
+    // The step only ever calls resolveInstallCwds/Agent/Credentials; there is no
+    // provider-secret collection. Guard against a regression that adds one.
+    const ask = vi.fn(async () => "y");
+    const c = ctx({ io: { log: vi.fn(), isTTY: true, ask } });
+    await setupDaemon(c);
+    const askedText = ask.mock.calls.flat().join(" ");
+    expect(askedText).not.toMatch(/AWS|ANTHROPIC|BEDROCK|secret|token/i);
+  });
+});

--- a/cli/daemon-service.mjs
+++ b/cli/daemon-service.mjs
@@ -35,6 +35,9 @@ import { fileURLToPath } from "node:url";
 /** The systemd --user unit name (also the launchd label stem). */
 export const SERVICE_NAME = "chorus-daemon";
 
+/** The macOS launchd LaunchAgent label. */
+export const LAUNCHD_LABEL = "com.chorus.daemon";
+
 /** Default IO bundle — overridable per-call for tests (no real disk/process). */
 function defaultIO() {
   return {
@@ -232,25 +235,39 @@ function systemdQuoteArg(token) {
 
 /**
  * Detect whether a supervisor already manages the chorus daemon on this host.
- * Linux only (systemd --user); everything else reports `{ kind: "none" }`.
- *   - kind: "systemd" with installed (unit file present, `is-enabled` not
- *     "not-found") and active (`is-active` == "active").
- *   - kind: "none" otherwise (or when systemctl is unavailable).
+ *   - Linux → kind: "systemd" (unit file present and/or `is-active` == "active").
+ *   - macOS → kind: "launchd" (LaunchAgent plist present and/or `launchctl list
+ *     <label>` reports it loaded).
+ *   - kind: "none" otherwise (or when the service manager is unavailable).
  * Used by the lifecycle subcommands to decide whether to delegate.
  * @param {object} [io]
- * @returns {{ kind: "systemd", installed: boolean, active: boolean, unitPath: string } | { kind: "none" }}
+ * @returns {{ kind: "systemd", installed: boolean, active: boolean, unitPath: string }
+ *   | { kind: "launchd", installed: boolean, active: boolean, label: string, plistPath: string }
+ *   | { kind: "none" }}
  */
 export function detectSupervisor(io = defaultIO()) {
-  if (io.platform !== "linux") return { kind: "none" };
-  const unitPath = systemdUnitPath(io);
-  const installed = safeExists(unitPath, io);
-  // `is-active` is authoritative for "running under systemd right now". Query it
-  // even when the unit file is absent: a transient/unit-less path still returns
-  // non-active, and we never want to throw here.
-  const activeRes = systemctlUser(["is-active", `${SERVICE_NAME}.service`], io);
-  const active = (activeRes.stdout ?? "").trim() === "active";
-  if (!installed && !active) return { kind: "none" };
-  return { kind: "systemd", installed, active, unitPath };
+  if (io.platform === "linux") {
+    const unitPath = systemdUnitPath(io);
+    const installed = safeExists(unitPath, io);
+    // `is-active` is authoritative for "running under systemd right now". Query it
+    // even when the unit file is absent: a transient/unit-less path still returns
+    // non-active, and we never want to throw here.
+    const activeRes = systemctlUser(["is-active", `${SERVICE_NAME}.service`], io);
+    const active = (activeRes.stdout ?? "").trim() === "active";
+    if (!installed && !active) return { kind: "none" };
+    return { kind: "systemd", installed, active, unitPath };
+  }
+  if (io.platform === "darwin") {
+    const plistPath = launchdPlistPath(io);
+    const installed = safeExists(plistPath, io);
+    // `launchctl list <label>` exits 0 when the agent is loaded (prints its dict),
+    // non-zero otherwise. This is authoritative for "loaded right now".
+    const listRes = launchctl(["list", LAUNCHD_LABEL], io);
+    const active = listRes.status === 0;
+    if (!installed && !active) return { kind: "none" };
+    return { kind: "launchd", installed, active, label: LAUNCHD_LABEL, plistPath };
+  }
+  return { kind: "none" };
 }
 
 function safeExists(path, io) {
@@ -279,6 +296,44 @@ export function journalctlUser(args, io = defaultIO()) {
   } catch (err) {
     return { status: null, stdout: "", stderr: err instanceof Error ? err.message : String(err) };
   }
+}
+
+/** Run `launchctl <args>`, capturing output. Never throws. macOS only. */
+export function launchctl(args, io = defaultIO()) {
+  try {
+    const r = io.spawnSync("launchctl", args, { encoding: "utf8" });
+    // spawnSync sets .error (and status null) when the binary is missing (ENOENT);
+    // surface that as a null status + the error message rather than throwing.
+    if (r?.error) {
+      return { status: null, stdout: r?.stdout ?? "", stderr: String(r.error.message ?? r.error) };
+    }
+    return { status: r?.status ?? null, stdout: r?.stdout ?? "", stderr: r?.stderr ?? "" };
+  } catch (err) {
+    return { status: null, stdout: "", stderr: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Classify whether THIS host supports installing a real boot-autostart daemon
+ * service, and via which supervisor. The single source of truth both
+ * `chorus daemon install` and the `chorus init` daemon-setup step consult so they
+ * cannot disagree about what "supported" means (add-chorus-init-daemon-setup).
+ *   - "systemd"     — Linux where `systemctl --user` is usable.
+ *   - "launchd"     — macOS (launchctl is always present).
+ *   - "unsupported" — Linux without a usable systemctl, Windows, or anything else.
+ * Pure-ish: only probes `systemctl --user --version` on Linux (injected IO).
+ * @param {object} [io]
+ * @returns {"systemd" | "launchd" | "unsupported"}
+ */
+export function autostartCapability(io = defaultIO()) {
+  if (io.platform === "darwin") return "launchd";
+  if (io.platform === "linux") {
+    // `systemctl --user` must be reachable — a container/minimal host may lack it,
+    // in which case there is no real boot service we can install.
+    const probe = systemctlUser(["--version"], io);
+    return probe.status === 0 ? "systemd" : "unsupported";
+  }
+  return "unsupported";
 }
 
 /**
@@ -331,19 +386,39 @@ export function installService(spec, io = defaultIO()) {
     }
   }
   if (io.platform === "darwin") {
+    // Real launchd install (add-chorus-init-daemon-setup): write the LaunchAgent
+    // plist and `launchctl load -w` it so it starts now and at every login —
+    // no longer a printed-template-only posture.
     const plistPath = launchdPlistPath(io);
     const unitText = renderLaunchdPlist({ ...spec, home, logPath: join(home, ".chorus", "daemon.log") });
-    return {
-      platform: "darwin",
-      installed: false,
-      unitPath: plistPath,
-      unitText,
-      steps: [
-        `Save the plist below to ${plistPath}`,
-        `launchctl load -w ${plistPath}`,
-        `Check: launchctl list | grep com.chorus.daemon`,
-      ],
-    };
+    const steps = [];
+    try {
+      io.mkdirSync(dirname(plistPath), { recursive: true });
+      // Back up an existing plist before overwrite (backup-before-overwrite
+      // convention, mirrors the init plugin-install step); best-effort.
+      if (safeExists(plistPath, io) && typeof io.readFileSync === "function") {
+        try {
+          io.writeFileSync(`${plistPath}.chorus-bak`, io.readFileSync(plistPath));
+          steps.push(`backed up existing plist → ${plistPath}.chorus-bak`);
+        } catch {
+          // a failed backup must not block the (idempotent) re-install
+        }
+      }
+      // Unload any currently-loaded copy first so a re-install applies the new
+      // plist rather than leaving the old agent running (parallels the systemd
+      // restart). Best-effort — a not-loaded agent returns non-zero here.
+      launchctl(["unload", plistPath], io);
+      io.writeFileSync(plistPath, unitText, { mode: 0o644 });
+      steps.push(`wrote ${plistPath}`);
+      const load = launchctl(["load", "-w", plistPath], io);
+      if (load.status !== 0) {
+        return { platform: "darwin", installed: false, unitPath: plistPath, unitText, steps, error: `launchctl load -w failed: ${load.stderr.trim() || `exit ${load.status}`}` };
+      }
+      steps.push(`launchctl load -w ${plistPath}`);
+      return { platform: "darwin", installed: true, unitPath: plistPath, unitText, steps };
+    } catch (err) {
+      return { platform: "darwin", installed: false, unitPath: plistPath, unitText, steps, error: err instanceof Error ? err.message : String(err) };
+    }
   }
   // Windows / other: no first-class service model without native deps. Print the
   // foreground command an operator can wrap in their supervisor of choice.
@@ -398,18 +473,30 @@ export function uninstallService(io = defaultIO()) {
     return { platform: "linux", removed: existed || disable.status === 0, unitPath, steps };
   }
   if (io.platform === "darwin") {
+    // Real launchd uninstall (add-chorus-init-daemon-setup): unload the agent and
+    // remove the plist. Idempotent: tolerate an already-absent plist / not-loaded
+    // agent.
     const plistPath = launchdPlistPath(io);
-    return {
-      platform: "darwin",
-      removed: false,
-      unitPath: plistPath,
-      steps: [`launchctl unload -w ${plistPath}`, `rm ${plistPath}`],
-    };
+    const steps = [];
+    const existed = safeExists(plistPath, io);
+    // unload -w stops the agent and clears its "enabled" override; a not-loaded
+    // agent returns non-zero, which we tolerate.
+    const unload = launchctl(["unload", "-w", plistPath], io);
+    if (unload.status === 0) steps.push(`launchctl unload -w ${plistPath}`);
+    try {
+      if (existed) {
+        io.unlinkSync(plistPath);
+        steps.push(`removed ${plistPath}`);
+      }
+    } catch (err) {
+      return { platform: "darwin", removed: false, unitPath: plistPath, steps, error: err instanceof Error ? err.message : String(err) };
+    }
+    return { platform: "darwin", removed: existed, unitPath: plistPath, steps };
   }
   return {
     platform: "other",
     removed: false,
-    steps: ["Automatic service uninstall is only supported on Linux (systemd). Remove the daemon from your supervisor manually."],
+    steps: ["Automatic service uninstall is only supported on Linux (systemd) and macOS (launchd). Remove the daemon from your supervisor manually."],
   };
 }
 

--- a/cli/daemon.mjs
+++ b/cli/daemon.mjs
@@ -75,6 +75,7 @@ import {
   uninstallService,
   systemctlUser,
   journalctlUser,
+  launchctl,
   resolveServicePaths,
   SERVICE_NAME,
 } from "./daemon-service.mjs";
@@ -783,6 +784,7 @@ export async function runDaemon(flags = {}, deps = {}) {
     uninstallService,
     systemctlUser,
     journalctlUser,
+    launchctl,
     resolveServicePaths: () => resolveServicePaths(env),
   };
   // The preflight dep bundle — built from the same seams runDaemon resolved, so
@@ -1118,11 +1120,13 @@ export async function preflight(ctx) {
 /**
  * Dispatch a daemon lifecycle subcommand. Two families:
  *   - install / uninstall — manage the boot-autostart supervisor service
- *     (systemd --user on Linux; a printed template on macOS/Windows).
+ *     (systemd --user on Linux; launchd LaunchAgent on macOS; a printed template
+ *     on Windows/other).
  *   - status / stop / restart / logs — when a supervisor unit is installed and
- *     active, DELEGATE to it (systemctl / journalctl) so a supervised daemon is
- *     never misreported as "not running"; otherwise operate on the
- *     pidfile/logfile-managed `-d` background daemon exactly as before.
+ *     active, DELEGATE to it (systemctl / journalctl on Linux, launchctl on
+ *     macOS) so a supervised daemon is never misreported as "not running";
+ *     otherwise operate on the pidfile/logfile-managed `-d` background daemon
+ *     exactly as before.
  * Each reports clearly (no silent failure). `restart` performs
  * stop-then-detached-start on the pidfile path.
  * @returns {Promise<number>} exit code
@@ -1239,21 +1243,26 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
       for (const s of r.steps) log(`[Chorus]   ${s}`);
       log(`[Chorus] it will now start automatically at login. Manage it with:`);
       log(`[Chorus]   chorus daemon status | stop | restart | logs`);
-      // A --user service only survives logout with lingering enabled; and a
-      // separately-started `chorus daemon -d` would hold the same paths and make
-      // this service exit-and-retry. Surface both so neither is a silent gotcha.
-      log(`[Chorus] to keep it running after you log out: loginctl enable-linger "$USER"`);
-      log(`[Chorus] if you previously ran 'chorus daemon -d', stop it first ('chorus daemon stop') so it doesn't hold the same paths.`);
+      if (r.platform === "linux") {
+        // A --user service only survives logout with lingering enabled; and a
+        // separately-started `chorus daemon -d` would hold the same paths and make
+        // this service exit-and-retry. Surface both so neither is a silent gotcha.
+        log(`[Chorus] to keep it running after you log out: loginctl enable-linger "$USER"`);
+        log(`[Chorus] if you previously ran 'chorus daemon -d', stop it first ('chorus daemon stop') so it doesn't hold the same paths.`);
+      } else if (r.platform === "darwin") {
+        log(`[Chorus] if you previously ran 'chorus daemon -d', stop it first ('chorus daemon stop') so it doesn't hold the same paths.`);
+      }
       return 0;
     }
-    if (r.platform === "linux") {
-      // Linux install actually failed (write / systemctl error) — surface it.
+    if (r.platform === "linux" || r.platform === "darwin") {
+      // A real install (systemd/launchd) actually failed — surface it, never a
+      // silent success or a misleading "not supported" message.
       errLog(`[Chorus] service install failed: ${r.error}`);
       for (const s of r.steps) errLog(`[Chorus]   (did: ${s})`);
       return 1;
     }
-    // macOS / Windows: not auto-installed by design — print the template + steps.
-    log(`[Chorus] automatic install is Linux-only. To run the daemon as a service on this platform:`);
+    // Windows / other: no first-class auto-install — print the template + steps.
+    log(`[Chorus] automatic install is not supported on this platform. To run the daemon as a service:`);
     for (const s of r.steps) log(`[Chorus]   ${s}`);
     log("");
     log(r.unitText);
@@ -1261,7 +1270,7 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
   }
   if (action === "uninstall") {
     const r = svc.uninstallService();
-    if (r.platform === "linux") {
+    if (r.platform === "linux" || r.platform === "darwin") {
       if (r.error) {
         errLog(`[Chorus] service uninstall failed: ${r.error}`);
         return 1;
@@ -1274,19 +1283,29 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
       }
       return 0;
     }
-    log(`[Chorus] automatic uninstall is Linux-only. To remove the service on this platform:`);
+    log(`[Chorus] automatic uninstall is not supported on this platform. To remove the service:`);
     for (const s of r.steps) log(`[Chorus]   ${s}`);
     return 0;
   }
 
   // For the control verbs, prefer a live supervisor unit over the pidfile.
+  // A supervisor is systemd (Linux) or launchd (macOS); both delegate the verbs
+  // to their service manager so a supervised daemon is never misreported as "not
+  // running" via the pidfile.
   const sup = svc.detectSupervisor();
-  const supervised = sup.kind === "systemd" && sup.installed;
+  const systemd = sup.kind === "systemd" && sup.installed;
+  const launchd = sup.kind === "launchd" && sup.installed;
 
   if (action === "status") {
-    if (supervised) {
+    if (systemd) {
       log(`[Chorus] daemon is managed by systemd (${SERVICE_NAME}.service) — ${sup.active ? "active" : "installed but NOT active"}.`);
       const r = svc.systemctlUser(["status", "--no-pager", `${SERVICE_NAME}.service`]);
+      if (r.stdout) log(r.stdout.trimEnd());
+      return sup.active ? 0 : 1;
+    }
+    if (launchd) {
+      log(`[Chorus] daemon is managed by launchd (${sup.label}) — ${sup.active ? "loaded" : "installed but NOT loaded"}.`);
+      const r = svc.launchctl(["list", sup.label]);
       if (r.stdout) log(r.stdout.trimEnd());
       return sup.active ? 0 : 1;
     }
@@ -1297,7 +1316,7 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
     return 0;
   }
   if (action === "logs") {
-    if (supervised) {
+    if (systemd) {
       const r = svc.journalctlUser(["-u", `${SERVICE_NAME}.service`, "--no-pager", "-n", "200"]);
       if (r.status !== 0 && !r.stdout) {
         errLog(`[Chorus] could not read the service journal: ${r.stderr.trim() || `exit ${r.status}`}`);
@@ -1306,6 +1325,8 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
       log(r.stdout.trimEnd());
       return 0;
     }
+    // launchd (and the pidfile path) both log to ~/.chorus/daemon.log — the plist
+    // routes stdout/stderr there — so the pidfile logfile reader serves both.
     const r = lifecycle.readLog();
     if (!r.ok) {
       errLog(`[Chorus] ${r.message}`);
@@ -1315,11 +1336,21 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
     return 0;
   }
   if (action === "stop") {
-    if (supervised) {
+    if (systemd) {
       const r = svc.systemctlUser(["stop", `${SERVICE_NAME}.service`]);
       if (r.status === 0) {
         log(`[Chorus] stopped the daemon service (systemctl --user stop ${SERVICE_NAME}.service).`);
         log(`[Chorus] note: it is still enabled and will start again at next login. To disable: chorus daemon uninstall`);
+        return 0;
+      }
+      errLog(`[Chorus] failed to stop the service: ${r.stderr.trim() || `exit ${r.status}`}`);
+      return 1;
+    }
+    if (launchd) {
+      const r = svc.launchctl(["unload", sup.plistPath]);
+      if (r.status === 0) {
+        log(`[Chorus] stopped the daemon service (launchctl unload ${sup.plistPath}).`);
+        log(`[Chorus] note: it will load again at next login. To disable: chorus daemon uninstall`);
         return 0;
       }
       errLog(`[Chorus] failed to stop the service: ${r.stderr.trim() || `exit ${r.status}`}`);
@@ -1336,10 +1367,21 @@ export async function handleLifecycleAction(action, { log, errLog, lifecycle, se
     return ok ? 0 : 1;
   }
   if (action === "restart") {
-    if (supervised) {
+    if (systemd) {
       const r = svc.systemctlUser(["restart", `${SERVICE_NAME}.service`]);
       if (r.status === 0) {
         log(`[Chorus] restarted the daemon service (systemctl --user restart ${SERVICE_NAME}.service).`);
+        return 0;
+      }
+      errLog(`[Chorus] failed to restart the service: ${r.stderr.trim() || `exit ${r.status}`}`);
+      return 1;
+    }
+    if (launchd) {
+      // launchd has no atomic restart — unload then load the same plist.
+      svc.launchctl(["unload", sup.plistPath]);
+      const r = svc.launchctl(["load", sup.plistPath]);
+      if (r.status === 0) {
+        log(`[Chorus] restarted the daemon service (launchctl unload+load ${sup.plistPath}).`);
         return 0;
       }
       errLog(`[Chorus] failed to restart the service: ${r.stderr.trim() || `exit ${r.status}`}`);

--- a/cli/init-args.mjs
+++ b/cli/init-args.mjs
@@ -21,7 +21,7 @@
  *
  * @param {string[]} argv
  * @returns {{ agents?: string[], all?: boolean, yes?: boolean, url?: string,
- *   apiKey?: string, help?: boolean }}
+ *   apiKey?: string, daemonAutostart?: boolean, help?: boolean }}
  */
 export function parseInitFlags(argv) {
   const out = {};
@@ -33,6 +33,7 @@ export function parseInitFlags(argv) {
     else if (a.startsWith("--agents=")) agentTokens.push(a.slice("--agents=".length));
     else if (a === "--all") out.all = true;
     else if (a === "--yes" || a === "-y") out.yes = true;
+    else if (a === "--daemon-autostart") out.daemonAutostart = true;
     else if (a === "--url") out.url = argv[i + 1];
     else if (a.startsWith("--url=")) out.url = a.slice("--url=".length);
     else if (a === "--api-key") out.apiKey = argv[i + 1];
@@ -85,21 +86,30 @@ OPTIONS
   --all                    Configure every supported agent.
   --url <url>              Chorus server URL     (env: CHORUS_URL) — seeded once.
   --api-key <cho_...>      Agent API key         (env: CHORUS_API_KEY) — seeded once.
+  --daemon-autostart       Install & enable the daemon boot service (Linux systemd /
+                           macOS launchd) in a non-interactive run. Ignored where
+                           auto-start is unsupported (e.g. Windows). In an
+                           interactive TTY run the daemon-setup step prompts instead
+                           (default: No).
   -y, --yes                Skip confirmation prompts (implied when non-TTY).
   -h, --help               Show this help message.
 
 NON-INTERACTIVE
   When stdin/stdout is not a TTY, you MUST pass --agents or --all — init will not
-  guess which agents to configure and aborts otherwise.
+  guess which agents to configure and aborts otherwise. The daemon boot service is
+  installed non-interactively ONLY when you pass --daemon-autostart; otherwise the
+  daemon config is written and you start it yourself with 'chorus daemon'.
 
 SCOPE
-  This installs the plugin SURFACE and seeds credentials into the daemon config.
-  Live MCP tools for each agent arrive with a sibling feature (the 'chorus mcp'
-  proxy). The legacy install-*.sh scripts are left untouched.
+  This installs the plugin SURFACE, seeds credentials into the daemon config, and
+  optionally configures + auto-starts the local daemon. Live MCP tools for each
+  agent arrive with a sibling feature (the 'chorus mcp' proxy). The legacy
+  install-*.sh scripts are left untouched.
 
 EXAMPLES
   chorus init
   chorus init --all --yes
   chorus init --agents claude,codex --url https://chorus.example.com --api-key cho_xxx --yes
+  chorus init --all --yes --daemon-autostart
 `;
 }

--- a/cli/init/registry.mjs
+++ b/cli/init/registry.mjs
@@ -17,6 +17,7 @@
 import { ADAPTERS } from "./adapters.mjs";
 import { credentialSeedStep } from "./steps/credential-seed.mjs";
 import { pluginInstallStep } from "./steps/plugin-install.mjs";
+import { daemonSetupStep } from "./steps/daemon-setup.mjs";
 
 /** @typedef {import("./contracts.mjs").AgentAdapter} AgentAdapter */
 /** @typedef {import("./contracts.mjs").InitStep} InitStep */
@@ -30,12 +31,11 @@ import { pluginInstallStep } from "./steps/plugin-install.mjs";
 export const AGENT_REGISTRY = [...ADAPTERS];
 
 /**
- * Configuration steps, run in ascending `order`. The credential-seed step
- * (order 10) is registered by its own task; the plugin-install step (order 20)
- * is registered here. Sibling ideas push their steps too.
+ * Configuration steps, run in ascending `order`: credential-seed (10),
+ * plugin-install (20), daemon-setup (30). Sibling ideas push their steps too.
  * @type {InitStep[]}
  */
-export const STEP_REGISTRY = [credentialSeedStep, pluginInstallStep];
+export const STEP_REGISTRY = [credentialSeedStep, pluginInstallStep, daemonSetupStep];
 
 /**
  * Run every adapter's detection and return one AgentDetection per supported agent.

--- a/cli/init/steps/daemon-setup.mjs
+++ b/cli/init/steps/daemon-setup.mjs
@@ -1,0 +1,187 @@
+// cli/init/steps/daemon-setup.mjs
+// The `once`-scoped daemon-setup step for `chorus init` (idea a7c2a3e8). It is the
+// reserved sibling slot in the step registry (see registry.mjs / contracts.mjs):
+// after credentials are seeded (order 10) and each agent's plugin is installed
+// (order 20), this step (order 30) configures the local Chorus daemon and, opt-in,
+// installs it as a boot-autostart service.
+//
+// Owner decisions (elaboration Round 1):
+//   - full_preflight    : reuse `daemon install`'s cwds + backend preflight so the
+//                         installed service is usable out of the box.
+//   - connection_only   : the credential model is Chorus URL + API key only — this
+//                         step collects NO provider secrets (AWS_/ANTHROPIC_/…).
+//   - default_off        : the interactive prompt defaults to No (opt-in).
+//   - explicit_flag      : a non-interactive run (non-TTY OR --yes) installs the
+//                         boot service ONLY when --daemon-autostart is passed.
+//   - linux_and_mac      : auto-start is real on Linux (systemd) and macOS (launchd);
+//                         unsupported platforms write daemon.json + print manual steps.
+//   - boot_and_now       : accepting installs AND enables the service (start now +
+//                         at every boot) via the shared installService.
+//   - report_skip_repair : a re-run where the service is already installed reports
+//                         "already configured" and does not rewrite.
+//
+// All collaborators are injected (matching credential-seed.mjs) so the step
+// unit-tests with fakes; production uses the real daemon-service / install-config
+// modules, and an integration test can drive REAL installService against a fake io.
+
+import { STEP_SCOPES, OUTCOME_ACTIONS } from "../contracts.mjs";
+import {
+  autostartCapability as defaultAutostartCapability,
+  detectSupervisor as defaultDetectSupervisor,
+  installService as defaultInstallService,
+  resolveServicePaths as defaultResolveServicePaths,
+} from "../../daemon-service.mjs";
+import {
+  resolveInstallCredentials as defaultResolveInstallCredentials,
+  resolveInstallCwds as defaultResolveInstallCwds,
+  resolveInstallAgent as defaultResolveInstallAgent,
+} from "../../daemon-install-config.mjs";
+
+const STEP_ID = "daemon-setup";
+const { INSTALLED, SKIPPED, FAILED } = OUTCOME_ACTIONS;
+const out = (action, detail) => ({ stepId: STEP_ID, action, detail });
+
+/**
+ * The daemon-setup step body.
+ * @param {import("../contracts.mjs").StepContext & {
+ *   autostartCapability?: Function, detectSupervisor?: Function,
+ *   installService?: Function, resolveServicePaths?: Function, serviceIo?: object,
+ *   resolveInstallCredentials?: Function, resolveInstallCwds?: Function,
+ *   resolveInstallAgent?: Function,
+ *   writeConfig?: Function, readJson?: Function, loginPath?: string,
+ *   resolve?: Function, validate?: Function, processCwd?: string,
+ * }} ctx
+ * @returns {Promise<import("../contracts.mjs").StepOutcome>}
+ */
+export async function setupDaemon(ctx) {
+  const env = ctx.env ?? process.env;
+  const io = ctx.io ?? {};
+  const isTTY = !!io.isTTY;
+  const flags = ctx.flags ?? {};
+  const log = typeof io.log === "function" ? io.log : () => {};
+
+  // Injectable collaborators (real defaults in production).
+  const capabilityOf = ctx.autostartCapability ?? defaultAutostartCapability;
+  const detect = ctx.detectSupervisor ?? defaultDetectSupervisor;
+  const install = ctx.installService ?? defaultInstallService;
+  const servicePaths = ctx.resolveServicePaths ?? defaultResolveServicePaths;
+  const serviceIo = ctx.serviceIo; // undefined ⇒ daemon-service uses its real defaultIO
+  const resolveCreds = ctx.resolveInstallCredentials ?? defaultResolveInstallCredentials;
+  const resolveCwds = ctx.resolveInstallCwds ?? defaultResolveInstallCwds;
+  const resolveAgent = ctx.resolveInstallAgent ?? defaultResolveInstallAgent;
+
+  // "Non-interactive" for the auto-start decision = non-TTY OR --yes (a --yes run in
+  // a TTY must never block on the prompt), matching `daemon install --yes`.
+  const nonInteractive = !isTTY || flags.yes === true;
+  const skip = nonInteractive; // suppress the resolvers' prompts in non-interactive mode
+
+  // Shared opts threaded into the reused preflight resolvers. undefined deps fall
+  // through to the resolvers' real defaults (updateDaemonConfig / readJsonSafe / …).
+  const preflightOpts = {
+    isTTY,
+    skip,
+    writeConfig: ctx.writeConfig,
+    readJson: ctx.readJson,
+    loginPath: ctx.loginPath,
+    prompt: io.ask,
+    log,
+  };
+
+  // 1. Full preflight (decision: full_preflight). Persist the served cwd set and
+  //    the default backend agent into daemon.json (credentials were seeded by the
+  //    credential-seed step at order 10). Connection-only: no provider secrets.
+  try {
+    await resolveCwds(flags, preflightOpts);
+    await resolveAgent(flags, env, { ...preflightOpts, errLog: log });
+  } catch (err) {
+    return out(FAILED, `daemon preflight failed: ${err?.message ?? String(err)}`);
+  }
+
+  const manual = () => {
+    log("[chorus init] daemon config written to ~/.chorus/daemon.json.");
+    log("[chorus init] start the daemon yourself: `chorus daemon` (foreground) or `chorus daemon -d` (background).");
+  };
+
+  // 2. Capability gate (decision: linux_and_mac). Only offer auto-start where a real
+  //    boot service exists; unsupported platforms write the config + print manual steps.
+  const capability = capabilityOf(serviceIo);
+  if (capability === "unsupported") {
+    const platformLabel = serviceIo?.platform ?? process.platform;
+    manual();
+    return out(SKIPPED, `daemon.json written; auto-start unsupported on ${platformLabel} — start with 'chorus daemon'`);
+  }
+
+  // 3. Decide whether to install (decision: default_off / explicit_flag).
+  if (nonInteractive) {
+    if (flags.daemonAutostart !== true) {
+      manual();
+      return out(SKIPPED, "daemon.json written; pass --daemon-autostart to install the boot service");
+    }
+  } else {
+    const answer = typeof io.ask === "function"
+      ? String((await io.ask("Install & enable the Chorus daemon to auto-start on boot? [y/N]: ")) ?? "").trim()
+      : "";
+    if (!/^y(es)?$/i.test(answer)) {
+      manual();
+      return out(SKIPPED, "declined auto-start; daemon.json written — start with 'chorus daemon'");
+    }
+  }
+
+  // 4. Idempotency short-circuit (decision: report_skip_repair) — BEFORE the
+  //    credential gate, so an already-installed healthy re-run neither re-validates
+  //    (which could fail on a transient server outage) nor rewrites the unit. A
+  //    missing/absent service falls through to install (which repairs the drift).
+  const sup = detect(serviceIo);
+  if ((sup.kind === "systemd" || sup.kind === "launchd") && sup.installed) {
+    return out(SKIPPED, `daemon already configured for auto-start (${sup.kind}) — left unchanged`);
+  }
+
+  // 5. Credential validate-or-abort gate — reached only when actually installing.
+  //    Reuse the SAME guarantee as `daemon install`: resolve → server-validate the
+  //    key → persist url+key+identity; abort (install nothing) on failure. This does
+  //    NOT lean on credential-seed, whose SKIPPED path performs no server validation
+  //    and whose FAILED outcome does not stop runInit.
+  let cred;
+  try {
+    cred = await resolveCreds(flags, env, {
+      isTTY,
+      skip,
+      resolve: ctx.resolve,
+      validate: ctx.validate,
+      writeConfig: ctx.writeConfig,
+      prompt: io.ask,
+      log,
+      errLog: log,
+    });
+  } catch (err) {
+    return out(FAILED, `credential preflight failed: ${err?.message ?? String(err)}`);
+  }
+  if (!cred || !cred.ok) {
+    return out(FAILED, "credentials could not be resolved/validated — no boot service installed");
+  }
+
+  // 6. Install & enable the boot service (decision: boot_and_now).
+  const cwdList = Array.isArray(flags.cwd) ? flags.cwd : typeof flags.cwd === "string" ? [flags.cwd] : [];
+  const spec = {
+    ...servicePaths(env),
+    // cwds/agent live in daemon.json (persisted above); the unit carries neither.
+    cwds: cwdList,
+    chorusOnly: flags.chorusOnly === true,
+    workingDir: ctx.processCwd ?? process.cwd(),
+  };
+  const r = install(spec, serviceIo);
+  if (r && r.installed) {
+    log("[chorus init] daemon installed & enabled — it will auto-start on boot.");
+    for (const s of r.steps ?? []) log(`[chorus init]   ${s}`);
+    return out(INSTALLED, `boot service installed (${r.platform}); manage with 'chorus daemon status|stop|restart|logs'`);
+  }
+  return out(FAILED, `service install failed: ${r?.error ?? "unknown error"}`);
+}
+
+/** @type {import("../contracts.mjs").InitStep} */
+export const daemonSetupStep = {
+  id: STEP_ID,
+  order: 30, // after credential-seed (10) and plugin-install (20)
+  scope: STEP_SCOPES.ONCE,
+  run: setupDaemon,
+};

--- a/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/README.md
+++ b/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/README.md
@@ -1,0 +1,3 @@
+# add-chorus-init-daemon-setup
+
+chorus init daemon-setup step: opt-in boot auto-start (systemd + real launchd) + connection-only centralized credential model

--- a/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/design.md
+++ b/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/design.md
@@ -1,0 +1,212 @@
+# Technical Design: `chorus init` daemon-setup + real cross-platform auto-start
+
+## Overview
+
+Two coupled pieces:
+
+1. A new **`once`-scoped init step** (`cli/init/steps/daemon-setup.mjs`) that wires
+   `chorus init` to the existing `daemon install` machinery, behind an opt-in
+   auto-start prompt and a platform capability gate.
+2. Upgrading `cli/daemon-service.mjs` so `installService` / `uninstallService`
+   perform a **real** macOS launchd install (today macOS only prints a template),
+   plus a platform capability classifier and launchd-aware supervisor detection,
+   plus launchctl delegation for the lifecycle verbs in `cli/daemon.mjs`.
+
+Everything reuses the already-tested, dependency-injected modules; nothing here
+adds a dependency or uses `shell:true`.
+
+## Existing seams this builds on (verified)
+
+- **Init step contract** (`cli/init/contracts.mjs`): `InitStep = { id, order, scope, run(ctx) }`, `scope ∈ {once, per-agent}`. The orchestrator (`cli/init.mjs`) owns per-agent iteration and passes `ctx = { selection, flags, io, env, backup, agentId?, adapter? }`. Steps today: `credential-seed` (order 10, once), `plugin-install` (order 20, per-agent). The registry (`cli/init/registry.mjs`) reserves the daemon-setup slot for this change.
+- **Install preflight** (`cli/daemon-install-config.mjs`): `resolveInstallCredentials`, `resolveInstallCwds`, `resolveInstallBrowseRoots`, `resolveInstallAgent` — each resolves via the layered resolver and persists into `~/.chorus/daemon.json` with the owner-only field-merge writer. `chorus daemon install` (dispatch in `cli/daemon.mjs`) calls them before `installService`.
+- **Service install** (`cli/daemon-service.mjs`): `installService(spec, io)` branches on `io.platform`. Linux = real `systemd --user` (write unit, `daemon-reload`, `enable --now`, `restart`). macOS = `renderLaunchdPlist(spec)` returned as a printed template only (`launchdPlistPath` = `~/Library/LaunchAgents/com.chorus.daemon.plist`). Windows/other = printed foreground command. `detectSupervisor(io)` returns a systemd verdict on Linux, `{ kind: "none" }` everywhere else. All IO is injectable (`io.spawnSync`, `io.platform`, `io.home`, `io.writeFileSync`, `io.existsSync`, `io.rmSync`).
+
+## Module contracts
+
+### 1. Platform auto-start capability classifier (`cli/daemon-service.mjs`)
+
+```
+autostartCapability(io = defaultIO()) -> "systemd" | "launchd" | "unsupported"
+```
+
+- `linux` + `systemctl --user` resolvable → `"systemd"`.
+- `darwin` → `"launchd"` (launchctl is always present on macOS).
+- anything else (`win32`, unknown) → `"unsupported"`.
+
+`detectSupervisor(io)` is extended: on `darwin`, if the LaunchAgent plist exists
+and `launchctl list` reports the label loaded, return
+`{ kind: "launchd", installed: true, active: <bool>, label }`; else `{ kind: "none" }`.
+The Linux systemd branch is unchanged. The classifier is the single source of the
+"is auto-start real here?" answer used by both the init step and install.
+
+### 2. Real macOS launchd install / uninstall (`cli/daemon-service.mjs`)
+
+`installService(spec, io)` on `darwin`:
+1. Render the plist (`renderLaunchdPlist`, already exists — foreground, `RunAtLoad`
+   + `KeepAlive`, no `-d`, no `--cwd`).
+2. Ensure `~/Library/LaunchAgents/` exists; write the plist to
+   `launchdPlistPath(io)` (back up an existing file first, mirroring the
+   backup-before-overwrite convention).
+3. `launchctl unload <plist>` (best-effort, ignore failure) then
+   `launchctl load -w <plist>` to (re)load and enable at login.
+4. On any `launchctl load -w` non-zero exit, return
+   `{ platform: "darwin", installed: false, error }` — the caller reports and exits
+   non-zero. No silent success.
+
+`uninstallService(io)` on `darwin`: `launchctl unload -w <plist>`, remove the plist
+file, report "nothing to remove" when absent. Windows/other unchanged (template).
+Credentials are still never baked into the plist — `daemon.json` (0600) is the
+persistence surface, identical to the systemd guarantee.
+
+### 3. launchd lifecycle delegation (`cli/daemon.mjs`)
+
+The lifecycle verbs already delegate to `systemctl --user` when
+`detectSupervisor` reports a Linux supervisor. Generalize the branch: when
+`detectSupervisor` reports `kind: "launchd"`, delegate to `launchctl`:
+
+- `status` → `launchctl list <label>` (exit non-zero when installed-but-not-loaded).
+- `stop` → `launchctl unload <plist>` (note it re-loads at next login unless
+  uninstalled) — consistent with the "stop leaves it enabled" systemd wording.
+- `restart` → `launchctl unload <plist>` then `launchctl load <plist>`.
+- `logs` → tail `~/.chorus/daemon.log` (the plist already routes stdout/stderr
+  there via `renderLaunchdPlist`).
+
+The pidfile path is unchanged when no supervisor is detected.
+
+### 4. `chorus init` daemon-setup step (`cli/init/steps/daemon-setup.mjs`)
+
+```
+daemonSetupStep = { id: "daemon-setup", order: 30, scope: "once", run: setupDaemon }
+```
+
+"Non-interactive" below means **non-TTY OR `--yes`** — a `--yes` run in a TTY is
+treated as non-interactive for the auto-start decision (consistent with how
+`daemon install --yes` suppresses prompts), so it never blocks on a prompt.
+
+`setupDaemon(ctx)` flow:
+1. **Full preflight (decision: full_preflight).** Reuse the `resolveInstall*`
+   persisters: this resolves/persists the **served cwd set** and the **default
+   backend agent** into `daemon.json` (interactive wizard in a TTY,
+   flags/existing/default otherwise — exactly as `daemon install` does today).
+   Credential model stays connection-only: no provider secrets collected.
+2. **Capability gate.** `cap = autostartCapability(io)`.
+   - `unsupported` → do NOT offer auto-start. Report the daemon config is written
+     and print the manual start command (`chorus daemon`), then return a
+     `skipped (autostart unsupported on <platform>)` outcome.
+3. **Decide whether to install.**
+   - **Interactive (TTY, not `--yes`):** prompt `Install & enable the Chorus daemon
+     to auto-start on boot? [y/N]`, **default No** (decision: default_off). Install
+     only on an affirmative answer.
+   - **Non-interactive (non-TTY or `--yes`) (decision: explicit_flag):** install
+     only when `flags.daemonAutostart` is set; otherwise return
+     `skipped (daemon.json written; pass --daemon-autostart to install boot service)`.
+4. **Idempotency short-circuit (decision: report_skip_repair).** Consult
+   `detectSupervisor(io)` **before** the credential gate. If a service is already
+   installed for this platform **and no drift is detected**, report
+   `skipped (already configured — autostart)` and return immediately — do NOT run
+   the credential validate-or-abort gate or rewrite anything. This ordering matters:
+   an already-installed, healthy re-run must not fail merely because the server is
+   momentarily unreachable at re-run time. Only when the service is absent, or a
+   drift is detected (missing unit but recorded, or credential/path mismatch), does
+   the step proceed to install/repair (steps 5–6).
+5. **Credential validate-or-abort gate (never install a service that fails at
+   boot).** Reached only when the step is actually going to install or repair. It
+   MUST guarantee the boot service can authenticate from the clean-env source
+   before writing any unit/plist — reusing the same `resolveInstallCredentials`
+   guarantee that standalone `daemon install` runs (layered resolve →
+   **server-validate the key** → persist url+key+identity into `daemon.json`; abort
+   non-zero if creds cannot be resolved or the key fails validation). This does NOT
+   rely on the earlier `credential-seed` step, whose SKIPPED path only checks that
+   creds *resolve* locally (no server validation) and whose FAILED outcome does not
+   stop `runInit`. If the guarantee cannot be met the step returns `failed` and
+   installs nothing — matching "Install guarantees resolvable credentials for the
+   clean-env boot service" in daemon-background-lifecycle.
+6. **Install (decision: boot_and_now).** Delegate to the existing `installService`
+   (Linux systemd `enable --now` + linger hint; macOS `launchctl load -w`). Return
+   `installed` / `repaired` / `failed` with the underlying detail; a failed install
+   is a visible non-zero outcome, never a silent skip.
+
+> **Reuse, don't reimplement:** steps 1 and 5 delegate to the existing
+> `daemon-install-config.mjs` resolvers (`resolveInstallCredentials`,
+> `resolveInstallCwds`, `resolveInstallAgent`) so the init path and standalone
+> `daemon install` share one credential/cwd/agent guarantee and cannot diverge.
+
+The step takes its collaborators (`autostartCapability`, `detectSupervisor`,
+`installService`, the `resolveInstall*` persisters, prompt `io.ask`) via the same
+injection pattern as the other steps, so it unit-tests with fakes and an injected
+`io.platform`.
+
+### 5. `--daemon-autostart` flag (`cli/init-args.mjs`)
+
+Add `--daemon-autostart` (boolean) to the parser and help text: "In a
+non-interactive run, install & enable the daemon boot service (Linux systemd /
+macOS launchd); ignored where auto-start is unsupported." In an interactive TTY run
+the prompt governs; the flag is the opt-in for non-interactive runs (non-TTY or
+`--yes`) — decision: explicit_flag.
+
+## Credential boundary & the clean-env limitation (owner decision: connection_only)
+
+`daemon.json` holds only the Chorus URL + API key. A boot-launched daemon
+(systemd `--user` or launchd LaunchAgent) starts in a **clean environment** that
+does not inherit the operator's shell-exported provider secrets, and — per this
+decision — the service unit injects only `HOME`/`PATH`, not `AWS_*` / `ANTHROPIC_*`
+/ Bedrock. Consequence: agents the boot daemon spawns will only reach a model
+provider if those provider credentials are present in the service's environment by
+some other means.
+
+This is an accepted limitation, not a bug. The daemon-setup step and the docs
+SHALL make it explicit and give concrete operator guidance, e.g.:
+
+- **systemd (Linux):** add a drop-in
+  `~/.config/systemd/user/chorus-daemon.service.d/env.conf` with
+  `[Service]\nEnvironment=ANTHROPIC_API_KEY=...`, or
+  `systemctl --user set-environment`, or a `~/.config/environment.d/*.conf` file.
+- **launchd (macOS):** `launchctl setenv` / a `EnvironmentVariables` dict in the
+  plist maintained by the operator.
+
+A future sibling (the `env`-block credential model we deferred) can automate this;
+this change only documents the manual path.
+
+## Testing strategy
+
+All paths are exercised by unit tests with an injected `io` (`io.platform`,
+`io.spawnSync`, `io.home`, fs shims), matching `cli/__tests__/daemon-service.test.mjs`
+and the init step tests. Because CI/this host is Linux, the macOS launchd paths are
+validated by setting `io.platform = "darwin"` and asserting the exact `launchctl`
+argv and plist write — not by running a real macOS service. Coverage:
+
+- `autostartCapability` → systemd / launchd / unsupported per platform.
+- `detectSupervisor` recognizes a loaded launchd LaunchAgent on darwin.
+- `installService` darwin: writes plist + `launchctl load -w`; failure → non-zero;
+  `uninstallService` darwin: unload + remove; Windows unchanged.
+- launchd lifecycle delegation: status/stop/restart/logs argv on darwin.
+- daemon-setup step: TTY prompt defaults No; `--daemon-autostart` drives
+  non-interactive (non-TTY or `--yes`) install; unsupported platform →
+  daemon.json written + manual steps, no service; already-installed → skip;
+  delegates to `installService`; never collects provider secrets; full preflight
+  persists cwds + agent; **credential validate-or-abort** — a run that decides to
+  install but whose key fails server validation installs nothing and returns
+  `failed`.
+- **Integration checkpoint (not fakes):** one end-to-end test drives the real
+  `runInit` → `daemon-setup` → real `installService` with `io.platform="linux"` and
+  a fake `spawnSync`, asserting a coherent `systemd` unit is rendered, `daemon.json`
+  carries the resolved creds + cwds + agent, and `enable --now` is invoked — so the
+  modules compose, not just pass in isolation.
+
+## Risks
+
+- **Whole-block MODIFIED of "Supervisor service install / uninstall":** the spec
+  delta overwrites the entire requirement — every scenario (including the
+  unchanged systemd ones) is re-stated with the macOS behavior flipped from
+  "template" to "real install". Reviewed for completeness.
+- **launchctl API drift across macOS versions** (`load -w` vs the newer
+  `bootstrap`/`enable`). We use the legacy `launchctl load -w`/`unload -w` verbs
+  the existing template already documents, for consistency; a future change can
+  modernize to `launchctl bootstrap gui/$UID`.
+- **No macOS in CI:** launchd behavior is only unit-verified with fakes; a live
+  macOS smoke test is a manual follow-up flagged for a human on a Mac.
+
+## design.pen
+
+Not applicable — `chorus init` is a CLI flow with no web/mobile screen. No `.pen`
+document change.

--- a/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/proposal.md
+++ b/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/proposal.md
@@ -1,0 +1,90 @@
+# Proposal: `chorus init` daemon-setup step + real cross-platform auto-start
+
+## Why
+
+The `chorus init` foundation (shipped) already detects coding agents, seeds the
+Chorus URL + API key once into the centralized `~/.chorus/daemon.json`, and
+installs each agent's plugin. Its step registry explicitly reserves a slot for a
+**daemon-setup** step (this change) so a machine can go from "nothing" to "a
+Chorus daemon running and auto-starting on boot" in one command.
+
+Today that last mile is manual: after `chorus init` the user still has to run
+`chorus daemon install` themselves, and on macOS that command only *prints* a
+launchd template — it never actually installs a boot service. So the smoothest
+onboarding path stops short of a running, boot-persistent daemon on two of the
+three target platforms.
+
+This change closes that gap: `chorus init` gains an opt-in daemon-setup step, and
+the underlying `daemon install` becomes a **real** boot-service install on macOS
+(launchd), not just Linux (systemd).
+
+## What Changes
+
+- **New `chorus init` daemon-setup step** (`once`-scoped, ordered after
+  credential-seed and plugin-install). It:
+  - Runs the same full preflight as `chorus daemon install` — resolves/persists
+    credentials **plus** the served working-directory set (`cwds`) and the
+    default backend agent — so the installed service is usable out of the box.
+  - Offers an **opt-in** "auto-start the daemon on boot?" choice, **defaulting to
+    No** in a TTY.
+  - Only offers auto-start where the platform actually supports it (Linux systemd
+    or macOS launchd). On an unsupported platform it still writes `daemon.json`
+    and prints the manual start steps, never a broken service.
+  - In a non-interactive / CI run it installs the boot service only when an
+    explicit `--daemon-autostart` flag is passed; otherwise it writes
+    `daemon.json` and skips the service (never guesses).
+  - On accept, installs **and enables** the boot service (starts now and at every
+    boot).
+  - Is idempotent: a re-run where the service is already installed reports
+    "already configured" and skips, repairing only on drift.
+
+- **Real macOS launchd install/uninstall** for `chorus daemon install` /
+  `uninstall` — writes the LaunchAgent plist to `~/Library/LaunchAgents/` and runs
+  `launchctl load -w` / `unload -w`, mirroring the Linux systemd path (validate,
+  surface failures non-zero, no silent success). Windows/other stays a printed
+  template. This is what makes the init auto-start option real on macOS.
+
+- **Platform auto-start capability classification** — a single helper that
+  classifies the host as `systemd` | `launchd` | `unsupported`, so both the init
+  step and `daemon install` agree on what "supported" means. Supervisor detection
+  is extended to recognize an installed launchd LaunchAgent (not just systemd).
+
+- **launchd lifecycle delegation** — `chorus daemon status` / `stop` / `restart` /
+  `logs` recognize a loaded launchd service on macOS and delegate to `launchctl`,
+  so a real macOS boot service is manageable through the CLI rather than being
+  misreported via the pidfile path.
+
+## Capabilities
+
+- `chorus-init` — ADDED: "Optional daemon auto-start step in `chorus init`".
+- `daemon-background-lifecycle` — MODIFIED: "Supervisor service install /
+  uninstall" (macOS becomes a real launchd install); ADDED: "Platform auto-start
+  capability classification"; ADDED: "macOS launchd lifecycle delegation".
+
+## Non-goals / Boundaries (owner decisions, elaboration Round 1)
+
+- **Credential model is connection-only.** `daemon.json` continues to hold only
+  the Chorus URL + API key. This change does **not** add a provider-secrets /
+  `env` block and does **not** inject `AWS_*` / `ANTHROPIC_*` / Bedrock secrets
+  into the service unit. Provider credentials remain inherited from the daemon
+  process environment; for a clean-env boot service the operator is responsible
+  for supplying them (documented, with concrete guidance, in `design.md`).
+- **MCP-proxy boundary.** This change only guarantees `daemon.json` is the single
+  credential source and introduces no per-agent secret injection. The `chorus mcp`
+  proxy that consumes those credentials is sibling idea cc115e6b — out of scope.
+- **Windows auto-start is out of scope.** Windows remains "unsupported for
+  auto-start" (write `daemon.json` + print manual steps). Only Linux systemd and
+  macOS launchd are real auto-start targets this version.
+
+## Impact
+
+- New file: `cli/init/steps/daemon-setup.mjs`; new flag `--daemon-autostart` in
+  `cli/init-args.mjs`; registration in `cli/init/registry.mjs`.
+- Modified: `cli/daemon-service.mjs` (real launchd install/uninstall + capability
+  classification + launchd-aware supervisor detection), `cli/daemon.mjs`
+  (lifecycle delegation to launchctl on darwin).
+- No database, API, or web-UI change. No new runtime dependency (pure Node, no
+  native bindings, no `shell:true`).
+- Docs: `chorus init` help text and the chorus skill docs (standalone + plugin)
+  gain the daemon-setup step, the `--daemon-autostart` flag, and the
+  provider-credential note.

--- a/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/specs/chorus-init/spec.md
+++ b/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/specs/chorus-init/spec.md
@@ -1,0 +1,102 @@
+# chorus-init Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Optional daemon auto-start step in `chorus init`
+
+`chorus init` SHALL run a `once`-scoped daemon-setup step, ordered after the
+credential-seed and plugin-install steps, that configures the local Chorus daemon
+and optionally installs it as a boot-autostart service. The step SHALL reuse the
+existing `chorus daemon install` preflight to resolve and persist the served
+working-directory set (`cwds`) and the default backend agent into
+`~/.chorus/daemon.json` (credentials are already seeded by the credential-seed
+step). The step SHALL NOT collect or persist model-provider secrets (e.g. `AWS_*`,
+`ANTHROPIC_*`, Bedrock) — the centralized credential model is connection-only
+(Chorus URL + API key), and no per-agent secret injection is introduced.
+
+The step SHALL offer the auto-start install **only** on a platform whose auto-start
+capability is supported (Linux systemd or macOS launchd). On an unsupported
+platform it SHALL still persist `~/.chorus/daemon.json` and print the manual start
+command, and SHALL NOT attempt to install a service.
+
+In an interactive run (a TTY without `--yes`) the step SHALL prompt whether to
+install and enable the daemon to auto-start on boot, **defaulting to No** (opt-in),
+and SHALL install only on an affirmative answer. In a non-interactive run (non-TTY,
+or `--yes`) the step SHALL install the boot service only when an explicit
+`--daemon-autostart` flag is passed; otherwise it SHALL persist
+`~/.chorus/daemon.json` and skip the service install without guessing.
+
+Before installing a boot service, the step SHALL run the same credential
+validate-or-abort guarantee as `chorus daemon install`: resolve credentials from
+the layered source, validate the key against the server, and persist the
+url + key + identity into `~/.chorus/daemon.json`. If credentials cannot be resolved
+or the key fails validation, the step SHALL install nothing and report a failure —
+it SHALL NOT rely solely on the earlier credential-seed step, and SHALL never
+install a boot service that would fail authentication and restart-loop at boot.
+
+When the user opts in on a supported platform, the step SHALL install **and enable**
+the boot service so the daemon starts immediately and at every boot (delegating to
+the same install path as `chorus daemon install`). The step SHALL be idempotent:
+when a boot service is already installed for the platform it SHALL report the
+daemon as already configured and make no destructive rewrite, applying only a
+missing/drifted delta as a repair. A failed install SHALL be reported visibly with
+its underlying error (non-zero outcome), never a silent skip.
+
+#### Scenario: Interactive run offers opt-in auto-start defaulting to No
+
+- **WHEN** a user runs `chorus init` in a TTY on a platform that supports
+  auto-start (Linux systemd or macOS launchd)
+- **THEN** the daemon-setup step persists the served cwds and backend to
+  `~/.chorus/daemon.json`, prompts whether to auto-start the daemon on boot with a
+  default of No, and installs & enables the boot service only if the user
+  affirmatively accepts
+
+#### Scenario: Declining auto-start still writes daemon config
+
+- **WHEN** a user runs `chorus init` in a TTY and declines the auto-start prompt
+- **THEN** `~/.chorus/daemon.json` is written (credentials, cwds, backend) and the
+  step prints the manual `chorus daemon` start command without installing any
+  service
+
+#### Scenario: Non-interactive run requires an explicit flag to install
+
+- **WHEN** `chorus init` runs in a non-TTY environment, or with `--yes` in a TTY,
+  WITHOUT `--daemon-autostart`
+- **THEN** the step persists `~/.chorus/daemon.json` and skips the boot-service
+  install, reporting that `--daemon-autostart` is required to install the service,
+  and does not block on a prompt
+
+#### Scenario: Auto-start install aborts on unvalidated credentials
+
+- **WHEN** the daemon-setup step decides to install (opt-in or `--daemon-autostart`)
+  but the resolved Chorus key fails server validation, or no credentials resolve
+- **THEN** the step installs no service and reports a failure, rather than
+  installing a boot service that would fail authentication at boot
+
+#### Scenario: Non-interactive run with the flag installs the service
+
+- **WHEN** `chorus init --daemon-autostart` runs in a non-TTY environment on a
+  supported platform with resolvable credentials
+- **THEN** the step installs and enables the boot service without prompting
+
+#### Scenario: Unsupported platform skips the service and prints manual steps
+
+- **WHEN** `chorus init` runs on a platform whose auto-start capability is
+  unsupported (e.g. Windows)
+- **THEN** the step persists `~/.chorus/daemon.json`, prints the manual start
+  steps, and does not attempt to install a boot service, regardless of
+  `--daemon-autostart`
+
+#### Scenario: Re-run is idempotent when the service is already installed
+
+- **WHEN** a user re-runs `chorus init` (opting in, or with `--daemon-autostart`)
+  on a machine where the boot service is already installed
+- **THEN** the step reports the daemon as already configured for auto-start and
+  makes no destructive rewrite, repairing only if a drift is detected
+
+#### Scenario: The step never collects provider secrets
+
+- **WHEN** the daemon-setup step runs in any mode
+- **THEN** it collects only the Chorus connection credentials and the daemon's
+  cwds/backend, and never prompts for or persists model-provider secrets into
+  `~/.chorus/daemon.json` or any service unit

--- a/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/specs/daemon-background-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/specs/daemon-background-lifecycle/spec.md
@@ -1,0 +1,150 @@
+# daemon-background-lifecycle Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Supervisor service install / uninstall
+
+The CLI SHALL provide `chorus daemon install` and `chorus daemon uninstall` to
+manage the daemon as an OS-supervised, boot-autostart service, replacing the prior
+documentation-templates-only posture. On **Linux** the CLI SHALL generate a
+`systemd --user` unit that runs the daemon in the **foreground** (`Type=simple`,
+`ExecStart` invoking `chorus daemon` WITHOUT `-d`, so systemd owns the process
+directly as `MainPID`), SHALL capture the `--agent` / `--chorus-only` flags passed
+to `install` plus absolute node and script paths and the current `PATH`, SHALL
+write it to `~/.config/systemd/user/chorus-daemon.service`, and SHALL then run
+`systemctl --user daemon-reload` followed by `systemctl --user enable --now` so the
+service starts immediately and at every login. On **macOS** the CLI SHALL perform a
+**real** launchd install: render the foreground LaunchAgent plist (`RunAtLoad` +
+`KeepAlive`, no `-d`, no embedded `--cwd`), back up any existing file, write it to
+`~/Library/LaunchAgents/com.chorus.daemon.plist`, and run `launchctl load -w
+<plist>` (preceded by a best-effort `launchctl unload` of any prior copy) so the
+service starts immediately and at every login — it SHALL NOT merely print a
+template. On **other platforms** (e.g. Windows) the CLI SHALL print the foreground
+command to run under the operator's supervisor of choice and write no file.
+
+The generated systemd unit and the launchd plist SHALL NOT embed `--cwd`
+arguments: the set of working directories the daemon serves is persisted to
+`~/.chorus/daemon.json` `cwds` at install time (see "Install configures the served
+working directory set") and read from there by the daemon, so a boot-time service
+and a plain `chorus daemon` serve the same paths and cannot drift. The generated
+systemd unit SHALL use `Restart=on-failure` (so a clean stop stays stopped) and
+SHALL NOT declare an `ExecStop` (a `Type=simple` stop is SIGTERM to the daemon's
+existing graceful-shutdown handler). The CLI SHALL NOT generate a `Type=forking`
+unit or an `ExecStart` containing `-d`.
+
+Before writing any service unit or plist the CLI SHALL complete the install
+credential guarantee (see "Install guarantees resolvable credentials for the
+clean-env boot service") and the working-directory configuration (see "Install
+configures the served working directory set"); if the credential guarantee cannot
+be satisfied the CLI SHALL abort without installing. On any install failure —
+failing to write the unit/plist, or a `systemctl` / `launchctl` command returning
+non-zero — the CLI SHALL report the underlying error and exit non-zero (no silent
+failure). Credentials SHALL NOT be baked into the service unit or plist as
+environment lines (a 0600 `daemon.json` is the persistence surface).
+
+`uninstall` on **Linux** SHALL `disable --now` the unit, remove the unit file, and
+`daemon-reload`; on **macOS** SHALL `launchctl unload -w <plist>` and remove the
+plist file; on both platforms SHALL report clearly when nothing was installed. On
+**other platforms** it SHALL print the manual removal steps. The implementation
+SHALL be pure Node with no native-binding dependency and SHALL NOT use `shell:true`.
+
+#### Scenario: install generates a correct systemd unit and starts it
+
+- **WHEN** the user runs `chorus daemon install` on a Linux host with `systemctl --user` available, resolvable credentials, and a configured cwd set
+- **THEN** the CLI writes `~/.config/systemd/user/chorus-daemon.service` with `Type=simple`, an `ExecStart` that runs `chorus daemon` with no `-d` and no `--cwd` argument, `Restart=on-failure`, and no `ExecStop`, then runs `daemon-reload` and `enable --now`, so systemd owns the node process as `MainPID` and the service starts at login
+
+#### Scenario: install performs a real launchd install on macOS
+
+- **WHEN** the user runs `chorus daemon install` on a macOS host with resolvable credentials and a configured cwd set
+- **THEN** the CLI writes the foreground LaunchAgent plist to `~/Library/LaunchAgents/com.chorus.daemon.plist` (RunAtLoad + KeepAlive, no `-d`, no embedded `--cwd`) and runs `launchctl load -w` on it, so the daemon starts immediately and at every login — no manual template step is required
+
+#### Scenario: install persists cwds to daemon.json rather than the unit
+
+- **WHEN** the user runs `chorus daemon install --cwd /a --cwd /b` on a Linux or macOS host
+- **THEN** the generated unit/plist contains no `--cwd` argument, and `~/.chorus/daemon.json` `cwds` contains `/a` and `/b`, so the boot service reads the served paths from the config file
+
+#### Scenario: generated unit never self-daemonizes
+
+- **WHEN** the CLI renders the systemd unit or the launchd plist for any set of flags
+- **THEN** the `ExecStart` / `ProgramArguments` contains neither `-d` nor `--detach`, and the systemd unit is not `Type=forking` — so the supervisor tracks the daemon directly and the boot-time restart loop cannot occur
+
+#### Scenario: install surfaces a failure instead of reporting success
+
+- **WHEN** `chorus daemon install` fails to write the unit/plist, or a `systemctl --user daemon-reload` / `enable --now` (Linux) or a `launchctl load -w` (macOS) returns non-zero
+- **THEN** the CLI reports the failure with the underlying error and exits non-zero (no silent failure)
+
+#### Scenario: install on an unsupported platform prints a template and does not write
+
+- **WHEN** the user runs `chorus daemon install` on Windows or another unsupported platform
+- **THEN** the CLI prints a correct foreground service template plus manual steps, writes no service file, and exits 0
+
+#### Scenario: uninstall removes the service or reports nothing to remove
+
+- **WHEN** the user runs `chorus daemon uninstall` on Linux or macOS
+- **THEN** on Linux the CLI disables and stops the unit, removes the unit file, and reloads systemd; on macOS it unloads the LaunchAgent and removes the plist — or, when nothing is installed, reports that there was nothing to remove — and on an unsupported platform prints the manual removal steps
+
+## ADDED Requirements
+
+### Requirement: Platform auto-start capability classification
+
+The CLI SHALL expose a single capability classifier that reports whether the
+current host supports installing a real boot-autostart daemon service, returning
+`systemd` on Linux where `systemctl --user` is available, `launchd` on macOS, and
+`unsupported` on every other platform. The `chorus init` daemon-setup step SHALL
+consult this classifier to decide whether to offer/perform a real service install
+on the current host, and `chorus daemon install` SHALL perform the
+platform-appropriate install (systemd on Linux, launchd on macOS, printed template
+otherwise) consistent with the classifier's verdict, so the two paths cannot
+disagree about what "supported" means. Supervisor detection SHALL recognize an
+installed service for the classified capability — a `systemd --user`
+`chorus-daemon.service` on Linux, or a loaded `com.chorus.daemon` LaunchAgent on
+macOS — so lifecycle commands do not misclassify a supervised daemon.
+
+#### Scenario: Capability reflects the platform
+
+- **WHEN** the classifier runs on Linux with `systemctl --user` available, on macOS, and on Windows respectively
+- **THEN** it returns `systemd`, `launchd`, and `unsupported` respectively
+
+#### Scenario: Linux without systemctl is unsupported for auto-start
+
+- **WHEN** the classifier runs on Linux where `systemctl --user` is not available
+- **THEN** it returns `unsupported`, so no systemd install is attempted
+
+#### Scenario: Supervisor detection recognizes a loaded launchd agent
+
+- **WHEN** supervisor detection runs on macOS and the `com.chorus.daemon` LaunchAgent plist exists and `launchctl` reports the label loaded
+- **THEN** detection reports an installed launchd supervisor rather than "none"
+
+### Requirement: macOS launchd lifecycle delegation
+
+The CLI SHALL delegate `chorus daemon status` / `stop` / `restart` / `logs` to
+`launchctl` and the service log file rather than the pidfile when a
+`com.chorus.daemon` LaunchAgent is installed and loaded on macOS, so a real macOS
+boot service is manageable through the CLI and is never misreported as "not
+running". `status`
+SHALL report the loaded state via `launchctl list` (exiting non-zero when installed
+but not loaded); `stop` SHALL `launchctl unload` the agent (noting it re-loads at
+next login unless uninstalled); `restart` SHALL `launchctl unload` then
+`launchctl load` the agent; `logs` SHALL display `~/.chorus/daemon.log`. When no
+launchd agent is installed, the subcommands SHALL operate on the pidfile/logfile
+exactly as before.
+
+#### Scenario: status delegates to launchctl when the agent is loaded
+
+- **WHEN** the user runs `chorus daemon status` on macOS while the `com.chorus.daemon` LaunchAgent is loaded
+- **THEN** the CLI reports the daemon is managed by launchd (via `launchctl list`) and does not consult the pidfile
+
+#### Scenario: stop delegates to launchctl unload when the agent is loaded
+
+- **WHEN** the user runs `chorus daemon stop` on macOS while the LaunchAgent is loaded
+- **THEN** the CLI runs `launchctl unload` on the plist, reports the stop (noting it re-loads at next login unless uninstalled), and does not signal via the pidfile
+
+#### Scenario: restart delegates to launchctl when the agent is loaded
+
+- **WHEN** the user runs `chorus daemon restart` on macOS while the LaunchAgent is loaded
+- **THEN** the CLI runs `launchctl unload` then `launchctl load` on the plist and does not start a detached pidfile instance
+
+#### Scenario: pidfile path is unchanged when no launchd agent is installed
+
+- **WHEN** the user runs `chorus daemon status` / `stop` / `restart` / `logs` on macOS with no `com.chorus.daemon` LaunchAgent installed
+- **THEN** the subcommands operate on the pidfile/logfile managed by the `-d` path exactly as before

--- a/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/tasks.md
+++ b/openspec/changes/archive/2026-08-19-add-chorus-init-daemon-setup/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: chorus init daemon-setup + real cross-platform auto-start
+
+## 1. Platform auto-start capability classifier
+- [ ] Add `autostartCapability(io)` → `systemd` | `launchd` | `unsupported` in `cli/daemon-service.mjs`
+- [ ] Extend `detectSupervisor(io)` to recognize a loaded `com.chorus.daemon` LaunchAgent on darwin
+- [ ] Unit tests for both across linux (with/without systemctl), darwin, win32
+
+## 2. Real macOS launchd install / uninstall
+- [ ] `installService` darwin: write plist to `~/Library/LaunchAgents/` (backup-first) + `launchctl load -w`; failure → non-zero
+- [ ] `uninstallService` darwin: `launchctl unload -w` + remove plist; report nothing-to-remove
+- [ ] Keep Windows/other as printed template; credentials never in the plist
+- [ ] Unit tests with injected darwin io (exact launchctl argv + plist write)
+
+## 3. launchd lifecycle delegation
+- [ ] `cli/daemon.mjs`: status/stop/restart/logs delegate to `launchctl` when `detectSupervisor` reports launchd
+- [ ] Pidfile path unchanged when no agent installed
+- [ ] Unit tests for darwin delegation argv
+
+## 4. `chorus init` daemon-setup step
+- [ ] New `cli/init/steps/daemon-setup.mjs` (id `daemon-setup`, order 30, scope once)
+- [ ] Full preflight reuse (cwds + backend), capability gate, opt-in TTY prompt (default No)
+- [ ] Non-TTY: install only with `--daemon-autostart`, else daemon.json-only
+- [ ] boot_and_now delegate to installService; idempotent report/skip/repair; connection-only (no provider secrets)
+- [ ] Register in `cli/init/registry.mjs`; add `--daemon-autostart` to `cli/init-args.mjs` + help
+- [ ] Unit tests (injected io, fake installService/capability/preflight)
+
+## 5. Docs
+- [ ] `chorus init --help` text lists `--daemon-autostart`
+- [ ] chorus skill docs (public/skill + public/chorus-plugin) describe the daemon-setup step, auto-start, credential boundary, provider-cred operator note
+- [ ] Note the clean-env provider-credential limitation + concrete systemd/launchd guidance

--- a/openspec/specs/chorus-init/spec.md
+++ b/openspec/specs/chorus-init/spec.md
@@ -79,3 +79,102 @@ The command SHALL run configuration through an ordered, extensible step registry
 - **WHEN** a sibling registers an additional step into the registry
 - **THEN** it participates in the ordered run with no edit to the command's orchestration core
 
+### Requirement: Optional daemon auto-start step in `chorus init`
+
+`chorus init` SHALL run a `once`-scoped daemon-setup step, ordered after the
+credential-seed and plugin-install steps, that configures the local Chorus daemon
+and optionally installs it as a boot-autostart service. The step SHALL reuse the
+existing `chorus daemon install` preflight to resolve and persist the served
+working-directory set (`cwds`) and the default backend agent into
+`~/.chorus/daemon.json` (credentials are already seeded by the credential-seed
+step). The step SHALL NOT collect or persist model-provider secrets (e.g. `AWS_*`,
+`ANTHROPIC_*`, Bedrock) — the centralized credential model is connection-only
+(Chorus URL + API key), and no per-agent secret injection is introduced.
+
+The step SHALL offer the auto-start install **only** on a platform whose auto-start
+capability is supported (Linux systemd or macOS launchd). On an unsupported
+platform it SHALL still persist `~/.chorus/daemon.json` and print the manual start
+command, and SHALL NOT attempt to install a service.
+
+In an interactive run (a TTY without `--yes`) the step SHALL prompt whether to
+install and enable the daemon to auto-start on boot, **defaulting to No** (opt-in),
+and SHALL install only on an affirmative answer. In a non-interactive run (non-TTY,
+or `--yes`) the step SHALL install the boot service only when an explicit
+`--daemon-autostart` flag is passed; otherwise it SHALL persist
+`~/.chorus/daemon.json` and skip the service install without guessing.
+
+Before installing a boot service, the step SHALL run the same credential
+validate-or-abort guarantee as `chorus daemon install`: resolve credentials from
+the layered source, validate the key against the server, and persist the
+url + key + identity into `~/.chorus/daemon.json`. If credentials cannot be resolved
+or the key fails validation, the step SHALL install nothing and report a failure —
+it SHALL NOT rely solely on the earlier credential-seed step, and SHALL never
+install a boot service that would fail authentication and restart-loop at boot.
+
+When the user opts in on a supported platform, the step SHALL install **and enable**
+the boot service so the daemon starts immediately and at every boot (delegating to
+the same install path as `chorus daemon install`). The step SHALL be idempotent:
+when a boot service is already installed for the platform it SHALL report the
+daemon as already configured and make no destructive rewrite, applying only a
+missing/drifted delta as a repair. A failed install SHALL be reported visibly with
+its underlying error (non-zero outcome), never a silent skip.
+
+#### Scenario: Interactive run offers opt-in auto-start defaulting to No
+
+- **WHEN** a user runs `chorus init` in a TTY on a platform that supports
+  auto-start (Linux systemd or macOS launchd)
+- **THEN** the daemon-setup step persists the served cwds and backend to
+  `~/.chorus/daemon.json`, prompts whether to auto-start the daemon on boot with a
+  default of No, and installs & enables the boot service only if the user
+  affirmatively accepts
+
+#### Scenario: Declining auto-start still writes daemon config
+
+- **WHEN** a user runs `chorus init` in a TTY and declines the auto-start prompt
+- **THEN** `~/.chorus/daemon.json` is written (credentials, cwds, backend) and the
+  step prints the manual `chorus daemon` start command without installing any
+  service
+
+#### Scenario: Non-interactive run requires an explicit flag to install
+
+- **WHEN** `chorus init` runs in a non-TTY environment, or with `--yes` in a TTY,
+  WITHOUT `--daemon-autostart`
+- **THEN** the step persists `~/.chorus/daemon.json` and skips the boot-service
+  install, reporting that `--daemon-autostart` is required to install the service,
+  and does not block on a prompt
+
+#### Scenario: Auto-start install aborts on unvalidated credentials
+
+- **WHEN** the daemon-setup step decides to install (opt-in or `--daemon-autostart`)
+  but the resolved Chorus key fails server validation, or no credentials resolve
+- **THEN** the step installs no service and reports a failure, rather than
+  installing a boot service that would fail authentication at boot
+
+#### Scenario: Non-interactive run with the flag installs the service
+
+- **WHEN** `chorus init --daemon-autostart` runs in a non-TTY environment on a
+  supported platform with resolvable credentials
+- **THEN** the step installs and enables the boot service without prompting
+
+#### Scenario: Unsupported platform skips the service and prints manual steps
+
+- **WHEN** `chorus init` runs on a platform whose auto-start capability is
+  unsupported (e.g. Windows)
+- **THEN** the step persists `~/.chorus/daemon.json`, prints the manual start
+  steps, and does not attempt to install a boot service, regardless of
+  `--daemon-autostart`
+
+#### Scenario: Re-run is idempotent when the service is already installed
+
+- **WHEN** a user re-runs `chorus init` (opting in, or with `--daemon-autostart`)
+  on a machine where the boot service is already installed
+- **THEN** the step reports the daemon as already configured for auto-start and
+  makes no destructive rewrite, repairing only if a drift is detected
+
+#### Scenario: The step never collects provider secrets
+
+- **WHEN** the daemon-setup step runs in any mode
+- **THEN** it collects only the Chorus connection credentials and the daemon's
+  cwds/backend, and never prompts for or persists model-provider secrets into
+  `~/.chorus/daemon.json` or any service unit
+

--- a/openspec/specs/daemon-background-lifecycle/spec.md
+++ b/openspec/specs/daemon-background-lifecycle/spec.md
@@ -159,37 +159,84 @@ The CLI SHALL accept `chorus daemon stop --force`, which best-effort signals the
 
 ### Requirement: Supervisor service install / uninstall
 
-The CLI SHALL provide `chorus daemon install` and `chorus daemon uninstall` to manage the daemon as an OS-supervised, boot-autostart service, replacing the prior documentation-templates-only posture. On Linux the CLI SHALL generate a `systemd --user` unit that runs the daemon in the **foreground** (`Type=simple`, `ExecStart` invoking `chorus daemon` WITHOUT `-d`, so systemd owns the process directly as `MainPID`), SHALL capture the `--agent` / `--chorus-only` flags passed to `install` plus absolute node and script paths and the current `PATH`, SHALL write it to `~/.config/systemd/user/chorus-daemon.service`, and SHALL then run `systemctl --user daemon-reload` followed by `systemctl --user enable --now` so the service starts immediately and at every login. The generated unit SHALL NOT embed `--cwd` arguments: the set of working directories the daemon serves is persisted to `~/.chorus/daemon.json` `cwds` at install time (see "Install configures the served working directory set") and read from there by the daemon, so a boot-time service and a plain `chorus daemon` serve the same paths and cannot drift. The generated unit SHALL use `Restart=on-failure` (so a clean stop stays stopped) and SHALL NOT declare an `ExecStop` (a `Type=simple` stop is SIGTERM to the daemon's existing graceful-shutdown handler). The CLI SHALL NOT generate a `Type=forking` unit or an `ExecStart` containing `-d`. Before writing any service unit the CLI SHALL complete the install credential guarantee (see "Install guarantees resolvable credentials for the clean-env boot service") and the working-directory configuration (see "Install configures the served working directory set"); if the credential guarantee cannot be satisfied the CLI SHALL abort without writing a unit. On macOS the CLI SHALL print a correct launchd LaunchAgent plist (foreground, `RunAtLoad` + `KeepAlive`, no `-d`, no embedded `--cwd`) plus manual install steps and exit 0 without writing any file; on other platforms it SHALL print the foreground command to run under the operator's supervisor of choice. `uninstall` on Linux SHALL `disable --now` the unit, remove the unit file, and `daemon-reload`, reporting clearly when nothing was installed; off Linux it SHALL print the manual removal steps. The implementation SHALL be pure Node with no native-binding dependency and SHALL NOT use `shell:true`.
+The CLI SHALL provide `chorus daemon install` and `chorus daemon uninstall` to
+manage the daemon as an OS-supervised, boot-autostart service, replacing the prior
+documentation-templates-only posture. On **Linux** the CLI SHALL generate a
+`systemd --user` unit that runs the daemon in the **foreground** (`Type=simple`,
+`ExecStart` invoking `chorus daemon` WITHOUT `-d`, so systemd owns the process
+directly as `MainPID`), SHALL capture the `--agent` / `--chorus-only` flags passed
+to `install` plus absolute node and script paths and the current `PATH`, SHALL
+write it to `~/.config/systemd/user/chorus-daemon.service`, and SHALL then run
+`systemctl --user daemon-reload` followed by `systemctl --user enable --now` so the
+service starts immediately and at every login. On **macOS** the CLI SHALL perform a
+**real** launchd install: render the foreground LaunchAgent plist (`RunAtLoad` +
+`KeepAlive`, no `-d`, no embedded `--cwd`), back up any existing file, write it to
+`~/Library/LaunchAgents/com.chorus.daemon.plist`, and run `launchctl load -w
+<plist>` (preceded by a best-effort `launchctl unload` of any prior copy) so the
+service starts immediately and at every login — it SHALL NOT merely print a
+template. On **other platforms** (e.g. Windows) the CLI SHALL print the foreground
+command to run under the operator's supervisor of choice and write no file.
+
+The generated systemd unit and the launchd plist SHALL NOT embed `--cwd`
+arguments: the set of working directories the daemon serves is persisted to
+`~/.chorus/daemon.json` `cwds` at install time (see "Install configures the served
+working directory set") and read from there by the daemon, so a boot-time service
+and a plain `chorus daemon` serve the same paths and cannot drift. The generated
+systemd unit SHALL use `Restart=on-failure` (so a clean stop stays stopped) and
+SHALL NOT declare an `ExecStop` (a `Type=simple` stop is SIGTERM to the daemon's
+existing graceful-shutdown handler). The CLI SHALL NOT generate a `Type=forking`
+unit or an `ExecStart` containing `-d`.
+
+Before writing any service unit or plist the CLI SHALL complete the install
+credential guarantee (see "Install guarantees resolvable credentials for the
+clean-env boot service") and the working-directory configuration (see "Install
+configures the served working directory set"); if the credential guarantee cannot
+be satisfied the CLI SHALL abort without installing. On any install failure —
+failing to write the unit/plist, or a `systemctl` / `launchctl` command returning
+non-zero — the CLI SHALL report the underlying error and exit non-zero (no silent
+failure). Credentials SHALL NOT be baked into the service unit or plist as
+environment lines (a 0600 `daemon.json` is the persistence surface).
+
+`uninstall` on **Linux** SHALL `disable --now` the unit, remove the unit file, and
+`daemon-reload`; on **macOS** SHALL `launchctl unload -w <plist>` and remove the
+plist file; on both platforms SHALL report clearly when nothing was installed. On
+**other platforms** it SHALL print the manual removal steps. The implementation
+SHALL be pure Node with no native-binding dependency and SHALL NOT use `shell:true`.
 
 #### Scenario: install generates a correct systemd unit and starts it
 
 - **WHEN** the user runs `chorus daemon install` on a Linux host with `systemctl --user` available, resolvable credentials, and a configured cwd set
 - **THEN** the CLI writes `~/.config/systemd/user/chorus-daemon.service` with `Type=simple`, an `ExecStart` that runs `chorus daemon` with no `-d` and no `--cwd` argument, `Restart=on-failure`, and no `ExecStop`, then runs `daemon-reload` and `enable --now`, so systemd owns the node process as `MainPID` and the service starts at login
 
+#### Scenario: install performs a real launchd install on macOS
+
+- **WHEN** the user runs `chorus daemon install` on a macOS host with resolvable credentials and a configured cwd set
+- **THEN** the CLI writes the foreground LaunchAgent plist to `~/Library/LaunchAgents/com.chorus.daemon.plist` (RunAtLoad + KeepAlive, no `-d`, no embedded `--cwd`) and runs `launchctl load -w` on it, so the daemon starts immediately and at every login — no manual template step is required
+
 #### Scenario: install persists cwds to daemon.json rather than the unit
 
-- **WHEN** the user runs `chorus daemon install --cwd /a --cwd /b` on a Linux host
-- **THEN** the generated unit's `ExecStart` contains no `--cwd` argument, and `~/.chorus/daemon.json` `cwds` contains `/a` and `/b`, so the boot service reads the served paths from the config file
+- **WHEN** the user runs `chorus daemon install --cwd /a --cwd /b` on a Linux or macOS host
+- **THEN** the generated unit/plist contains no `--cwd` argument, and `~/.chorus/daemon.json` `cwds` contains `/a` and `/b`, so the boot service reads the served paths from the config file
 
 #### Scenario: generated unit never self-daemonizes
 
-- **WHEN** the CLI renders the systemd unit for any set of flags
-- **THEN** the `ExecStart` line contains neither `-d` nor `--detach`, and the unit is not `Type=forking` — so systemd tracks the daemon directly and the boot-time restart loop cannot occur
+- **WHEN** the CLI renders the systemd unit or the launchd plist for any set of flags
+- **THEN** the `ExecStart` / `ProgramArguments` contains neither `-d` nor `--detach`, and the systemd unit is not `Type=forking` — so the supervisor tracks the daemon directly and the boot-time restart loop cannot occur
 
 #### Scenario: install surfaces a failure instead of reporting success
 
-- **WHEN** `chorus daemon install` on Linux fails to write the unit or a `systemctl --user daemon-reload` / `enable --now` returns non-zero
+- **WHEN** `chorus daemon install` fails to write the unit/plist, or a `systemctl --user daemon-reload` / `enable --now` (Linux) or a `launchctl load -w` (macOS) returns non-zero
 - **THEN** the CLI reports the failure with the underlying error and exits non-zero (no silent failure)
 
-#### Scenario: install off Linux prints a template and does not write
+#### Scenario: install on an unsupported platform prints a template and does not write
 
-- **WHEN** the user runs `chorus daemon install` on macOS or Windows
-- **THEN** the CLI prints a correct foreground service template (launchd plist on macOS) carrying no embedded `--cwd`, plus manual steps, writes no service file, and exits 0
+- **WHEN** the user runs `chorus daemon install` on Windows or another unsupported platform
+- **THEN** the CLI prints a correct foreground service template plus manual steps, writes no service file, and exits 0
 
 #### Scenario: uninstall removes the service or reports nothing to remove
 
-- **WHEN** the user runs `chorus daemon uninstall` on Linux
-- **THEN** the CLI disables and stops the unit, removes the unit file, and reloads systemd — or, when no unit is installed, reports that there was nothing to remove — and off Linux prints the manual removal steps
+- **WHEN** the user runs `chorus daemon uninstall` on Linux or macOS
+- **THEN** on Linux the CLI disables and stops the unit, removes the unit file, and reloads systemd; on macOS it unloads the LaunchAgent and removes the plist — or, when nothing is installed, reports that there was nothing to remove — and on an unsupported platform prints the manual removal steps
 
 ### Requirement: Install guarantees resolvable credentials for the clean-env boot service
 
@@ -269,4 +316,68 @@ The CLI SHALL accept a `--yes` / `-y` flag on `chorus daemon install` that suppr
 #### Scenario: Install runs without browse-root flags
 - **WHEN** `daemon.json` already contains `browseRoots`
 - **THEN** reinstall MUST preserve and reuse them without prompting or replacing them
+
+### Requirement: Platform auto-start capability classification
+
+The CLI SHALL expose a single capability classifier that reports whether the
+current host supports installing a real boot-autostart daemon service, returning
+`systemd` on Linux where `systemctl --user` is available, `launchd` on macOS, and
+`unsupported` on every other platform. The `chorus init` daemon-setup step SHALL
+consult this classifier to decide whether to offer/perform a real service install
+on the current host, and `chorus daemon install` SHALL perform the
+platform-appropriate install (systemd on Linux, launchd on macOS, printed template
+otherwise) consistent with the classifier's verdict, so the two paths cannot
+disagree about what "supported" means. Supervisor detection SHALL recognize an
+installed service for the classified capability — a `systemd --user`
+`chorus-daemon.service` on Linux, or a loaded `com.chorus.daemon` LaunchAgent on
+macOS — so lifecycle commands do not misclassify a supervised daemon.
+
+#### Scenario: Capability reflects the platform
+
+- **WHEN** the classifier runs on Linux with `systemctl --user` available, on macOS, and on Windows respectively
+- **THEN** it returns `systemd`, `launchd`, and `unsupported` respectively
+
+#### Scenario: Linux without systemctl is unsupported for auto-start
+
+- **WHEN** the classifier runs on Linux where `systemctl --user` is not available
+- **THEN** it returns `unsupported`, so no systemd install is attempted
+
+#### Scenario: Supervisor detection recognizes a loaded launchd agent
+
+- **WHEN** supervisor detection runs on macOS and the `com.chorus.daemon` LaunchAgent plist exists and `launchctl` reports the label loaded
+- **THEN** detection reports an installed launchd supervisor rather than "none"
+
+### Requirement: macOS launchd lifecycle delegation
+
+The CLI SHALL delegate `chorus daemon status` / `stop` / `restart` / `logs` to
+`launchctl` and the service log file rather than the pidfile when a
+`com.chorus.daemon` LaunchAgent is installed and loaded on macOS, so a real macOS
+boot service is manageable through the CLI and is never misreported as "not
+running". `status`
+SHALL report the loaded state via `launchctl list` (exiting non-zero when installed
+but not loaded); `stop` SHALL `launchctl unload` the agent (noting it re-loads at
+next login unless uninstalled); `restart` SHALL `launchctl unload` then
+`launchctl load` the agent; `logs` SHALL display `~/.chorus/daemon.log`. When no
+launchd agent is installed, the subcommands SHALL operate on the pidfile/logfile
+exactly as before.
+
+#### Scenario: status delegates to launchctl when the agent is loaded
+
+- **WHEN** the user runs `chorus daemon status` on macOS while the `com.chorus.daemon` LaunchAgent is loaded
+- **THEN** the CLI reports the daemon is managed by launchd (via `launchctl list`) and does not consult the pidfile
+
+#### Scenario: stop delegates to launchctl unload when the agent is loaded
+
+- **WHEN** the user runs `chorus daemon stop` on macOS while the LaunchAgent is loaded
+- **THEN** the CLI runs `launchctl unload` on the plist, reports the stop (noting it re-loads at next login unless uninstalled), and does not signal via the pidfile
+
+#### Scenario: restart delegates to launchctl when the agent is loaded
+
+- **WHEN** the user runs `chorus daemon restart` on macOS while the LaunchAgent is loaded
+- **THEN** the CLI runs `launchctl unload` then `launchctl load` on the plist and does not start a detached pidfile instance
+
+#### Scenario: pidfile path is unchanged when no launchd agent is installed
+
+- **WHEN** the user runs `chorus daemon status` / `stop` / `restart` / `logs` on macOS with no `com.chorus.daemon` LaunchAgent installed
+- **THEN** the subcommands operate on the pidfile/logfile managed by the `-d` path exactly as before
 

--- a/public/chorus-plugin/skills/chorus/SKILL.md
+++ b/public/chorus-plugin/skills/chorus/SKILL.md
@@ -359,6 +359,24 @@ openspec init --tools claude        # 2. scaffold openspec/ + wire up Claude Cod
 
 To turn it off, flip `enableOpenSpec` to `false` or set `CHORUS_OPENSPEC_MODE=off` — the banner then reads a neutral `(OpenSpec off)`.
 
+### 7. Daemon auto-start via `chorus init`
+
+`chorus init` runs an ordered set of steps to wire this machine to Chorus. Its final step — **daemon-setup** — configures the local Chorus daemon and, opt-in, installs it as a boot-autostart service.
+
+- **What it configures.** Reusing the same preflight as `chorus daemon install`, it persists the served working directories (`cwds`) and the default backend agent into `~/.chorus/daemon.json`. Credentials are the **connection credentials only** — the Chorus URL + API key (`cho_…`) seeded earlier in the run. `chorus init` never collects or stores model-provider secrets (see the limitation below).
+- **Opt-in auto-start.**
+  - Interactive (TTY): it asks *"Install & enable the Chorus daemon to auto-start on boot?"* — **default No**. Answer yes to install.
+  - Non-interactive (non-TTY, or `--yes`): it installs the boot service **only** when you pass `--daemon-autostart`; otherwise it writes `~/.chorus/daemon.json` and leaves starting the daemon to you (`chorus daemon`).
+- **Platform support.** Auto-start is a *real* boot service on **Linux (systemd `--user`)** and **macOS (launchd LaunchAgent)** — both start now and at every login. On other platforms (e.g. Windows) it writes the config and prints the manual start steps instead of installing anything.
+- **Idempotent.** Re-running when the service is already installed reports it as already configured and changes nothing.
+- **Manage it.** `chorus daemon status | stop | restart | logs` transparently delegate to the installed supervisor (`systemctl --user` on Linux, `launchctl` on macOS); with no service installed they operate on the `chorus daemon -d` pidfile/log as before.
+
+> **⚠️ Provider credentials on a boot service (important).** A boot-launched daemon (systemd `--user` or launchd) starts in a **clean environment** and does **not** inherit your shell-exported model-provider secrets (`ANTHROPIC_API_KEY`, `AWS_*` / `CLAUDE_CODE_USE_BEDROCK`, etc.). Chorus keeps `daemon.json` to the Chorus connection credentials only, so you must supply provider credentials to the service's environment yourself:
+> - **Linux (systemd):** add a drop-in `~/.config/systemd/user/chorus-daemon.service.d/env.conf` containing `[Service]` + `Environment=ANTHROPIC_API_KEY=…` then `systemctl --user daemon-reload && systemctl --user restart chorus-daemon.service`; or place the vars in `~/.config/environment.d/*.conf`.
+> - **macOS (launchd):** `launchctl setenv ANTHROPIC_API_KEY …` (before load), or add an `EnvironmentVariables` dict to `~/Library/LaunchAgents/com.chorus.daemon.plist`.
+>
+> Without this, a boot-started daemon reaches Chorus fine but its spawned agents may fail to reach the model provider.
+
 ---
 
 ## Execution Rules

--- a/public/skill/chorus/SKILL.md
+++ b/public/skill/chorus/SKILL.md
@@ -367,6 +367,24 @@ The table below shows default tool availability for each preset (no custom permi
 | `chorus_admin_delete_idea` | `idea:admin` | No | No | Yes |
 | `chorus_admin_delete_document` | `document:admin` | No | No | Yes |
 
+### 5. Daemon auto-start via `chorus init`
+
+`chorus init` runs an ordered set of steps to wire this machine to Chorus. Its final step — **daemon-setup** — configures the local Chorus daemon and, opt-in, installs it as a boot-autostart service.
+
+- **What it configures.** Reusing the same preflight as `chorus daemon install`, it persists the served working directories (`cwds`) and the default backend agent into `~/.chorus/daemon.json`. Credentials are the **connection credentials only** — the Chorus URL + API key (`cho_…`) seeded earlier in the run. `chorus init` never collects or stores model-provider secrets (see the limitation below).
+- **Opt-in auto-start.**
+  - Interactive (TTY): it asks *"Install & enable the Chorus daemon to auto-start on boot?"* — **default No**. Answer yes to install.
+  - Non-interactive (non-TTY, or `--yes`): it installs the boot service **only** when you pass `--daemon-autostart`; otherwise it writes `~/.chorus/daemon.json` and leaves starting the daemon to you (`chorus daemon`).
+- **Platform support.** Auto-start is a *real* boot service on **Linux (systemd `--user`)** and **macOS (launchd LaunchAgent)** — both start now and at every login. On other platforms (e.g. Windows) it writes the config and prints the manual start steps instead of installing anything.
+- **Idempotent.** Re-running when the service is already installed reports it as already configured and changes nothing.
+- **Manage it.** `chorus daemon status | stop | restart | logs` transparently delegate to the installed supervisor (`systemctl --user` on Linux, `launchctl` on macOS); with no service installed they operate on the `chorus daemon -d` pidfile/log as before.
+
+> **⚠️ Provider credentials on a boot service (important).** A boot-launched daemon (systemd `--user` or launchd) starts in a **clean environment** and does **not** inherit your shell-exported model-provider secrets (`ANTHROPIC_API_KEY`, `AWS_*` / `CLAUDE_CODE_USE_BEDROCK`, etc.). Chorus keeps `daemon.json` to the Chorus connection credentials only, so you must supply provider credentials to the service's environment yourself:
+> - **Linux (systemd):** add a drop-in `~/.config/systemd/user/chorus-daemon.service.d/env.conf` containing `[Service]` + `Environment=ANTHROPIC_API_KEY=…` then `systemctl --user daemon-reload && systemctl --user restart chorus-daemon.service`; or place the vars in `~/.config/environment.d/*.conf`.
+> - **macOS (launchd):** `launchctl setenv ANTHROPIC_API_KEY …` (before load), or add an `EnvironmentVariables` dict to `~/Library/LaunchAgents/com.chorus.daemon.plist`.
+>
+> Without this, a boot-started daemon reaches Chorus fine but its spawned agents may fail to reach the model provider.
+
 ---
 
 ## Execution Rules


### PR DESCRIPTION
## Summary
Integrates daemon configuration into the `chorus init` flow and makes the Chorus daemon a **real** boot-autostart service on both Linux and macOS. Implements idea `a7c2a3e8` (child of the 0.17.0 CLI control-plane container), covering the owner's 8 elaboration decisions.

- **New `chorus init` daemon-setup step** (`cli/init/steps/daemon-setup.mjs`, once-scoped, order 30): reuses the `daemon install` preflight (served cwds + backend agent → `~/.chorus/daemon.json`), gates auto-start on platform capability, prompts opt-in (default **No**) or requires `--daemon-autostart` when non-interactive, short-circuits when already installed, runs a credential validate-or-abort guarantee, then installs & enables the boot service.
- **Real macOS launchd install/uninstall** (`cli/daemon-service.mjs`): `installService`/`uninstallService` now write the LaunchAgent plist and run `launchctl load -w` / `unload -w` — upgraded from the previous printed-template-only posture. Adds an `autostartCapability()` classifier (systemd | launchd | unsupported) and launchd-aware `detectSupervisor`.
- **launchd lifecycle delegation** (`cli/daemon.mjs`): `status` / `stop` / `restart` / `logs` delegate to `launchctl` when a LaunchAgent is loaded; the pidfile path is unchanged when no supervisor is installed.
- **`--daemon-autostart` flag** + help (`cli/init-args.mjs`).
- **Docs**: daemon-setup + auto-start + connection-only credential boundary + the clean-env provider-credential limitation documented in both chorus `SKILL.md` surfaces.

**Credential model = connection-only** (owner decision): `daemon.json` holds only the Chorus URL + API key; no model-provider secrets are injected into the service unit. Windows auto-start is out of scope (config written + manual steps printed).

## Changed files
| File | Change |
|------|--------|
| `cli/init/steps/daemon-setup.mjs` | **New** once-scoped daemon-setup step |
| `cli/init/registry.mjs` | Register `daemonSetupStep` (order 30) |
| `cli/init-args.mjs` | `--daemon-autostart` flag + help |
| `cli/daemon-service.mjs` | `autostartCapability`, `launchctl` helper, launchd `detectSupervisor`, real launchd install/uninstall |
| `cli/daemon.mjs` | Install/uninstall dispatch (darwin real) + launchd lifecycle delegation |
| `public/skill/chorus/SKILL.md`, `public/chorus-plugin/skills/chorus/SKILL.md` | Daemon-setup + auto-start + credential-boundary docs |
| `cli/__tests__/*` | New/updated unit + integration tests |
| `openspec/…` | Archived change + updated cumulative specs |

## Test plan
- [x] `cli/__tests__/daemon-service.test.mjs` (42) — capability classifier, launchd install/uninstall, detection
- [x] `cli/__tests__/daemon-lifecycle-dispatch.test.mjs` — launchd delegation + darwin install dispatch
- [x] `cli/__tests__/init-daemon-setup.test.mjs` (14) — step decision logic
- [x] `cli/__tests__/init-daemon-setup-integration.test.mjs` — real `runInit → daemon-setup → real installService` composition
- [x] eslint clean on changed files
- [ ] Live macOS launchd smoke test (launchd path is injected-io unit-tested only; no macOS CI)

> Note: the repo's `cli/` suite has pre-existing environment-dependent failures on `develop` (credential-completion / permission-wiring / integration / one `-d` detach test) that fail identically with this branch stashed — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)