### PR TITLE
fix(onboarding): simplify Codex setup guidance

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1178,9 +1178,9 @@
       },
       "codex": {
         "step1Title": "Step 1: Set environment variables",
-        "step1Tip": "Tip: chorus agents add (Step 2) reads these and writes them into ~/.codex/.env, so you don't need to persist them to your shell rc for Codex — an interactively-launched Codex resolves its identity (plugin hooks, shell-tool chorus calls, and native MCP) from ~/.codex/.env. Daemon-woken sessions get them automatically.",
+        "step1Tip": "No need to persist these — chorus agents add (Step 2) writes them to ~/.codex/.env.",
         "step2Title": "Step 2: Run chorus agents add",
-        "step2Tip": "chorus agents add registers the chorus-plugins marketplace, installs the Chorus plugin into Codex, seeds your credentials, writes CHORUS_URL / CHORUS_API_KEY / CHORUS_AGENT_PROFILE into ~/.codex/.env (which Codex loads into its process env at startup), and writes a keyless [mcp_servers.chorus] into ~/.codex/config.toml using bearer_token_env_var = \"CHORUS_API_KEY\" — so interactive Codex needs no manual export at all: the plugin hooks, the model's shell-tool chorus calls, and native MCP all resolve your identity from ~/.codex/.env (no API key is stored in config.toml). It reads CHORUS_URL and CHORUS_API_KEY from your environment (Step 1). The first command installs the Chorus CLI globally (pinned to version 0.17.0)."
+        "step2Tip": "chorus agents add installs the Chorus plugin and writes CHORUS_URL, CHORUS_API_KEY and CHORUS_AGENT_PROFILE to ~/.codex/.env — so interactive Codex needs no manual export."
       },
       "kiro": {
         "step1Title": "Step 1: Set environment variables",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1178,9 +1178,9 @@
       },
       "codex": {
         "step1Title": "ステップ 1：環境変数を設定",
-        "step1Tip": "ヒント：chorus agents add（ステップ 2）がこれらを読み取り ~/.codex/.env に書き込むため、Codex のためにシェルの rc へ永続化する必要はありません。対話的に起動した Codex は ~/.codex/.env から自身の識別情報（プラグインフック、shell ツールでの chorus 呼び出し、ネイティブ MCP）を解決します。デーモンに起こされたセッションは自動的に取得します。",
+        "step1Tip": "永続化は不要です。ステップ 2 の chorus agents add が ~/.codex/.env に書き込みます。",
         "step2Title": "ステップ 2：chorus agents add を実行",
-        "step2Tip": "chorus agents add は chorus-plugins マーケットプレイスを登録し、Chorus プラグインを Codex にインストールし、認証情報を保存し、CHORUS_URL / CHORUS_API_KEY / CHORUS_AGENT_PROFILE を ~/.codex/.env に書き込み（Codex は起動時にこれを自身のプロセス環境へ読み込みます）、さらにキーを含まない [mcp_servers.chorus] を bearer_token_env_var = \"CHORUS_API_KEY\" で ~/.codex/config.toml に書き込みます。これにより、インタラクティブな Codex は一切手動の export が不要になります。プラグインの hook、モデルによる shell ツールでの chorus 呼び出し、ネイティブ MCP はすべて ~/.codex/.env から本人確認を解決します（API キーは config.toml に保存されません）。CHORUS_URL と CHORUS_API_KEY は環境変数（ステップ 1）から読み取ります。 最初のコマンドは Chorus CLI をグローバルにインストールします（バージョン 0.17.0 に固定）。"
+        "step2Tip": "chorus agents add は Chorus プラグインをインストールし、CHORUS_URL・CHORUS_API_KEY・CHORUS_AGENT_PROFILE を ~/.codex/.env に書き込みます。そのため対話的な Codex では手動の export は不要です。"
       },
       "kiro": {
         "step1Title": "ステップ 1：環境変数を設定",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1178,9 +1178,9 @@
       },
       "codex": {
         "step1Title": "1단계: 환경 변수 설정",
-        "step1Tip": "팁: chorus agents add(2단계)이 이 값들을 읽어 ~/.codex/.env에 기록하므로 Codex를 위해 셸 rc에 영구 저장할 필요가 없습니다. 대화형으로 실행한 Codex는 ~/.codex/.env에서 자신의 신원(플러그인 훅, shell 도구의 chorus 호출, 네이티브 MCP)을 해석합니다. 데몬이 깨운 세션은 자동으로 받습니다.",
+        "step1Tip": "영구 저장할 필요가 없습니다. 2단계의 chorus agents add이 ~/.codex/.env에 기록합니다.",
         "step2Title": "2단계: chorus agents add 실행",
-        "step2Tip": "chorus agents add은 chorus-plugins 마켓플레이스를 등록하고 Chorus 플러그인을 Codex에 설치하며, 자격 증명을 저장하고, CHORUS_URL / CHORUS_API_KEY / CHORUS_AGENT_PROFILE를 ~/.codex/.env에 기록하며(Codex가 시작 시 자신의 프로세스 환경으로 로드), 키가 없는 [mcp_servers.chorus]를 bearer_token_env_var = \"CHORUS_API_KEY\"로 ~/.codex/config.toml에 기록합니다. 따라서 대화형 Codex는 수동 export가 전혀 필요 없습니다. 플러그인 hook, 모델의 shell 도구 chorus 호출, 네이티브 MCP 모두 ~/.codex/.env에서 신원을 해석합니다(API 키는 config.toml에 저장되지 않음). CHORUS_URL과 CHORUS_API_KEY는 환경 변수(1단계)에서 읽습니다. 첫 번째 명령은 Chorus CLI를 전역으로 설치합니다(버전 0.17.0으로 고정)."
+        "step2Tip": "chorus agents add은 Chorus 플러그인을 설치하고 CHORUS_URL, CHORUS_API_KEY, CHORUS_AGENT_PROFILE를 ~/.codex/.env에 기록합니다. 따라서 대화형 Codex는 수동 export가 필요 없습니다."
       },
       "kiro": {
         "step1Title": "1단계: 환경 변수 설정",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1178,9 +1178,9 @@
       },
       "codex": {
         "step1Title": "第 1 步：设置环境变量",
-        "step1Tip": "提示：chorus agents add（第 2 步）会读取这些变量并写入 ~/.codex/.env，因此你无需为 Codex 把它们持久化到 shell rc——交互式启动的 Codex 会从 ~/.codex/.env 解析出自己的身份（插件 hook、shell 工具里的 chorus 调用、以及原生 MCP）。被 daemon 唤醒的会话会自动拿到。",
+        "step1Tip": "无需持久化——第 2 步的 chorus agents add 会将它们写入 ~/.codex/.env。",
         "step2Title": "第 2 步：运行 chorus agents add",
-        "step2Tip": "chorus agents add 会注册 chorus-plugins marketplace，把 Chorus 插件安装进 Codex，写入你的凭证，把 CHORUS_URL / CHORUS_API_KEY / CHORUS_AGENT_PROFILE 写进 ~/.codex/.env（Codex 启动时加载进自己的进程环境），并把一个不含密钥的 [mcp_servers.chorus] 写进 ~/.codex/config.toml，使用 bearer_token_env_var = \"CHORUS_API_KEY\"——因此交互式 Codex 完全无需手动 export：插件 hook、模型在 shell 里调用 chorus、以及原生 MCP 都从 ~/.codex/.env 解析你的身份（config.toml 里不存 API key）。它会从环境变量（第 1 步）读取 CHORUS_URL 和 CHORUS_API_KEY。 上面第一条命令会全局安装 Chorus CLI（锁定 0.17.0 版本）。"
+        "step2Tip": "chorus agents add 会安装 Chorus 插件，并将 CHORUS_URL、CHORUS_API_KEY、CHORUS_AGENT_PROFILE 写入 ~/.codex/.env——交互式 Codex 无需手动 export。"
       },
       "kiro": {
         "step1Title": "第 1 步：设置环境变量",

--- a/src/components/install-guide/AgentInstallGuide.tsx
+++ b/src/components/install-guide/AgentInstallGuide.tsx
@@ -20,10 +20,6 @@ export function AgentInstallGuide({ apiKey }: AgentInstallGuideProps) {
   const origin = typeof window !== "undefined" ? window.location.origin : "";
   const displayKey = apiKey || "<YOUR_API_KEY>";
 
-  // Optional step, identical across every `chorus agents add` tab (Claude Code /
-  // Codex / Kiro / OpenCode): pick the default agent the chorus CLI acts as. dsh
-  // omits it (its profile is seeded into $DSH_HOME/.env and loaded by dsh);
-  // openClaw / other don't run `chorus agents add`, so no CLI profile applies.
   const profileStep = (
     <div>
       <h3 className="mb-2 text-sm font-medium text-foreground">
@@ -121,7 +117,6 @@ export function AgentInstallGuide({ apiKey }: AgentInstallGuideProps) {
               </p>
             </div>
 
-            {profileStep}
           </TabsContent>
 
           {/* Kiro Tab */}

--- a/src/components/install-guide/__tests__/agent-install-guide.test.tsx
+++ b/src/components/install-guide/__tests__/agent-install-guide.test.tsx
@@ -156,39 +156,21 @@ describe("AgentInstallGuide dsh onboarding", () => {
     }
   });
 
-  it("shows the optional 'default agent' Step 3 on every chorus-agents-add tab, and drops the redundant 'Verify connection' step (onboarding has its own connection check)", async () => {
+  it("removes the manual default-agent step from Codex only", async () => {
     const user = userEvent.setup();
     render(<AgentInstallGuide apiKey={null} />);
 
     const PROFILE_TITLE = "Step 3 (optional): Set the default agent for the Chorus CLI";
-    // Codex / Kiro / OpenCode still show the manual export-profile step (their
-    // settings-file auto-write is a separate, unbuilt sibling idea).
-    for (const tab of ["Codex", "Kiro", "OpenCode"]) {
+
+    await user.click(screen.getByRole("tab", { name: "Codex" }));
+    expect(screen.queryByText(PROFILE_TITLE)).toBeNull();
+    expect(screen.queryByText(/export CHORUS_AGENT_PROFILE="<agent-uuid>"/)).toBeNull();
+
+    for (const tab of ["Kiro", "OpenCode"]) {
       await user.click(screen.getByRole("tab", { name: tab }));
       expect(screen.getByText(PROFILE_TITLE)).toBeTruthy();
       expect(screen.getByText(/export CHORUS_AGENT_PROFILE="<agent-uuid>"/)).toBeTruthy();
-      // The old per-tab "Verify connection" step is gone on every tab.
-      expect(screen.queryByText(/Verify connection/)).toBeNull();
     }
-
-    // Claude Code shows NO Step 3 at all: no export-profile step and no separate
-    // writes-section (the settings.json write is stated concisely in the Step 2 tip).
-    await user.click(screen.getByRole("tab", { name: "Claude Code" }));
-    expect(screen.queryByText(PROFILE_TITLE)).toBeNull();
-    expect(
-      screen.queryByText("What chorus agents add writes (no manual export needed)"),
-    ).toBeNull();
-    expect(screen.queryByText(/Verify connection/)).toBeNull();
-
-    // dsh keeps its own flow and does NOT get the CLI profile step (its profile is
-    // seeded into $DSH_HOME/.env, not exported by hand).
-    await user.click(screen.getByRole("tab", { name: "DeepSeek Harness" }));
-    expect(screen.queryByText(PROFILE_TITLE)).toBeNull();
-
-    // OpenClaw no longer shows a "Verify connection" step either.
-    await user.click(screen.getByRole("tab", { name: "OpenClaw" }));
-    expect(screen.queryByText(/Verify connection/)).toBeNull();
-    expect(screen.queryByText(PROFILE_TITLE)).toBeNull();
   });
 
   it("uses the API-key placeholder when no live key is available", async () => {


### PR DESCRIPTION
## Summary
- remove the redundant optional default-agent step from the Codex onboarding tab only
- shorten Codex setup guidance across English, Chinese, Japanese, and Korean
- preserve the existing Kiro and OpenCode profile steps

## Changed files
| File | Change |
|------|--------|
| `src/components/install-guide/AgentInstallGuide.tsx` | Stop rendering the shared profile step for Codex |
| `src/components/install-guide/__tests__/agent-install-guide.test.tsx` | Verify the behavior is Codex-only |
| `messages/{en,zh,ja,ko}.json` | Align Codex copy with Claude Code's concise guidance |

## Test plan
- [x] `pnpm vitest run src/components/install-guide/__tests__/agent-install-guide.test.tsx`
- [x] `pnpm exec tsc --noEmit`
- [x] Targeted ESLint (0 errors)
- [x] Browser verification on `/onboarding`: Codex shows only steps 1 and 2
- [x] Impeccable detector: 0 findings