### PR TITLE
fix(ideas): roll up nested theme status bottom-up

### DIFF
--- a/openspec/changes/archive/2026-08-28-fix-nested-theme-status-rollup/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-28-fix-nested-theme-status-rollup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/archive/2026-08-28-fix-nested-theme-status-rollup/README.md
+++ b/openspec/changes/archive/2026-08-28-fix-nested-theme-status-rollup/README.md
@@ -1,0 +1,3 @@
+# fix-nested-theme-status-rollup
+
+Aggregate nested theme derived status bottom-up so parent themes reflect completed child themes without N+1 queries.

--- a/openspec/changes/archive/2026-08-28-fix-nested-theme-status-rollup/design.md
+++ b/openspec/changes/archive/2026-08-28-fix-nested-theme-status-rollup/design.md
@@ -1,0 +1,56 @@
+## Context
+
+`getIdeasWithDerivedStatus()` currently computes base statuses, groups those base values by parent, and then rolls containers up in result order. Because the grouped values are snapshots, a parent container never observes the later rolled-up value of a child container. The detail path reads direct children after project aggregation, producing inconsistent tracker and panel results.
+
+Constraints are to preserve direct-child progress semantics, avoid per-Idea database reads, and tolerate malformed lineage defensively.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Produce deterministic leaf-to-root container status aggregation at arbitrary depth.
+- Ensure each container's progress counts only direct children.
+- Reuse the existing batched Idea, Proposal, Task, child-count, and reference-count queries.
+- Terminate safely for missing-parent edges and accidental cycles.
+
+**Non-Goals:**
+
+- Flattening descendant counts into `childProgress`.
+- Changing stored Idea status, lineage validation, or API response shapes.
+- Adding database queries or migrations.
+
+## Decisions
+
+### Resolve container status with a memoized lineage walk
+
+Build an in-memory UUID index and direct-child adjacency map from the already fetched results. Resolve each node through a memoized depth-first walk: resolve direct children first, then roll a container from those final child statuses. Track nodes currently being visited so a back-edge terminates at the affected node's base status instead of recurring forever.
+
+This is preferred over sorting by computed depth because malformed cycles make depth undefined. It is preferred over repeated fixed-point passes because the memoized walk is linear for valid forests.
+
+### Normalize every cyclic component before rollup
+
+Before resolving containers, identify strongly connected components in the in-project lineage graph. Any component with more than one node, or a self-loop, is cyclic. Mark every member of that component as resolved at its own immutable proposal/task-derived base status. The normal leaf-to-root resolver then treats those values as stable inputs, allowing non-cycle ancestors to aggregate deterministically.
+
+Applying the fallback to the whole strongly connected component is preferred over cutting whichever back-edge a DFS encounters first, because the latter changes memoized results when database order changes.
+
+### Preserve base status as the fallback
+
+Keep each Idea's proposal/task-derived base status available during the walk. A childless container, a node whose parent is missing, or a member of a cyclic component retains that base status unless valid direct children outside the cyclic component can be safely aggregated by an ancestor.
+
+### Keep direct-child progress
+
+Each container calls `rollupThemeDerivedStatus()` with only the final statuses of entries in its direct-child adjacency list. Descendant completion influences ancestors through each intermediate container's final status, not by flattening descendants.
+
+## Risks / Trade-offs
+
+- **Cycle participants can have no mathematically unique rollup** → Detect the complete strongly connected component and retain every member's base status; prove results are unchanged across input-order permutations.
+- **Mutable result objects can obscure base values** → Store immutable base status/badge values separately or return resolved values from the memoized function before applying them.
+- **Tracker/detail drift can reappear through separate assumptions** → Cover the service result and real tracker integration with the same nested fixtures.
+
+## Migration Plan
+
+Deploy as an application-only change with no data migration. Rollback is the previous application image; stored data is unchanged.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-28-fix-nested-theme-status-rollup/proposal.md
+++ b/openspec/changes/archive/2026-08-28-fix-nested-theme-status-rollup/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Nested themes currently aggregate direct-child statuses captured before child themes are rolled up. A completed child theme can therefore remain incomplete in its parent tracker card even though the detail panel reports the correct progress.
+
+## What Changes
+
+- Aggregate container Idea status from the leaves toward the roots so each parent sees every direct child's final derived status.
+- Preserve `childProgress` as a count of direct children only.
+- Keep the existing project-level batch query shape and perform lineage aggregation in memory.
+- Detect malformed cyclic components, apply a uniform fallback to every cycle member, and bound aggregation so results are independent of input order.
+- Add regression coverage for complete, partial, deeply nested, malformed, input-order permutation, and tracker/detail-consistency cases.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `container-idea`: Define recursive nested-theme status rollup while preserving direct-child progress semantics and safe bounded execution.
+
+## Impact
+
+- `src/services/idea.service.ts`: project-wide derived-status aggregation.
+- `src/services/__tests__/idea.service.lineage.test.ts`: service-level nested lineage cases.
+- `src/services/__tests__/idea-tracker.container.integration.test.ts`: tracker consistency coverage.
+- No schema, API shape, or dependency changes.

--- a/openspec/changes/archive/2026-08-28-fix-nested-theme-status-rollup/specs/container-idea/spec.md
+++ b/openspec/changes/archive/2026-08-28-fix-nested-theme-status-rollup/specs/container-idea/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Nested container status SHALL aggregate from leaves to roots
+
+For a project lineage forest, the system SHALL derive every container Idea's status from the final derived statuses of its direct children, including child Ideas that are themselves containers. Aggregation SHALL proceed logically from leaves toward roots at arbitrary nesting depth. Each container's `childProgress` MUST continue to count only its direct children, and project-wide aggregation MUST use the existing batched data without introducing per-Idea database queries. Missing-parent edges and accidental cycles MUST terminate safely without an infinite loop. Every member of a cyclic component MUST use its own proposal/task-derived base status as a uniform component-level fallback, and results MUST be independent of database result order.
+
+#### Scenario: Completed nested container completes its parent
+
+- **WHEN** a parent container has one direct child container whose leaf Ideas are all `done`
+- **THEN** the child container and parent container both have derived status `done`
+- **AND** the parent container reports direct-child progress `1/1`
+
+#### Scenario: Partial completion propagates through every level
+
+- **WHEN** at least one leaf under a nested child container is not `done`
+- **THEN** the child container and each affected ancestor container remain non-done according to the existing rollup rules
+
+#### Scenario: Deep nesting is order independent
+
+- **WHEN** containers are nested across multiple levels and returned in any database result order
+- **THEN** each container is aggregated from its direct children's final derived statuses
+
+#### Scenario: Malformed lineage terminates safely
+
+- **WHEN** project data contains a missing-parent edge or an accidental lineage cycle
+- **THEN** derived-status aggregation completes without unbounded recursion or repeated database queries
+- **AND** every member of the cyclic component retains its own base status
+
+#### Scenario: Cyclic fallback is input-order independent
+
+- **WHEN** the same cyclic lineage and its non-cycle ancestors are returned in different database orders
+- **THEN** every Idea receives the same derived status and child progress in every ordering
+
+#### Scenario: Tracker and detail surfaces agree
+
+- **WHEN** the tracker and Idea detail APIs read the same nested container data
+- **THEN** they expose consistent final derived status and direct-child progress for the container

--- a/openspec/changes/archive/2026-08-28-fix-nested-theme-status-rollup/tasks.md
+++ b/openspec/changes/archive/2026-08-28-fix-nested-theme-status-rollup/tasks.md
@@ -1,0 +1,5 @@
+## 1. Nested Theme Rollup
+
+- [x] 1.1 Implement bounded bottom-up container status aggregation in `getIdeasWithDerivedStatus()`, using a uniform base-status fallback for cyclic strongly connected components while preserving direct-child progress and the existing batch query shape.
+- [x] 1.2 Add service and tracker integration regressions for complete, partial, deep, missing-parent, cyclic input-order permutation, and cross-surface-consistency scenarios.
+- [x] 1.3 Run focused tests, lint/type checks for changed files, and the production build.

--- a/openspec/specs/container-idea/spec.md
+++ b/openspec/specs/container-idea/spec.md
@@ -115,3 +115,39 @@ In the idea detail panel, a user SHALL be able to toggle the idea's container st
 - **THEN** it MUST display a read-only "3/5" (children done / total) indicator
 - **AND** this indicator MUST NOT be editable
 
+### Requirement: Nested container status SHALL aggregate from leaves to roots
+
+For a project lineage forest, the system SHALL derive every container Idea's status from the final derived statuses of its direct children, including child Ideas that are themselves containers. Aggregation SHALL proceed logically from leaves toward roots at arbitrary nesting depth. Each container's `childProgress` MUST continue to count only its direct children, and project-wide aggregation MUST use the existing batched data without introducing per-Idea database queries. Missing-parent edges and accidental cycles MUST terminate safely without an infinite loop. Every member of a cyclic component MUST use its own proposal/task-derived base status as a uniform component-level fallback, and results MUST be independent of database result order.
+
+#### Scenario: Completed nested container completes its parent
+
+- **WHEN** a parent container has one direct child container whose leaf Ideas are all `done`
+- **THEN** the child container and parent container both have derived status `done`
+- **AND** the parent container reports direct-child progress `1/1`
+
+#### Scenario: Partial completion propagates through every level
+
+- **WHEN** at least one leaf under a nested child container is not `done`
+- **THEN** the child container and each affected ancestor container remain non-done according to the existing rollup rules
+
+#### Scenario: Deep nesting is order independent
+
+- **WHEN** containers are nested across multiple levels and returned in any database result order
+- **THEN** each container is aggregated from its direct children's final derived statuses
+
+#### Scenario: Malformed lineage terminates safely
+
+- **WHEN** project data contains a missing-parent edge or an accidental lineage cycle
+- **THEN** derived-status aggregation completes without unbounded recursion or repeated database queries
+- **AND** every member of the cyclic component retains its own base status
+
+#### Scenario: Cyclic fallback is input-order independent
+
+- **WHEN** the same cyclic lineage and its non-cycle ancestors are returned in different database orders
+- **THEN** every Idea receives the same derived status and child progress in every ordering
+
+#### Scenario: Tracker and detail surfaces agree
+
+- **WHEN** the tracker and Idea detail APIs read the same nested container data
+- **THEN** they expose consistent final derived status and direct-child progress for the container
+

--- a/src/services/__tests__/idea-tracker.container.integration.test.ts
+++ b/src/services/__tests__/idea-tracker.container.integration.test.ts
@@ -100,6 +100,65 @@ function seed(childCount: number, childDone: number) {
   mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT, name: "A" }]);
 }
 
+function seedCompletedNestedContainer() {
+  const root = {
+    uuid: CONTAINER,
+    title: "Root theme",
+    status: "open",
+    elaborationStatus: null,
+    parentUuid: null,
+    isContainer: true,
+    projectUuid: PROJECT,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const nested = {
+    uuid: "idea-nested",
+    title: "Nested theme",
+    status: "open",
+    elaborationStatus: null,
+    parentUuid: CONTAINER,
+    isContainer: true,
+    projectUuid: PROJECT,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const leaf = {
+    uuid: "idea-leaf",
+    title: "Leaf",
+    status: "elaborated",
+    elaborationStatus: "resolved",
+    parentUuid: nested.uuid,
+    isContainer: false,
+    projectUuid: PROJECT,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  mockPrisma.idea.findMany.mockImplementation(async (args: { where?: { OR?: unknown } }) => {
+    if (args?.where?.OR) return [root];
+    return [root, nested, leaf];
+  });
+  mockPrisma.idea.groupBy.mockResolvedValue([
+    { parentUuid: CONTAINER, _count: { _all: 1 } },
+    { parentUuid: nested.uuid, _count: { _all: 1 } },
+  ]);
+  mockPrisma.proposal.findMany.mockResolvedValue([
+    {
+      uuid: "leaf-proposal",
+      projectUuid: PROJECT,
+      status: "approved",
+      inputType: "idea",
+      inputUuids: [leaf.uuid],
+      createdAt: now,
+    },
+  ]);
+  mockPrisma.task.findMany.mockResolvedValue([
+    { proposalUuid: "leaf-proposal", status: "done" },
+  ]);
+  mockPrisma.project.findMany.mockResolvedValue([{ uuid: PROJECT, name: "A" }]);
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockPrisma.agentInstance.findMany.mockResolvedValue([]);
@@ -111,6 +170,12 @@ beforeEach(() => {
 describe("buildIdeaTracker container rollup (real getIdeasWithDerivedStatus)", () => {
   it("drops a container whose children are ALL done", async () => {
     seed(3, 3);
+    const tracker = await buildIdeaTracker(agentAuth);
+    expect(tracker).toEqual({});
+  });
+
+  it("drops a root container when its completed direct child is itself a container", async () => {
+    seedCompletedNestedContainer();
     const tracker = await buildIdeaTracker(agentAuth);
     expect(tracker).toEqual({});
   });

--- a/src/services/__tests__/idea.service.lineage.test.ts
+++ b/src/services/__tests__/idea.service.lineage.test.ts
@@ -62,6 +62,7 @@ import {
   createIdea,
   setIdeaParent,
   getIdea,
+  getIdeaWithDerivedStatus,
   getIdeasWithDerivedStatus,
   getDescendantUuids,
   moveIdea,
@@ -336,6 +337,132 @@ describe("getIdeasWithDerivedStatus rollup", () => {
     expect(theme.derivedStatus).toBe("in_progress"); // not stuck at "planning"/elaborated
     expect(theme.childProgress).toEqual({ done: 1, total: 3 });
   });
+
+  it("rolls completed nested containers from leaves to roots with direct-child progress", async () => {
+    mockPrisma.idea.findMany.mockResolvedValueOnce([
+      { uuid: "root", title: "Root", status: "open", elaborationStatus: null, parentUuid: null, isContainer: true, createdAt: now, updatedAt: now },
+      { uuid: "nested", title: "Nested", status: "open", elaborationStatus: null, parentUuid: "root", isContainer: true, createdAt: now, updatedAt: now },
+      { uuid: "leaf", title: "Leaf", status: "elaborated", elaborationStatus: "resolved", parentUuid: "nested", isContainer: false, createdAt: now, updatedAt: now },
+    ]);
+    mockPrisma.idea.groupBy.mockResolvedValueOnce([
+      { parentUuid: "root", _count: { _all: 1 } },
+      { parentUuid: "nested", _count: { _all: 1 } },
+    ]);
+    mockPrisma.proposal.findMany.mockResolvedValueOnce([
+      { uuid: "leaf-proposal", status: "approved", inputUuids: ["leaf"], createdAt: now },
+    ]);
+    mockPrisma.task.findMany.mockResolvedValueOnce([
+      { proposalUuid: "leaf-proposal", status: "done" },
+    ]);
+
+    const result = await getIdeasWithDerivedStatus(COMPANY, PROJECT);
+
+    expect(result.find((idea) => idea.uuid === "nested")).toMatchObject({
+      derivedStatus: "done",
+      childProgress: { done: 1, total: 1 },
+    });
+    expect(result.find((idea) => idea.uuid === "root")).toMatchObject({
+      derivedStatus: "done",
+      childProgress: { done: 1, total: 1 },
+    });
+    expect(mockPrisma.idea.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.idea.groupBy).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.proposal.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.task.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates partial completion through deep containers independent of result order", async () => {
+    const rows = [
+      { uuid: "root", title: "Root", status: "open", elaborationStatus: null, parentUuid: null, isContainer: true, createdAt: now, updatedAt: now },
+      { uuid: "middle", title: "Middle", status: "open", elaborationStatus: null, parentUuid: "root", isContainer: true, createdAt: now, updatedAt: now },
+      { uuid: "inner", title: "Inner", status: "open", elaborationStatus: null, parentUuid: "middle", isContainer: true, createdAt: now, updatedAt: now },
+      { uuid: "done-leaf", title: "Done", status: "elaborated", elaborationStatus: "resolved", parentUuid: "inner", isContainer: false, createdAt: now, updatedAt: now },
+      { uuid: "todo-leaf", title: "Todo", status: "open", elaborationStatus: null, parentUuid: "inner", isContainer: false, createdAt: now, updatedAt: now },
+    ];
+    const counts = [
+      { parentUuid: "root", _count: { _all: 1 } },
+      { parentUuid: "middle", _count: { _all: 1 } },
+      { parentUuid: "inner", _count: { _all: 2 } },
+    ];
+    const proposals = [
+      { uuid: "done-proposal", status: "approved", inputUuids: ["done-leaf"], createdAt: now },
+    ];
+    const tasks = [{ proposalUuid: "done-proposal", status: "done" }];
+    mockPrisma.idea.findMany
+      .mockResolvedValueOnce(rows)
+      .mockResolvedValueOnce([...rows].reverse());
+    mockPrisma.idea.groupBy
+      .mockResolvedValueOnce(counts)
+      .mockResolvedValueOnce([...counts].reverse());
+    mockPrisma.proposal.findMany
+      .mockResolvedValueOnce(proposals)
+      .mockResolvedValueOnce(proposals);
+    mockPrisma.task.findMany
+      .mockResolvedValueOnce(tasks)
+      .mockResolvedValueOnce(tasks);
+
+    const first = await getIdeasWithDerivedStatus(COMPANY, PROJECT);
+    const second = await getIdeasWithDerivedStatus(COMPANY, PROJECT);
+    const snapshot = (items: typeof first) => Object.fromEntries(
+      items.map((item) => [item.uuid, {
+        status: item.derivedStatus,
+        progress: item.childProgress,
+      }]),
+    );
+
+    expect(snapshot(second)).toEqual(snapshot(first));
+    expect(snapshot(first)).toMatchObject({
+      inner: { status: "in_progress", progress: { done: 1, total: 2 } },
+      middle: { status: "in_progress", progress: { done: 0, total: 1 } },
+      root: { status: "in_progress", progress: { done: 0, total: 1 } },
+    });
+  });
+
+  it("uses each cyclic SCC member's base status deterministically and tolerates missing parents", async () => {
+    const rows = [
+      { uuid: "cycle-a", title: "A", status: "open", elaborationStatus: null, parentUuid: "cycle-b", isContainer: true, createdAt: now, updatedAt: now },
+      { uuid: "cycle-b", title: "B", status: "elaborating", elaborationStatus: "validating", parentUuid: "cycle-a", isContainer: true, createdAt: now, updatedAt: now },
+      { uuid: "done-child", title: "Done", status: "elaborated", elaborationStatus: "resolved", parentUuid: "cycle-a", isContainer: false, createdAt: now, updatedAt: now },
+      { uuid: "orphan", title: "Orphan", status: "elaborating", elaborationStatus: "validating", parentUuid: "missing-parent", isContainer: false, createdAt: now, updatedAt: now },
+    ];
+    const counts = [
+      { parentUuid: "cycle-a", _count: { _all: 2 } },
+      { parentUuid: "cycle-b", _count: { _all: 1 } },
+      { parentUuid: "missing-parent", _count: { _all: 1 } },
+    ];
+    const proposals = [
+      { uuid: "done-proposal", status: "approved", inputUuids: ["done-child"], createdAt: now },
+    ];
+    const tasks = [{ proposalUuid: "done-proposal", status: "done" }];
+    mockPrisma.idea.findMany
+      .mockResolvedValueOnce(rows)
+      .mockResolvedValueOnce([rows[2], rows[1], rows[3], rows[0]]);
+    mockPrisma.idea.groupBy
+      .mockResolvedValueOnce(counts)
+      .mockResolvedValueOnce([...counts].reverse());
+    mockPrisma.proposal.findMany
+      .mockResolvedValueOnce(proposals)
+      .mockResolvedValueOnce(proposals);
+    mockPrisma.task.findMany
+      .mockResolvedValueOnce(tasks)
+      .mockResolvedValueOnce(tasks);
+
+    const first = await getIdeasWithDerivedStatus(COMPANY, PROJECT);
+    const second = await getIdeasWithDerivedStatus(COMPANY, PROJECT);
+    const snapshot = (items: typeof first) => Object.fromEntries(
+      items.map((item) => [item.uuid, {
+        status: item.derivedStatus,
+        progress: item.childProgress,
+      }]),
+    );
+
+    expect(snapshot(second)).toEqual(snapshot(first));
+    expect(snapshot(first)).toMatchObject({
+      "cycle-a": { status: "todo", progress: { done: 1, total: 2 } },
+      "cycle-b": { status: "in_progress", progress: { done: 0, total: 1 } },
+      orphan: { status: "in_progress", progress: null },
+    });
+  });
 });
 
 describe("rollupThemeDerivedStatus (pure)", () => {
@@ -400,6 +527,54 @@ describe("getIdea lineage payload", () => {
     expect(res?.parent).toEqual({ uuid: "root", title: "Root", status: "open" });
     expect(res?.children?.map((c) => c.uuid)).toEqual(["leaf"]);
     expect(res?.descendantUuids).toEqual(["leaf"]);
+  });
+
+  it("returns the same nested rollup in the Idea detail response", async () => {
+    mockPrisma.idea.findFirst.mockResolvedValueOnce(
+      ideaRow({
+        uuid: "root",
+        status: "open",
+        isContainer: true,
+        project: { uuid: PROJECT, name: "P" },
+        parent: null,
+        children: [
+          { uuid: "nested", title: "Nested", status: "open", elaborationStatus: null },
+        ],
+      }),
+    );
+    const projectRows = [
+      { uuid: "root", title: "Root", status: "open", elaborationStatus: null, parentUuid: null, isContainer: true, createdAt: now, updatedAt: now },
+      { uuid: "nested", title: "Nested", status: "open", elaborationStatus: null, parentUuid: "root", isContainer: true, createdAt: now, updatedAt: now },
+      { uuid: "leaf", title: "Leaf", status: "elaborated", elaborationStatus: "resolved", parentUuid: "nested", isContainer: false, createdAt: now, updatedAt: now },
+    ];
+    mockPrisma.idea.findMany
+      .mockResolvedValueOnce(projectRows)
+      .mockResolvedValueOnce([{ uuid: "nested" }])
+      .mockResolvedValueOnce([{ uuid: "leaf" }])
+      .mockResolvedValueOnce([]);
+    mockPrisma.idea.groupBy.mockResolvedValueOnce([
+      { parentUuid: "root", _count: { _all: 1 } },
+      { parentUuid: "nested", _count: { _all: 1 } },
+    ]);
+    mockPrisma.proposal.findMany
+      .mockResolvedValueOnce([
+        { uuid: "leaf-proposal", status: "approved", inputUuids: ["leaf"], createdAt: now },
+      ])
+      .mockResolvedValueOnce([]);
+    mockPrisma.task.findMany.mockResolvedValueOnce([
+      { proposalUuid: "leaf-proposal", status: "done" },
+    ]);
+
+    const detail = await getIdeaWithDerivedStatus(COMPANY, "root");
+
+    expect(detail).toMatchObject({
+      uuid: "root",
+      derivedStatus: "done",
+      childProgress: { done: 1, total: 1 },
+      children: [
+        { uuid: "nested", derivedStatus: "done" },
+      ],
+    });
   });
 });
 

--- a/src/services/idea.service.ts
+++ b/src/services/idea.service.ts
@@ -1617,25 +1617,99 @@ export async function getIdeasWithDerivedStatus(
     };
   });
 
-  // Pass 2: a THEME (container) with ≥1 child aggregates its children — its own
-  // status would otherwise be stuck at what elaboration produced, hiding real
-  // progress. Group pass-1 derived statuses by parent (direct children only),
-  // then roll each theme up + attach childProgress for the x/y ring.
-  const childDerivedByParent = new Map<string, DerivedIdeaStatus[]>();
+  // Pass 2: resolve container statuses from leaves to roots. Keep the immutable
+  // pass-1 values separate so malformed cycles have a deterministic fallback.
+  const byUuid = new Map(base.map((item) => [item.uuid, item]));
+  const baseStatusByUuid = new Map(base.map((item) => [item.uuid, item.derivedStatus]));
+  const baseBadgeByUuid = new Map(base.map((item) => [item.uuid, item.badgeHint]));
+  const childUuidsByParent = new Map<string, string[]>();
   for (const item of base) {
-    if (!item.parentUuid) continue;
-    const arr = childDerivedByParent.get(item.parentUuid) ?? [];
-    arr.push(item.derivedStatus);
-    childDerivedByParent.set(item.parentUuid, arr);
+    if (!item.parentUuid || !byUuid.has(item.parentUuid)) continue;
+    const arr = childUuidsByParent.get(item.parentUuid) ?? [];
+    arr.push(item.uuid);
+    childUuidsByParent.set(item.parentUuid, arr);
   }
+
+  // Each Idea has at most one parent, so iterative parent-chain walks identify
+  // every strongly connected component without recursion. Marking the complete
+  // component (rather than whichever DFS back-edge is encountered first) makes
+  // the fallback independent of database result order.
+  const cyclicUuids = new Set<string>();
+  const scannedUuids = new Set<string>();
   for (const item of base) {
-    if (!item.isContainer) continue;
-    const childStatuses = childDerivedByParent.get(item.uuid) ?? [];
-    if (childStatuses.length === 0) continue; // childless theme keeps its own status
+    if (scannedUuids.has(item.uuid)) continue;
+    const path: string[] = [];
+    const pathIndex = new Map<string, number>();
+    let currentUuid: string | null = item.uuid;
+
+    while (currentUuid && byUuid.has(currentUuid) && !scannedUuids.has(currentUuid)) {
+      const cycleStart = pathIndex.get(currentUuid);
+      if (cycleStart !== undefined) {
+        for (const cycleUuid of path.slice(cycleStart)) cyclicUuids.add(cycleUuid);
+        break;
+      }
+      pathIndex.set(currentUuid, path.length);
+      path.push(currentUuid);
+      currentUuid = byUuid.get(currentUuid)?.parentUuid ?? null;
+    }
+    for (const pathUuid of path) scannedUuids.add(pathUuid);
+  }
+
+  // Non-containers, childless containers, and every cycle member already have
+  // their final value. Resolve the remaining acyclic containers only after all
+  // of their direct children are final, propagating each completion upward once.
+  const resolvedByUuid = new Map<string, DerivedStatusResult>();
+  for (const item of base) {
+    const childUuids = childUuidsByParent.get(item.uuid) ?? [];
+    if (!item.isContainer || childUuids.length === 0 || cyclicUuids.has(item.uuid)) {
+      resolvedByUuid.set(item.uuid, {
+        derivedStatus: baseStatusByUuid.get(item.uuid)!,
+        badgeHint: baseBadgeByUuid.get(item.uuid)!,
+      });
+    }
+  }
+
+  const pendingChildren = new Map<string, number>();
+  const ready: string[] = [];
+  for (const item of base) {
+    if (resolvedByUuid.has(item.uuid)) continue;
+    const unresolvedCount = (childUuidsByParent.get(item.uuid) ?? [])
+      .filter((childUuid) => !resolvedByUuid.has(childUuid)).length;
+    pendingChildren.set(item.uuid, unresolvedCount);
+    if (unresolvedCount === 0) ready.push(item.uuid);
+  }
+
+  for (let cursor = 0; cursor < ready.length; cursor += 1) {
+    const uuid = ready[cursor];
+    const childStatuses = (childUuidsByParent.get(uuid) ?? []).map(
+      (childUuid) => resolvedByUuid.get(childUuid)!.derivedStatus,
+    );
     const rolled = rollupThemeDerivedStatus(childStatuses);
-    item.derivedStatus = rolled.derivedStatus;
-    item.badgeHint = rolled.badgeHint;
-    item.childProgress = rolled.childProgress;
+    resolvedByUuid.set(uuid, rolled);
+
+    const parentUuid = byUuid.get(uuid)?.parentUuid;
+    if (!parentUuid || !pendingChildren.has(parentUuid)) continue;
+    const remaining = pendingChildren.get(parentUuid)! - 1;
+    pendingChildren.set(parentUuid, remaining);
+    if (remaining === 0) ready.push(parentUuid);
+  }
+
+  for (const item of base) {
+    const resolved = resolvedByUuid.get(item.uuid);
+    if (resolved) {
+      item.derivedStatus = resolved.derivedStatus;
+      item.badgeHint = resolved.badgeHint;
+    }
+
+    const childUuids = childUuidsByParent.get(item.uuid) ?? [];
+    if (!item.isContainer || childUuids.length === 0) continue;
+    const childStatuses = childUuids.map(
+      (childUuid) =>
+        resolvedByUuid.get(childUuid)?.derivedStatus ?? baseStatusByUuid.get(childUuid)!,
+    );
+    // Cycle members retain their own base status/badge, but their progress ring
+    // still reports deterministic direct-child completion.
+    item.childProgress = rollupThemeDerivedStatus(childStatuses).childProgress;
   }
 
   return base;


### PR DESCRIPTION
## Summary
- resolve nested container Idea status from leaves to roots using existing batch-loaded data
- preserve direct-child `childProgress` and deterministic SCC fallback for malformed cycles
- add nested completion, partial, order-permutation, malformed-lineage, tracker, and detail regressions
- archive the validated OpenSpec change and update the cumulative `container-idea` spec

## Test plan
- [x] 203/203 dependent service and tracker tests passed
- [x] production `pnpm build` passed
- [x] changed-file ESLint completed with 0 errors
- [x] aggregate Chorus code review passed
- [x] deployed revision 341 passed ECS and `/api/health` checks

## Notes
- Targets `develop`.
- This PR has not been merged.