### PR TITLE
feat(cli): refresh installed agent plugins

### DIFF
--- a/cli/__tests__/init-args.test.mjs
+++ b/cli/__tests__/init-args.test.mjs
@@ -78,5 +78,7 @@ describe("initHelpText", () => {
     expect(t).toContain("USAGE");
     expect(t).toContain("--agents");
     expect(t).toContain("NON-INTERACTIVE");
+    expect(t).toMatch(/--yes[\s\S]*installed plugins to latest/);
+    expect(t).toMatch(/non-TTY runs refresh selected installed/);
   });
 });

--- a/cli/__tests__/init-file-template.test.mjs
+++ b/cli/__tests__/init-file-template.test.mjs
@@ -8,7 +8,7 @@
 //     now owned SOLELY by file-template.mjs — install-kiro.sh is a deprecation
 //     stub with no manifest, so the old bash-side parity assertion is gone.
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -28,11 +28,12 @@ const { INSTALLED, REPAIRED, SKIPPED, FAILED } = OUTCOME_ACTIONS;
 
 const tmp = (p) => mkdtempSync(join(tmpdir(), p));
 
-// A small SYNTHETIC manifest so tests control the exact asset set (2 skills / 1
+// A small SYNTHETIC manifest so tests control the exact asset set (3 skills / 1
 // reviewer / 1 hook). Comment + blank lines exercise the parser's skips.
 const SYNTH_MANIFEST = `# Chorus kiro manifest (test)
 skill chorus-idea
 skill chorus-yolo
+skill chorus-orchestrate
 
 reviewer chorus-task-reviewer
 hook on-stop.sh
@@ -94,7 +95,7 @@ function makeFetch(routes, { fail } = {}) {
 describe("parseManifest", () => {
   it("splits kind/name lines, ignoring blanks, comments, and unknown kinds", () => {
     expect(parseManifest(SYNTH_MANIFEST)).toEqual({
-      skills: ["chorus-idea", "chorus-yolo"],
+      skills: ["chorus-idea", "chorus-yolo", "chorus-orchestrate"],
       reviewerAgents: ["chorus-task-reviewer"],
       hookScripts: ["on-stop.sh"],
     });
@@ -166,11 +167,12 @@ describe("installFileTemplate (temp dir + faked fetch)", () => {
     const logs = [];
     const res = await installFileTemplate({ chorusUrl: "https://x.dev/api/mcp", kiroDir, fetchImpl, log: (m) => logs.push(m) });
 
-    expect(res).toMatchObject({ skills: 2, reviewerAgents: 1, hookScripts: 1 });
+    expect(res).toMatchObject({ skills: 3, reviewerAgents: 1, hookScripts: 1 });
     expect(logs.join("\n")).toContain(kiroDir); // log hook fired
     // skills + reviewer + main agent + steering
     expect(existsSync(join(kiroDir, "skills", "chorus-idea", "SKILL.md"))).toBe(true);
     expect(existsSync(join(kiroDir, "skills", "chorus-yolo", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(kiroDir, "skills", "chorus-orchestrate", "SKILL.md"))).toBe(true);
     expect(existsSync(join(kiroDir, "agents", "chorus-task-reviewer.json"))).toBe(true);
     expect(existsSync(join(kiroDir, "agents", "chorus.md"))).toBe(true);
     expect(existsSync(join(kiroDir, "steering", "chorus.md"))).toBe(true);
@@ -302,6 +304,35 @@ describe("installKiro", () => {
     expect(fetchImpl.seen).toHaveLength(0);
   });
 
+  it("refreshes a complete installed template, replaces Chorus assets, and merge-preserves MCP config", async () => {
+    const kiroDir = join(tmp("kiro-refresh-"), ".kiro");
+    mkdirSync(join(kiroDir, "skills", "chorus-idea"), { recursive: true });
+    mkdirSync(join(kiroDir, "agents"), { recursive: true });
+    mkdirSync(join(kiroDir, "settings"), { recursive: true });
+    writeFileSync(join(kiroDir, "skills", "chorus-idea", "SKILL.md"), "# stale");
+    writeFileSync(join(kiroDir, "agents", "chorus.json"), '{"stale":true}');
+    writeFileSync(
+      join(kiroDir, "settings", "mcp.json"),
+      JSON.stringify({ mcpServers: { chorus: { stale: true }, mine: { type: "stdio" } } }),
+    );
+    const backups = [];
+    const res = await installKiro(kiroCtx({
+      state: { pluginInstalled: true, skillsPresent: true, agentPresent: true, mcpServerPresent: true },
+      env: { CHORUS_URL: "https://x.dev", KIRO_DIR: kiroDir },
+      flags: { updateInstalled: true },
+      fetchImpl: makeFetch(fullRoutes()),
+      backup: (p) => backups.push(p),
+    }));
+    expect(res.action).toBe(REPAIRED);
+    expect(readFileSync(join(kiroDir, "skills", "chorus-idea", "SKILL.md"), "utf8")).toBe("# chorus-idea");
+    expect(readFileSync(join(kiroDir, "skills", "chorus-orchestrate", "SKILL.md"), "utf8")).toBe("# chorus-orchestrate");
+    const mcp = JSON.parse(readFileSync(join(kiroDir, "settings", "mcp.json"), "utf8"));
+    expect(mcp.mcpServers.mine).toEqual({ type: "stdio" });
+    expect(mcp.mcpServers.chorus.url).toBe("https://x.dev/api/mcp");
+    expect(mcp.mcpServers.chorus.headers.Authorization).toBe("Bearer ${env:CHORUS_API_KEY}");
+    expect(backups).toEqual([join(kiroDir, "settings", "mcp.json")]);
+  });
+
   it("FAILED when no Chorus URL is resolvable (nothing to download from)", async () => {
     const res = await installKiro(kiroCtx({ state: { pluginInstalled: false }, env: {} }));
     expect(res.action).toBe(FAILED);
@@ -419,6 +450,16 @@ describe("kiro manifest (owned solely by file-template.mjs)", () => {
     expect(js.skills.length).toBeGreaterThan(0);
     expect(js.reviewerAgents.length).toBeGreaterThan(0);
     expect(js.hookScripts.length).toBeGreaterThan(0);
+  });
+
+  it("lists every skill shipped in the Kiro template", () => {
+    const manifestSkills = [...readKiroManifestFile().skills].sort();
+    const skillsDir = fileURLToPath(new URL(".kiro/skills/", KIRO_MANIFEST_URL));
+    const templateSkills = readdirSync(skillsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && existsSync(join(skillsDir, entry.name, "SKILL.md")))
+      .map((entry) => entry.name)
+      .sort();
+    expect(manifestSkills).toEqual(templateSkills);
   });
 
   it("readKiroManifestFile reads the repo manifest at its canonical path", () => {

--- a/cli/__tests__/init-integration.test.mjs
+++ b/cli/__tests__/init-integration.test.mjs
@@ -5,12 +5,13 @@
 // (ctxExtras) so no real server / agent CLI is touched. Exercises the full
 // detect → select → credential-seed → plugin-install → summary path.
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runInit } from "../init.mjs";
 import { detectAgents, orderedSteps, getAdapter, STEP_REGISTRY } from "../init/registry.mjs";
 import { STEP_SCOPES, OUTCOME_ACTIONS } from "../init/contracts.mjs";
+import { pluginInstallStep } from "../init/steps/plugin-install.mjs";
 
 function capture() {
   const lines = [];
@@ -43,6 +44,92 @@ function fakeKiroFetch() {
 }
 
 describe("chorus init — end-to-end (real registry, injected collaborators)", () => {
+  it("detects an installed live dsh profile before interactive profile resolution and asks once to refresh", async () => {
+    const dshHome = mkdtempSync(join(tmpdir(), "refresh-dsh-"));
+    const profileDir = join(dshHome, "profiles", "work");
+    mkdirSync(profileDir, { recursive: true });
+    writeFileSync(
+      join(profileDir, "package.json"),
+      JSON.stringify({ dependencies: { "@chorus-aidlc/chorus-dsh": "^0.16.4" } }),
+    );
+    const prompts = [];
+    const calls = [];
+    const lines = [];
+    const io = {
+      log: (m) => lines.push(String(m)),
+      isTTY: true,
+      ask: async (q) => {
+        prompts.push(String(q));
+        return String(q).includes("Update installed") ? "y" : "work";
+      },
+    };
+    const code = await runInit(["--agents", "dsh"], {
+      io,
+      env: { HOME: "/unused", DSH_HOME: dshHome },
+      detectAgents,
+      orderedSteps: () => [pluginInstallStep],
+      getAdapter,
+      backup: () => null,
+      ctxExtras: {
+        binaryOnPath: () => true,
+        run: (cmd, args) => {
+          calls.push([cmd, args]);
+          return { ok: true, stdout: "" };
+        },
+      },
+    });
+
+    expect(code).toBe(0);
+    expect(prompts.filter((q) => q.includes("Update installed"))).toHaveLength(1);
+    expect(prompts.filter((q) => q.includes("dsh profile"))).toHaveLength(1);
+    expect(prompts[0]).toContain("Update installed");
+    expect(prompts[1]).toContain("dsh profile");
+    expect(calls).toEqual([
+      ["dsh", ["plugin", "--profile", "work", "add", "@chorus-aidlc/chorus-dsh", "-w"]],
+    ]);
+    expect(lines.join("\n")).toContain("dsh: repaired");
+  });
+
+  it("continues accepted installed-plugin refreshes after one harness fails and exits non-zero", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "refresh-codex-"));
+    const opencodeDir = mkdtempSync(join(tmpdir(), "refresh-opencode-"));
+    writeFileSync(
+      join(codexHome, "config.toml"),
+      '[marketplaces.chorus-plugins]\nsource = "x"\n[plugins."chorus@chorus-plugins"]\nenabled = true\n',
+    );
+    mkdirSync(opencodeDir, { recursive: true });
+    writeFileSync(join(opencodeDir, "opencode.json"), JSON.stringify({ plugin: ["opencode-chorus@0.16.0"] }));
+    const calls = [];
+    const io = capture();
+    const code = await runInit(["--agents", "codex,opencode", "--yes"], {
+      io,
+      env: { HOME: "/unused", CODEX_HOME: codexHome, OPENCODE_CONFIG_DIR: opencodeDir },
+      detectAgents,
+      orderedSteps: () => [pluginInstallStep],
+      getAdapter,
+      backup: () => null,
+      ctxExtras: {
+        run: (cmd, args) => {
+          calls.push([cmd, args]);
+          if (cmd === "codex" && args.includes("upgrade")) {
+            return { ok: false, stderr: "simulated marketplace refresh failure" };
+          }
+          return { ok: true, stdout: "" };
+        },
+        writeCodexMcpServer: () => {},
+        resolveCredentials: () => ({ url: undefined }),
+      },
+    });
+    const text = io.lines.join("\n");
+    expect(code).toBe(1);
+    expect(text).toContain("codex: failed");
+    expect(text).toContain("opencode: repaired");
+    expect(calls).toContainEqual([
+      "opencode",
+      ["plugin", "opencode-chorus", "-g", "--force"],
+    ]);
+  });
+
   it("captures a key per selected agent then runs plugin-install per agent, in order, with a summary", async () => {
     // A TTY run so the SECOND agent's key can be prompted (the first pre-fills from
     // --api-key). `--yes` keeps daemon-setup non-interactive. All daemon-setup +

--- a/cli/__tests__/init-plugin-install.test.mjs
+++ b/cli/__tests__/init-plugin-install.test.mjs
@@ -94,6 +94,18 @@ describe("installClaude (verified `claude plugin` CLI)", () => {
     expect(run.calls[0].args).toEqual(["plugin", "marketplace", "add", "https://github.com/Chorus-AIDLC/Chorus"]);
     expect(run.calls[1].args).toEqual(["plugin", "install", "chorus@chorus-plugins", "-y"]);
   });
+  it("updates an installed plugin to latest with the live-verified -y signature", () => {
+    const run = fakeRun();
+    const res = installClaude(ctxFor("claude", {
+      state: { pluginInstalled: true, version: "0.17.0" },
+      run,
+      flags: { updateInstalled: true },
+    }));
+    expect(res.action).toBe(REPAIRED);
+    expect(run.calls.map((c) => c.args)).toEqual([
+      ["plugin", "update", "chorus@chorus-plugins", "-y"],
+    ]);
+  });
   it("repairs (install only) when marketplace already registered", () => {
     const run = fakeRun();
     const res = installClaude(ctxFor("claude", { state: { marketplaceRegistered: true, pluginInstalled: false }, run }));
@@ -124,6 +136,41 @@ describe("installCodex (verified codex-cli 0.146.1)", () => {
     const res = installCodex(ctxFor("codex", { state: { pluginInstalled: true }, run }));
     expect(res.action).toBe(SKIPPED);
     expect(run.calls).toHaveLength(0);
+  });
+
+  it("backs up, upgrades the marketplace, reinstalls with --json, and normalizes MCP on refresh", () => {
+    const run = fakeRun();
+    const backups = [];
+    const mcpCalls = [];
+    const res = installCodex(ctxFor("codex", {
+      state: { marketplaceRegistered: true, pluginInstalled: true },
+      run,
+      backup: (p) => backups.push(p),
+      env: { HOME: "/home/u", CHORUS_URL: "https://c.example" },
+      flags: { updateInstalled: true },
+      writeCodexMcpServer: (a) => mcpCalls.push(a),
+    }));
+    expect(res.action).toBe(REPAIRED);
+    expect(backups).toEqual(["/home/u/.codex/config.toml"]);
+    expect(run.calls.map((c) => c.args)).toEqual([
+      ["plugin", "marketplace", "upgrade", "chorus-plugins"],
+      ["plugin", "add", "chorus@chorus-plugins", "--json"],
+    ]);
+    expect(mcpCalls).toHaveLength(1);
+  });
+
+  it("reports a marketplace-upgrade failure without attempting plugin add", () => {
+    const run = fakeRun((cmd, args) => args.includes("upgrade")
+      ? { ok: false, stderr: "snapshot failed" }
+      : { ok: true });
+    const res = installCodex(ctxFor("codex", {
+      state: { marketplaceRegistered: true, pluginInstalled: true },
+      run,
+      flags: { updateInstalled: true },
+    }));
+    expect(res.action).toBe(FAILED);
+    expect(res.detail).toContain("snapshot failed");
+    expect(run.calls).toHaveLength(1);
   });
 
   it("writes [mcp_servers.chorus] after plugin add when a Chorus URL is available", () => {
@@ -228,6 +275,20 @@ describe("installOpencode (verified opencode 1.14.33)", () => {
     const res = installOpencode(ctxFor("opencode", { state: { pluginInstalled: true }, run }));
     expect(res.action).toBe(SKIPPED);
   });
+  it("backs up and forces global replacement when refresh is accepted", () => {
+    const run = fakeRun();
+    const backups = [];
+    const res = installOpencode(ctxFor("opencode", {
+      state: { pluginInstalled: true },
+      run,
+      backup: (p) => backups.push(p),
+      env: { HOME: "/home/u" },
+      flags: { updateInstalled: true },
+    }));
+    expect(res.action).toBe(REPAIRED);
+    expect(backups).toEqual(["/home/u/.config/opencode/opencode.json"]);
+    expect(run.calls[0].args).toEqual(["plugin", "opencode-chorus", "-g", "--force"]);
+  });
 });
 
 describe("installDsh (verified docs/CONNECT_DSH.md — dsh 0.1.0-rc.7)", () => {
@@ -288,6 +349,21 @@ describe("installDsh (verified docs/CONNECT_DSH.md — dsh 0.1.0-rc.7)", () => {
     }));
     expect(res.action).toBe(SKIPPED);
     expect(run.calls).toHaveLength(0);
+  });
+
+  it("backs up the profile package and reruns the live-verified add -w command on refresh", async () => {
+    const run = fakeRun();
+    const backups = [];
+    const res = await installDsh(ctxFor("dsh", {
+      state: { pluginInstalled: true, packagePath: "/home/u/.dsh/profiles/work/package.json" },
+      run,
+      backup: (p) => backups.push(p),
+      binaryOnPath: () => true,
+      flags: { dshProfile: "work", updateInstalled: true },
+    }));
+    expect(res.action).toBe(REPAIRED);
+    expect(backups).toEqual(["/home/u/.dsh/profiles/work/package.json"]);
+    expect(run.calls[0].args).toEqual(CMD);
   });
 
   it("fails (never guesses) in a non-TTY run with no explicit profile", async () => {
@@ -395,6 +471,25 @@ describe("installOpenclaw (verified openclaw-plugin README lines 32-35 + package
     }));
     expect(res.action).toBe(SKIPPED);
     expect(run.calls).toHaveLength(0);
+  });
+
+  it("reinstalls and enables an installed plugin on accepted refresh after the host guard", () => {
+    const run = openclawRun("2099.1.1");
+    const backups = [];
+    const res = installOpenclaw(ctxFor("openclaw", {
+      state: { pluginInstalled: true, pluginEnabled: true },
+      run,
+      backup: (p) => backups.push(p),
+      env: { HOME: "/home/u" },
+      flags: { updateInstalled: true },
+    }));
+    expect(res.action).toBe(REPAIRED);
+    expect(backups).toEqual(["/home/u/.openclaw/openclaw.json"]);
+    expect(run.calls.map((c) => c.args)).toEqual([
+      ["--version"],
+      INSTALL,
+      ENABLE,
+    ]);
   });
 
   it("FAILED (no mutation) when the openclaw version cannot be determined", () => {
@@ -505,6 +600,16 @@ describe("state readers (temp fixtures)", () => {
     expect(readDshInstallState({ env: { DSH_HOME: dshHome }, profile: "bare" }).pluginInstalled).toBe(false);
     // Missing profile dir → best-effort probe reports not-installed (no throw).
     expect(readDshInstallState({ env: { DSH_HOME: dshHome }, profile: "ghost" }).pluginInstalled).toBe(false);
+  });
+  it("readDshInstallState recognizes the live dsh profiles/<name> layout", () => {
+    const dshHome = mkdtempSync(join(tmpdir(), "dsh-live-"));
+    mkdirSync(join(dshHome, "profiles", "work"), { recursive: true });
+    const packagePath = join(dshHome, "profiles", "work", "package.json");
+    writeFileSync(packagePath, JSON.stringify({ dependencies: { "@chorus-aidlc/chorus-dsh": "^0.17.0" } }));
+    expect(readDshInstallState({ env: { DSH_HOME: dshHome }, profile: "work" })).toMatchObject({
+      pluginInstalled: true,
+      packagePath,
+    });
   });
   it("readDshInstallState reports not-installed without a profile and falls back to ~/.dsh", () => {
     // No profile at all → cannot resolve which workspace, so not-installed.

--- a/cli/__tests__/init.test.mjs
+++ b/cli/__tests__/init.test.mjs
@@ -112,6 +112,97 @@ describe("runInit — orchestration", () => {
     expect(code).toBe(1);
   });
 
+  it("asks once for installed-plugin refresh and passes a declined decision to every step", async () => {
+    const lines = [];
+    const questions = [];
+    const io = {
+      log: (m) => lines.push(String(m)),
+      isTTY: true,
+      ask: async (q) => {
+        questions.push(q);
+        return "n";
+      },
+    };
+    const seen = [];
+    const adapters = new Map([
+      ["claude", { id: "claude", readInstallState: () => ({ supported: true, pluginInstalled: true }) }],
+      ["codex", { id: "codex", readInstallState: () => ({ supported: true, pluginInstalled: true }) }],
+    ]);
+    const code = await runInit([], {
+      io,
+      detectAgents: () => DETECTIONS,
+      resolveSelection: async () => ({ selectedIds: ["claude", "codex"] }),
+      orderedSteps: () => [{
+        id: "plugin",
+        order: 1,
+        scope: STEP_SCOPES.PER_AGENT,
+        run: (ctx) => {
+          seen.push([ctx.agentId, ctx.flags.updateInstalled]);
+          return { stepId: "plugin", agentId: ctx.agentId, action: OUTCOME_ACTIONS.SKIPPED, detail: "repair only" };
+        },
+      }],
+      getAdapter: (id) => adapters.get(id),
+    });
+    expect(code).toBe(0);
+    expect(questions).toHaveLength(1);
+    expect(questions[0]).toMatch(/latest/i);
+    expect(seen).toEqual([["claude", false], ["codex", false]]);
+  });
+
+  it.each([
+    { label: "--yes", argv: ["--yes"], isTTY: true },
+    { label: "non-TTY", argv: [], isTTY: false },
+  ])("automatically accepts installed-plugin refresh for $label", async ({ argv, isTTY }) => {
+    const io = { ...capture(), isTTY, ask: async () => { throw new Error("must not prompt"); } };
+    let updateInstalled;
+    const code = await runInit(argv, {
+      io,
+      detectAgents: () => DETECTIONS,
+      resolveSelection: async () => ({ selectedIds: ["claude"] }),
+      orderedSteps: () => [{
+        id: "plugin",
+        order: 1,
+        scope: STEP_SCOPES.PER_AGENT,
+        run: (ctx) => {
+          updateInstalled = ctx.flags.updateInstalled;
+          return { stepId: "plugin", agentId: "claude", action: OUTCOME_ACTIONS.REPAIRED, detail: "updated" };
+        },
+      }],
+      getAdapter: () => ({
+        id: "claude",
+        readInstallState: () => ({ supported: true, pluginInstalled: true }),
+      }),
+    });
+    expect(code).toBe(0);
+    expect(updateInstalled).toBe(true);
+  });
+
+  it("does not prompt when only guided or not-installed adapters are selected", async () => {
+    const io = { ...capture(), isTTY: true, ask: async () => { throw new Error("must not prompt"); } };
+    let updateInstalled;
+    await runInit([], {
+      io,
+      detectAgents: () => DETECTIONS,
+      resolveSelection: async () => ({ selectedIds: ["claude", "codex"] }),
+      orderedSteps: () => [{
+        id: "noop",
+        order: 1,
+        scope: STEP_SCOPES.ONCE,
+        run: (ctx) => {
+          updateInstalled = ctx.flags.updateInstalled;
+          return { stepId: "noop", action: OUTCOME_ACTIONS.SKIPPED, detail: "none" };
+        },
+      }],
+      getAdapter: (id) => ({
+        id,
+        readInstallState: () => id === "claude"
+          ? { supported: false, pluginInstalled: true }
+          : { supported: true, pluginInstalled: false },
+      }),
+    });
+    expect(updateInstalled).toBe(false);
+  });
+
   it("a step that throws becomes a visible failed outcome, not a crash", async () => {
     const io = capture();
     const code = await runInit([], {

--- a/cli/init-args.mjs
+++ b/cli/init-args.mjs
@@ -113,7 +113,8 @@ OPTIONS
                            auto-start is unsupported (e.g. Windows). In an
                            interactive TTY run the daemon-setup step prompts instead
                            (default: No).
-  -y, --yes                Skip confirmation prompts (implied when non-TTY).
+  -y, --yes                Accept confirmation prompts, including refreshing
+                           installed plugins to latest (implied when non-TTY).
   -h, --help               Show this help message.
 
 NON-INTERACTIVE
@@ -121,6 +122,8 @@ NON-INTERACTIVE
   will not guess which agents to configure and aborts otherwise. The daemon boot service is
   installed non-interactively ONLY when you pass --daemon-autostart; otherwise the
   daemon config is written and you start it yourself with 'chorus daemon'.
+  With an explicit selection, --yes and non-TTY runs refresh selected installed
+  plugins to their latest available versions without prompting.
 
 SCOPE
   This installs the plugin SURFACE, seeds credentials into the daemon config, and

--- a/cli/init.mjs
+++ b/cli/init.mjs
@@ -97,11 +97,26 @@ export async function runInit(argv = [], deps = {}) {
 
   io.log(`[chorus agents add] Configuring: ${selectedIds.join(", ")}`);
 
+  // Resolve adapters once: update-intent detection and per-agent steps must see
+  // the same adapter instances/state readers.
+  const adapters = new Map();
+  for (const agentId of selectedIds) {
+    adapters.set(agentId, await getAdapter(agentId));
+  }
+  const updateInstalled = await resolveUpdateInstalled({
+    selectedIds,
+    adapters,
+    flags,
+    env,
+    io,
+  });
+  const resolvedFlags = { ...flags, updateInstalled };
+
   const steps = await orderedSteps();
   // `ctxExtras` lets a caller/test inject step-context collaborators (e.g. a
   // fake credential validator or command runner) so an end-to-end run is
   // hermetic; production passes none and steps use their real defaults.
-  const baseCtx = { selection: selectedIds, flags, io, env, backup, ...(deps.ctxExtras ?? {}) };
+  const baseCtx = { selection: selectedIds, flags: resolvedFlags, io, env, backup, ...(deps.ctxExtras ?? {}) };
   /** @type {import("./init/contracts.mjs").StepOutcome[]} */
   const outcomes = [];
 
@@ -109,7 +124,7 @@ export async function runInit(argv = [], deps = {}) {
     try {
       if (step.scope === STEP_SCOPES.PER_AGENT) {
         for (const agentId of selectedIds) {
-          const adapter = await getAdapter(agentId);
+          const adapter = adapters.get(agentId);
           outcomes.push(await step.run({ ...baseCtx, agentId, adapter }));
         }
       } else {
@@ -127,6 +142,36 @@ export async function runInit(argv = [], deps = {}) {
 
   summarize(outcomes.flat(), io, selectedIds);
   return outcomes.flat().some(isFailureOutcome) ? 1 : 0;
+}
+
+/**
+ * Resolve one installed-plugin update decision for the whole invocation.
+ * Unsupported/guided adapters and selected adapters without an installed
+ * Chorus payload do not trigger the question. `--yes` and non-TTY runs accept
+ * automatically; an interactive answer defaults to no.
+ */
+export async function resolveUpdateInstalled({ selectedIds, adapters, flags, env, io }) {
+  let anyInstalled = false;
+  for (const agentId of selectedIds) {
+    const adapter = adapters.get(agentId);
+    if (!adapter || typeof adapter.readInstallState !== "function") continue;
+    try {
+      const profile = flags.dshProfile ?? env.CHORUS_DSH_PROFILE;
+      const state = await adapter.readInstallState({ env, profile });
+      if (state?.supported === true && state?.pluginInstalled === true) {
+        anyInstalled = true;
+        break;
+      }
+    } catch {
+      // State probes are advisory and read-only. A broken probe must not block
+      // normal repair/install work; the installer will report its own outcome.
+    }
+  }
+  if (!anyInstalled) return false;
+  if (flags.yes || !io.isTTY) return true;
+  if (typeof io.ask !== "function") return false;
+  const answer = String(await io.ask("Update installed Chorus plugins to the latest available versions? [y/N] ")).trim();
+  return /^(?:y|yes)$/i.test(answer);
 }
 
 /** Print the per-outcome summary table. */

--- a/cli/init/contracts.mjs
+++ b/cli/init/contracts.mjs
@@ -108,6 +108,8 @@ export const FAILURE_ACTIONS = Object.freeze([OUTCOME_ACTIONS.FAILED]);
  * @property {string} [agentId]     The current agent id (per-agent steps only).
  * @property {AgentAdapter} [adapter] The current agent's adapter (per-agent steps only).
  * @property {object} flags         Parsed init flags (see cli/init-args.mjs).
+ *   `flags.updateInstalled` is the orchestrator-resolved, invocation-wide
+ *   decision to refresh selected installed plugin payloads.
  * @property {{ log: (m: string) => void, ask: Function, isTTY: boolean }} io
  * @property {(path: string) => (string|null)} backup  Copy a file to <path>.chorus-bak
  *   once before overwrite; returns the backup path or null if the source is absent.

--- a/cli/init/install-methods.mjs
+++ b/cli/init/install-methods.mjs
@@ -66,9 +66,10 @@ function readJsonSafe(path) {
 }
 
 // ---------------------------------------------------------------------------
-// Claude Code — VERIFIED against Claude Code 2.1.235:
+// Claude Code — VERIFIED LIVE against Claude Code 2.1.250:
 //   `claude plugin marketplace add <url|path|repo>`
 //   `claude plugin install <plugin@marketplace> -y`  (-y required when non-TTY)
+//   `claude plugin update <plugin@marketplace> -y`
 // State is read from ~/.claude/plugins/installed_plugins.json (read-only).
 // ---------------------------------------------------------------------------
 export function installClaude(ctx) {
@@ -77,6 +78,11 @@ export function installClaude(ctx) {
   const source = env.CHORUS_MARKETPLACE_SOURCE || CHORUS_MARKETPLACE_SOURCE;
   const state = safeState(ctx);
   if (state.pluginInstalled) {
+    if (ctx.flags?.updateInstalled) {
+      const r = run("claude", ["plugin", "update", CHORUS_PLUGIN_ID, "-y"], { env });
+      if (!r.ok) return out("claude", FAILED, `claude plugin update failed: ${errText(r)}`);
+      return out("claude", REPAIRED, `updated ${CHORUS_PLUGIN_ID} to latest via claude plugin update`);
+    }
     return out("claude", SKIPPED, `already installed${state.version ? ` (v${state.version})` : ""}`);
   }
   if (!state.marketplaceRegistered) {
@@ -91,6 +97,7 @@ export function installClaude(ctx) {
 // ---------------------------------------------------------------------------
 // Codex — VERIFIED against codex-cli 0.146.1 / 0.150.1:
 //   `codex plugin marketplace add <SOURCE>`   (SOURCE = local path | owner/repo[@ref] | Git URL)
+//   `codex plugin marketplace upgrade [MARKETPLACE_NAME]`
 //   `codex plugin add <PLUGIN@MARKETPLACE> --json`
 // config.toml is backed up before the CLI mutates it.
 //
@@ -153,6 +160,21 @@ export function installCodex(ctx) {
 
   if (state.pluginInstalled) {
     ctx.backup?.(configPath); // back up before we normalize the MCP block
+    if (ctx.flags?.updateInstalled) {
+      if (!state.marketplaceRegistered) {
+        const ra = run("codex", ["plugin", "marketplace", "add", source], { env });
+        if (!ra.ok) return out("codex", FAILED, `codex plugin marketplace add failed: ${errText(ra)}`);
+      }
+      const ru = run("codex", ["plugin", "marketplace", "upgrade", CHORUS_MARKETPLACE_NAME], { env });
+      if (!ru.ok) return out("codex", FAILED, `codex plugin marketplace upgrade failed: ${errText(ru)}`);
+      const rp = run("codex", ["plugin", "add", CHORUS_PLUGIN_ID, "--json"], { env });
+      if (!rp.ok) return out("codex", FAILED, `codex plugin add failed: ${errText(rp)}`);
+      return out(
+        "codex",
+        REPAIRED,
+        `refreshed ${CHORUS_MARKETPLACE_NAME} and reinstalled ${CHORUS_PLUGIN_ID}${ensureMcp()}`,
+      );
+    }
     return out("codex", SKIPPED, `already installed (config.toml)${ensureMcp()}`);
   }
 
@@ -171,8 +193,9 @@ export function installCodex(ctx) {
 }
 
 // ---------------------------------------------------------------------------
-// opencode — VERIFIED against opencode 1.14.33:
+// opencode — VERIFIED LIVE against opencode 1.14.33:
 //   `opencode plugin <module>`  ("install plugin and update config")
+//   `--global` targets the user config; `--force` replaces an existing version.
 // module name "opencode-chorus" from public/install-opencode.sh. opencode.json
 // is backed up before the CLI mutates it.
 // ---------------------------------------------------------------------------
@@ -195,15 +218,21 @@ export function installOpencode(ctx) {
   const home = env.HOME || homedir();
   const dir = env.OPENCODE_CONFIG_DIR || join(home, ".config", "opencode");
   const state = safeState(ctx);
-  if (state.pluginInstalled) return out("opencode", SKIPPED, "already in opencode.json plugin list");
+  if (state.pluginInstalled && !ctx.flags?.updateInstalled) {
+    return out("opencode", SKIPPED, "already in opencode.json plugin list");
+  }
 
   ctx.backup?.(join(dir, "opencode.json")); // back up before the CLI edits it
   // `-g` writes the GLOBAL ~/.config/opencode/opencode.json (the same file
   // readOpencodeInstallState checks); without it opencode installs project-local
   // (cwd), which would defeat idempotency for a machine-wide `chorus init`.
-  const r = run("opencode", ["plugin", OPENCODE_PLUGIN_MODULE, "-g"], { env });
+  const args = ["plugin", OPENCODE_PLUGIN_MODULE, "-g"];
+  if (state.pluginInstalled) args.push("--force");
+  const r = run("opencode", args, { env });
   if (!r.ok) return out("opencode", FAILED, `opencode plugin install failed: ${errText(r)}`);
-  return out("opencode", INSTALLED, `installed ${OPENCODE_PLUGIN_MODULE} via opencode plugin -g`);
+  return state.pluginInstalled
+    ? out("opencode", REPAIRED, `updated ${OPENCODE_PLUGIN_MODULE} to latest via opencode plugin -g --force`)
+    : out("opencode", INSTALLED, `installed ${OPENCODE_PLUGIN_MODULE} via opencode plugin -g`);
 }
 
 // ---------------------------------------------------------------------------
@@ -225,18 +254,35 @@ const DSH_BUNDLE = "@chorus-aidlc/chorus-dsh";
 export function readDshInstallState({ env = process.env, profile } = {}) {
   // Best-effort, per-profile idempotency probe. A dsh profile is a pnpm workspace
   // root under $DSH_HOME (docs/CONNECT_DSH.md); a profile that has added the bundle
-  // records it in that root's package.json. The exact layout is NOT verifiable here,
-  // so this degrades to "not installed" if it differs (dsh's own `add` is idempotent)
-  // — never a false positive, never a throw. Called with no `profile` (registry-level
-  // detection, which does not know the user's pick) it reports not-installed.
-  if (!profile) return { marketplaceRegistered: false, pluginInstalled: false };
+  // records it in that root's package.json. Before an interactive profile has
+  // been chosen, inspect the live profiles/<name> store so runInit can include
+  // dsh in its one invocation-wide installed-plugin refresh decision.
   const home = env.HOME || homedir();
   const dshHome = env.DSH_HOME || join(home, ".dsh");
-  const pkg = readJsonSafe(join(dshHome, profile, "package.json"));
-  const deps = { ...(pkg?.dependencies ?? {}), ...(pkg?.devDependencies ?? {}) };
+  let candidates;
+  if (profile) {
+    candidates = [
+      join(dshHome, "profiles", profile, "package.json"),
+      join(dshHome, profile, "package.json"),
+    ];
+  } else {
+    try {
+      candidates = readdirSync(join(dshHome, "profiles"), { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => join(dshHome, "profiles", entry.name, "package.json"));
+    } catch {
+      candidates = [];
+    }
+  }
+  const packagePath = candidates.find((path) => {
+    const pkg = readJsonSafe(path);
+    const deps = { ...(pkg?.dependencies ?? {}), ...(pkg?.devDependencies ?? {}) };
+    return Object.prototype.hasOwnProperty.call(deps, DSH_BUNDLE);
+  });
   return {
     marketplaceRegistered: false, // dsh has no marketplace concept
-    pluginInstalled: Object.prototype.hasOwnProperty.call(deps, DSH_BUNDLE),
+    pluginInstalled: !!packagePath,
+    packagePath: packagePath ?? (profile ? candidates[0] : undefined),
   };
 }
 
@@ -276,11 +322,16 @@ export async function installDsh(ctx) {
 
   // Idempotency: skip when the chosen profile already carries the bundle.
   const state = safeState(ctx, { profile });
-  if (state.pluginInstalled) return out("dsh", SKIPPED, `already installed in dsh profile '${profile}'`);
+  if (state.pluginInstalled && !ctx.flags?.updateInstalled) {
+    return out("dsh", SKIPPED, `already installed in dsh profile '${profile}'`);
+  }
+  if (state.pluginInstalled) ctx.backup?.(state.packagePath);
 
   const r = run("dsh", ["plugin", "--profile", profile, "add", DSH_BUNDLE, "-w"], { env });
   if (!r.ok) return out("dsh", FAILED, `dsh plugin add failed: ${errText(r)}`);
-  return out("dsh", INSTALLED, `installed ${DSH_BUNDLE} into dsh profile '${profile}'`);
+  return state.pluginInstalled
+    ? out("dsh", REPAIRED, `updated ${DSH_BUNDLE} to latest in dsh profile '${profile}'`)
+    : out("dsh", INSTALLED, `installed ${DSH_BUNDLE} into dsh profile '${profile}'`);
 }
 
 // ---------------------------------------------------------------------------
@@ -377,7 +428,7 @@ export function installOpenclaw(ctx) {
 
   // Already installed AND enabled → nothing to do. No version probe needed: an
   // enabled-and-loaded plugin necessarily already satisfied the host floor.
-  if (state.pluginInstalled && state.pluginEnabled) {
+  if (state.pluginInstalled && state.pluginEnabled && !ctx.flags?.updateInstalled) {
     return out("openclaw", SKIPPED, "already installed and enabled");
   }
 
@@ -395,18 +446,26 @@ export function installOpenclaw(ctx) {
   }
 
   // Installed-but-disabled → enable only (repair).
-  if (state.pluginInstalled) {
+  if (state.pluginInstalled && !ctx.flags?.updateInstalled) {
     const re = run("openclaw", ["plugins", "enable", OPENCLAW_PLUGIN_ID], { env });
     if (!re.ok) return out("openclaw", FAILED, `openclaw plugins enable failed: ${errText(re)}`);
     return out("openclaw", REPAIRED, `enabled ${OPENCLAW_PLUGIN_ID} (was installed but disabled)`);
   }
 
-  // Fresh → install from npm, then enable.
+  // Fresh or accepted refresh → install from npm, then ensure enabled. Back up
+  // the mutable host config before an installed payload is refreshed.
+  if (state.pluginInstalled) {
+    const home = env.HOME || homedir();
+    const dir = env.OPENCLAW_CONFIG_DIR || join(home, ".openclaw");
+    ctx.backup?.(join(dir, "openclaw.json"));
+  }
   const ri = run("openclaw", ["plugins", "install", OPENCLAW_NPM_SPEC], { env });
   if (!ri.ok) return out("openclaw", FAILED, `openclaw plugins install failed: ${errText(ri)}`);
   const re = run("openclaw", ["plugins", "enable", OPENCLAW_PLUGIN_ID], { env });
   if (!re.ok) return out("openclaw", FAILED, `openclaw plugins enable failed: ${errText(re)}`);
-  return out("openclaw", INSTALLED, `installed ${OPENCLAW_NPM_SPEC} and enabled ${OPENCLAW_PLUGIN_ID}`);
+  return state.pluginInstalled
+    ? out("openclaw", REPAIRED, `reinstalled latest ${OPENCLAW_NPM_SPEC} and ensured ${OPENCLAW_PLUGIN_ID} is enabled`)
+    : out("openclaw", INSTALLED, `installed ${OPENCLAW_NPM_SPEC} and enabled ${OPENCLAW_PLUGIN_ID}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -457,14 +516,16 @@ export async function installKiro(ctx) {
   const chorusUrl = nonEmpty(ctx.flags?.url) ?? nonEmpty(env.CHORUS_URL);
 
   const state = safeState(ctx);
-  if (state.pluginInstalled) return out("kiro", SKIPPED, `already installed (${kiroDir})`);
+  if (state.pluginInstalled && !ctx.flags?.updateInstalled) {
+    return out("kiro", SKIPPED, `already installed (${kiroDir})`);
+  }
 
   if (!chorusUrl) {
     return out("kiro", FAILED, "no Chorus URL — pass --url or set CHORUS_URL so the .kiro/ template can be downloaded from the connected instance");
   }
 
   // Any chorus-* asset already present ⇒ this is a delta repair, not a fresh drop.
-  const repairing = !!(state.skillsPresent || state.agentPresent || state.mcpServerPresent);
+  const repairing = !!(state.pluginInstalled || state.skillsPresent || state.agentPresent || state.mcpServerPresent);
   try {
     const res = await installFileTemplate({
       chorusUrl,

--- a/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/README.md
+++ b/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/README.md
@@ -1,0 +1,3 @@
+# refresh-installed-agent-plugins
+
+Let chorus agents add refresh already-installed Chorus plugins to the latest available version across all supported harnesses.

--- a/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/design.md
+++ b/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The plugin-install step receives one shared `flags` and `io` context and delegates per harness to functions in `cli/init/install-methods.mjs`. Each installer currently short-circuits when `readInstallState()` reports an installed plugin. That presence-based behavior is correct for ordinary repair, but it prevents a Chorus CLI upgrade from refreshing the independently cached plugin surface.
+
+The six automated harnesses expose different refresh mechanisms:
+
+- Claude Code: `claude plugin update chorus@chorus-plugins -y`.
+- Codex: refresh the configured `chorus-plugins` marketplace snapshot, then rerun `codex plugin add chorus@chorus-plugins --json`.
+- opencode: rerun the global plugin command with `--force`.
+- dsh: rerun its profile-scoped package add, which resolves the latest matching package.
+- OpenClaw: rerun the npm plugin install after the existing host-version guard, then ensure the plugin is enabled.
+- Kiro: rerun the existing file-template downloader, which backs up/merges protected configuration while replacing Chorus-owned assets.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Obtain one update decision per `agents add` invocation, after selection and before per-agent installation.
+- Prompt only when at least one selected automated harness reports an installed plugin.
+- Interpret `--yes` or non-TTY execution as acceptance, matching the existing “skip confirmations” contract.
+- Carry a boolean `updateInstalled` intent through the existing step context.
+- Refresh all six automated harnesses to their latest available plugin content.
+- Preserve per-agent failure isolation, final non-zero status, backups, MCP repair, and credential secrecy.
+
+**Non-Goals:**
+
+- Pin plugins to the local Chorus CLI version.
+- Add a standalone `chorus agents update` command or a new update flag.
+- Compare semantic versions before invoking native refresh mechanisms.
+- Change guided-only harness support or credential/daemon configuration semantics.
+
+## Decisions
+
+### Resolve update intent once in the orchestrator
+
+`runInit` will inspect selected adapters' install state and resolve `flags.updateInstalled` once. An interactive run asks a single yes/no question, defaulting to no; `--yes` and non-TTY runs accept automatically. A single decision avoids six repetitive prompts and keeps installer functions deterministic.
+
+Alternative considered: prompt inside each installer. Rejected because it fragments UX and makes mixed-harness automation harder to reason about.
+
+### Reuse native “latest” behavior instead of version comparison
+
+When `updateInstalled` is true, each installed harness invokes its verified native refresh/reinstall mechanism. The implementation does not compare installed and target versions. Native tools already own marketplace/package resolution, and Kiro's server template endpoint represents the connected instance's current bundle.
+
+Alternative considered: align every plugin to `package.json`'s CLI version. Rejected because the elaborated requirement explicitly chooses latest and several harnesses do not expose a uniform version pinning surface.
+
+### Preserve repair work after refresh
+
+Codex continues normalizing its keyless MCP block after plugin refresh; OpenClaw still enables a disabled plugin; Kiro still merge-preserves `settings/mcp.json`; the rest of the credential and daemon steps run unchanged. Update intent affects only the plugin payload path.
+
+### Treat successful refreshes as repaired outcomes
+
+The existing outcome vocabulary has no `updated` action. A successful installed-plugin refresh returns `repaired` with detail that identifies the refresh command/path. This keeps summary and failure logic compatible while making the action visible.
+
+## Risks / Trade-offs
+
+- [Native reinstall behavior changes across harness releases] → Keep command-shape tests and VERIFIED comments beside every installer; fail visibly when a command exits non-zero.
+- [Latest plugin can lead the installed CLI] → This is an explicit product decision; retain MCP/config compatibility repair and make the resolved latest semantics clear in help text.
+- [A refresh overwrites user-owned files] → Continue calling existing backup helpers before mutable config operations; Kiro replaces only Chorus-owned template assets and merge-preserves MCP settings.
+- [Non-TTY users previously expected a no-op rerun] → Document that `--yes`/non-TTY accepts the update confirmation, and require explicit agent selection as before.
+- [One harness update fails] → Preserve per-agent isolation, continue remaining harnesses, summarize failures, and return exit code 1.
+
+## Migration Plan
+
+No persisted-data migration is required. Ship the CLI behavior and tests together. Rollback restores presence-based skips; existing plugin and credential configurations remain valid.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/proposal.md
+++ b/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`chorus agents add` currently treats an installed plugin as complete, so rerunning it repairs missing configuration but never refreshes skills, hooks, or reviewer agents. Existing users therefore remain on stale plugin bundles unless they learn and invoke each harness's native upgrade mechanism themselves.
+
+## What Changes
+
+- Detect installed Chorus plugins during `chorus agents add` and ask interactive users whether to update them to the latest available release.
+- Treat `--yes` as acceptance of the update prompt so explicit non-interactive runs refresh installed plugins without blocking.
+- Refresh Claude Code, Codex, opencode, dsh, OpenClaw, and Kiro through their verified native update/reinstall or template-refresh mechanisms.
+- Preserve existing idempotent configuration repair, backup, and no-plaintext-key guarantees.
+- Continue processing other selected harnesses after an update failure, report each result, and return non-zero when any required refresh fails.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-plugin-install`: Installed plugins gain a safe latest-version refresh path across all automated harness installers.
+- `chorus-init`: Interactive and `--yes` execution semantics now resolve whether installed plugins are refreshed.
+
+## Impact
+
+The change affects `cli/init-args.mjs`, `cli/init.mjs`, `cli/init/install-methods.mjs`, the plugin-install context, and their unit/integration tests. It invokes existing harness package/plugin managers and the existing Kiro template downloader; it adds no runtime dependency and changes no credential storage format.

--- a/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/specs/agent-plugin-install/spec.md
+++ b/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/specs/agent-plugin-install/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: Idempotent, backed-up plugin installation
+
+The plugin-install step SHALL be idempotent per agent during ordinary repair: it reads current install state, skips agents already installed and enabled when installed-plugin refresh was not accepted, applies only the missing or repair delta for the rest, and backs up any config file before overwriting it. When installed-plugin refresh is accepted, an already-installed automated harness MUST invoke its verified native update/reinstall or template-refresh mechanism to obtain the latest available Chorus plugin payload while preserving the same backup and credential-safety guarantees. A failure for one agent MUST NOT abort configuration of the other selected agents; the step MUST record a per-agent outcome (installed / repaired / skipped / failed) for the final summary, and any failed refresh MUST contribute to a non-zero command exit.
+
+#### Scenario: Already-installed agent is skipped without refresh acceptance
+- **WHEN** an agent's Chorus plugin is already installed and enabled and installed-plugin refresh was not accepted
+- **THEN** the step reports `skipped` for that agent and performs no plugin-payload write
+
+#### Scenario: Already-installed agent is refreshed after acceptance
+- **WHEN** an automated harness's Chorus plugin is already installed and installed-plugin refresh was accepted
+- **THEN** the step invokes that harness's verified latest update/reinstall or template-refresh path and reports a visible `repaired` outcome on success
+
+#### Scenario: One agent's failure is isolated
+- **WHEN** installing or refreshing the plugin for one selected agent fails
+- **THEN** the step records that agent as `failed` with a reason, continues processing the remaining selected agents, and the overall command exits non-zero
+
+#### Scenario: Refresh preserves secret-storage guarantees
+- **WHEN** an installed plugin is refreshed
+- **THEN** existing mutable configuration is backed up before overwrite and no Chorus API key is written as a literal into plugin or MCP configuration
+
+## ADDED Requirements
+
+### Requirement: Harness-native latest plugin refresh
+
+When installed-plugin refresh is accepted, Chorus SHALL refresh every already-installed automated harness using its verified native latest-resolution mechanism: Claude Code plugin update, Codex marketplace upgrade followed by plugin add, opencode forced global plugin install, dsh profile-scoped package add, OpenClaw npm plugin install plus enable, and Kiro template download. Refresh MUST retain harness-specific prerequisites and repair behavior, including the OpenClaw host-version guard, dsh profile resolution, Codex keyless MCP normalization, and Kiro merge-preserving MCP configuration.
+
+#### Scenario: Claude Code refreshes through plugin update
+- **WHEN** Claude Code is selected, its Chorus plugin is installed, and refresh is accepted
+- **THEN** Chorus runs `claude plugin update chorus@chorus-plugins -y`
+
+#### Scenario: Codex refreshes marketplace and plugin cache
+- **WHEN** Codex is selected, its Chorus plugin is installed, and refresh is accepted
+- **THEN** Chorus backs up `config.toml`, upgrades the `chorus-plugins` marketplace snapshot, reruns `codex plugin add chorus@chorus-plugins --json`, and normalizes the keyless Chorus MCP block
+
+#### Scenario: opencode forces global plugin replacement
+- **WHEN** opencode is selected, its Chorus plugin is installed, and refresh is accepted
+- **THEN** Chorus backs up `opencode.json` and runs the global plugin install with `--force`
+
+#### Scenario: dsh refreshes the selected profile package
+- **WHEN** dsh is selected, its Chorus bundle is installed in the resolved profile, `pnpm` is available, and refresh is accepted
+- **THEN** Chorus reruns the profile-scoped `dsh plugin ... add @chorus-aidlc/chorus-dsh -w` command
+
+#### Scenario: OpenClaw reinstalls and enables the npm plugin
+- **WHEN** OpenClaw is selected, its Chorus plugin is installed, the host satisfies the minimum version, and refresh is accepted
+- **THEN** Chorus reruns the npm plugin install and ensures the plugin is enabled
+
+#### Scenario: Kiro replaces Chorus-owned template assets
+- **WHEN** Kiro is selected, its complete Chorus template is installed, and refresh is accepted
+- **THEN** Chorus redownloads the current template, replaces Chorus-owned skills, agents, steering, and hooks, and merge-preserves unrelated MCP configuration

--- a/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/specs/chorus-init/spec.md
+++ b/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/specs/chorus-init/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Scriptable non-interactive surface
+
+The command SHALL support non-interactive use via `--agents <csv>`, `--all`, `--yes`, `--url`, and `--api-key`. When stdin or stdout is not a TTY, the command MUST require an explicit `--agents` or `--all` and abort with a clear message otherwise, rather than guessing which agents to configure. An unknown value in `--agents` MUST be a hard error that lists the valid agent ids. After agent selection, if at least one selected automated harness is already installed, an interactive run without `--yes` MUST ask once whether to update installed plugins to the latest available versions, defaulting to no. A run with `--yes`, or a non-TTY run with the required explicit selection, MUST accept that update confirmation without prompting.
+
+#### Scenario: CI run with explicit agents
+- **WHEN** `chorus agents add --agents claude,codex --url <u> --api-key <k> --yes` runs in a non-TTY environment
+- **THEN** it configures exactly Claude Code and Codex without prompting and refreshes either selected plugin that is already installed
+
+#### Scenario: Non-TTY without a selection aborts
+- **WHEN** `chorus agents add` runs in a non-TTY environment with neither `--agents` nor `--all`
+- **THEN** it aborts with a message instructing the caller to pass `--agents` or `--all`, and configures nothing
+
+#### Scenario: Unknown agent id is rejected
+- **WHEN** `--agents` contains an id not in the adapter registry
+- **THEN** the command exits non-zero and lists the valid agent ids
+
+#### Scenario: Interactive update confirmation is declined
+- **WHEN** an interactive run selects at least one already-installed automated harness and the user declines the single update prompt
+- **THEN** installed plugin payloads remain unchanged while the existing idempotent configuration-repair steps continue
+
+#### Scenario: Interactive update confirmation is accepted
+- **WHEN** an interactive run selects at least one already-installed automated harness and the user accepts the single update prompt
+- **THEN** the plugin-install step refreshes installed selected harnesses to their latest available plugin payloads
+
+#### Scenario: Yes accepts the update confirmation
+- **WHEN** a run with `--yes` selects an already-installed automated harness
+- **THEN** the command refreshes that plugin without prompting

--- a/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/tasks.md
+++ b/openspec/changes/archive/2026-08-28-refresh-installed-agent-plugins/tasks.md
@@ -1,0 +1,15 @@
+## 1. Update intent
+
+- [x] 1.1 Add installed-plugin update decision resolution to `runInit`, including one interactive prompt and automatic acceptance for `--yes` / non-TTY runs.
+- [x] 1.2 Document the update behavior in `chorus agents add --help` and cover parsing/orchestration behavior with unit tests.
+
+## 2. Harness refresh paths
+
+- [x] 2.1 Implement and test installed-plugin refresh for Claude Code, Codex, and opencode using their verified native CLI command shapes.
+- [x] 2.2 Implement and test installed-plugin refresh for dsh and OpenClaw while preserving profile/prerequisite and host-version/enable guards.
+- [x] 2.3 Implement and test Kiro full template refresh while retaining backups, Chorus-owned asset replacement, and merge-preserving MCP configuration.
+
+## 3. Verification
+
+- [x] 3.1 Add integration coverage proving accepted refreshes continue across harness failures and produce a non-zero final exit when any refresh fails.
+- [x] 3.2 Run focused init tests, the full CLI test suite, and `openspec validate refresh-installed-agent-plugins`.

--- a/openspec/specs/agent-plugin-install/spec.md
+++ b/openspec/specs/agent-plugin-install/spec.md
@@ -35,15 +35,23 @@ Every command hardcoded by an installer MUST be verified against that agent's re
 
 ### Requirement: Idempotent, backed-up plugin installation
 
-The plugin-install step SHALL be idempotent per agent: it reads current install state, skips agents already installed and enabled, applies only the missing or repair delta for the rest, and backs up any config file before overwriting it. A failure for one agent MUST NOT abort configuration of the other selected agents; the step MUST record a per-agent outcome (installed / repaired / skipped / failed) for the final summary.
+The plugin-install step SHALL be idempotent per agent during ordinary repair: it reads current install state, skips agents already installed and enabled when installed-plugin refresh was not accepted, applies only the missing or repair delta for the rest, and backs up any config file before overwriting it. When installed-plugin refresh is accepted, an already-installed automated harness MUST invoke its verified native update/reinstall or template-refresh mechanism to obtain the latest available Chorus plugin payload while preserving the same backup and credential-safety guarantees. A failure for one agent MUST NOT abort configuration of the other selected agents; the step MUST record a per-agent outcome (installed / repaired / skipped / failed) for the final summary, and any failed refresh MUST contribute to a non-zero command exit.
 
-#### Scenario: Already-installed agent is skipped
-- **WHEN** an agent's Chorus plugin is already installed and enabled
-- **THEN** the step reports `skipped` for that agent and performs no write
+#### Scenario: Already-installed agent is skipped without refresh acceptance
+- **WHEN** an agent's Chorus plugin is already installed and enabled and installed-plugin refresh was not accepted
+- **THEN** the step reports `skipped` for that agent and performs no plugin-payload write
+
+#### Scenario: Already-installed agent is refreshed after acceptance
+- **WHEN** an automated harness's Chorus plugin is already installed and installed-plugin refresh was accepted
+- **THEN** the step invokes that harness's verified latest update/reinstall or template-refresh path and reports a visible `repaired` outcome on success
 
 #### Scenario: One agent's failure is isolated
-- **WHEN** installing the plugin for one selected agent fails (e.g. its marketplace is unreachable)
-- **THEN** the step records that agent as `failed` with a reason and continues installing the remaining selected agents
+- **WHEN** installing or refreshing the plugin for one selected agent fails
+- **THEN** the step records that agent as `failed` with a reason, continues processing the remaining selected agents, and the overall command exits non-zero
+
+#### Scenario: Refresh preserves secret-storage guarantees
+- **WHEN** an installed plugin is refreshed
+- **THEN** existing mutable configuration is backed up before overwrite and no Chorus API key is written as a literal into plugin or MCP configuration
 
 ### Requirement: dsh plugin installed via its npm-package plugin CLI
 
@@ -108,4 +116,32 @@ An agent with no verified automated install path MUST report `unsupported` with 
 #### Scenario: no stale "not a plugin surface" claim
 - **WHEN** an agent that does have a real install mechanism is described in guided copy anywhere in the installer
 - **THEN** the copy MUST NOT state the agent has no plugin surface or that `chorus agents add` cannot install it
+
+### Requirement: Harness-native latest plugin refresh
+
+When installed-plugin refresh is accepted, Chorus SHALL refresh every already-installed automated harness using its verified native latest-resolution mechanism: Claude Code plugin update, Codex marketplace upgrade followed by plugin add, opencode forced global plugin install, dsh profile-scoped package add, OpenClaw npm plugin install plus enable, and Kiro template download. Refresh MUST retain harness-specific prerequisites and repair behavior, including the OpenClaw host-version guard, dsh profile resolution, Codex keyless MCP normalization, and Kiro merge-preserving MCP configuration.
+
+#### Scenario: Claude Code refreshes through plugin update
+- **WHEN** Claude Code is selected, its Chorus plugin is installed, and refresh is accepted
+- **THEN** Chorus runs `claude plugin update chorus@chorus-plugins -y`
+
+#### Scenario: Codex refreshes marketplace and plugin cache
+- **WHEN** Codex is selected, its Chorus plugin is installed, and refresh is accepted
+- **THEN** Chorus backs up `config.toml`, upgrades the `chorus-plugins` marketplace snapshot, reruns `codex plugin add chorus@chorus-plugins --json`, and normalizes the keyless Chorus MCP block
+
+#### Scenario: opencode forces global plugin replacement
+- **WHEN** opencode is selected, its Chorus plugin is installed, and refresh is accepted
+- **THEN** Chorus backs up `opencode.json` and runs the global plugin install with `--force`
+
+#### Scenario: dsh refreshes the selected profile package
+- **WHEN** dsh is selected, its Chorus bundle is installed in the resolved profile, `pnpm` is available, and refresh is accepted
+- **THEN** Chorus reruns the profile-scoped `dsh plugin ... add @chorus-aidlc/chorus-dsh -w` command
+
+#### Scenario: OpenClaw reinstalls and enables the npm plugin
+- **WHEN** OpenClaw is selected, its Chorus plugin is installed, the host satisfies the minimum version, and refresh is accepted
+- **THEN** Chorus reruns the npm plugin install and ensures the plugin is enabled
+
+#### Scenario: Kiro replaces Chorus-owned template assets
+- **WHEN** Kiro is selected, its complete Chorus template is installed, and refresh is accepted
+- **THEN** Chorus redownloads the current template, replaces Chorus-owned skills, agents, steering, and hooks, and merge-preserves unrelated MCP configuration
 

--- a/openspec/specs/chorus-init/spec.md
+++ b/openspec/specs/chorus-init/spec.md
@@ -29,11 +29,11 @@ Re-running `chorus agents add` SHALL be idempotent: it reads each selected agent
 
 ### Requirement: Scriptable non-interactive surface
 
-The command SHALL support non-interactive use via `--agents <csv>`, `--all`, `--yes`, `--url`, and `--api-key`. When stdin or stdout is not a TTY, the command MUST require an explicit `--agents` or `--all` and abort with a clear message otherwise, rather than guessing which agents to configure. An unknown value in `--agents` MUST be a hard error that lists the valid agent ids.
+The command SHALL support non-interactive use via `--agents <csv>`, `--all`, `--yes`, `--url`, and `--api-key`. When stdin or stdout is not a TTY, the command MUST require an explicit `--agents` or `--all` and abort with a clear message otherwise, rather than guessing which agents to configure. An unknown value in `--agents` MUST be a hard error that lists the valid agent ids. After agent selection, if at least one selected automated harness is already installed, an interactive run without `--yes` MUST ask once whether to update installed plugins to the latest available versions, defaulting to no. A run with `--yes`, or a non-TTY run with the required explicit selection, MUST accept that update confirmation without prompting.
 
 #### Scenario: CI run with explicit agents
 - **WHEN** `chorus agents add --agents claude,codex --url <u> --api-key <k> --yes` runs in a non-TTY environment
-- **THEN** it configures exactly Claude Code and Codex without prompting
+- **THEN** it configures exactly Claude Code and Codex without prompting and refreshes either selected plugin that is already installed
 
 #### Scenario: Non-TTY without a selection aborts
 - **WHEN** `chorus agents add` runs in a non-TTY environment with neither `--agents` nor `--all`
@@ -42,6 +42,18 @@ The command SHALL support non-interactive use via `--agents <csv>`, `--all`, `--
 #### Scenario: Unknown agent id is rejected
 - **WHEN** `--agents` contains an id not in the adapter registry
 - **THEN** the command exits non-zero and lists the valid agent ids
+
+#### Scenario: Interactive update confirmation is declined
+- **WHEN** an interactive run selects at least one already-installed automated harness and the user declines the single update prompt
+- **THEN** installed plugin payloads remain unchanged while the existing idempotent configuration-repair steps continue
+
+#### Scenario: Interactive update confirmation is accepted
+- **WHEN** an interactive run selects at least one already-installed automated harness and the user accepts the single update prompt
+- **THEN** the plugin-install step refreshes installed selected harnesses to their latest available plugin payloads
+
+#### Scenario: Yes accepts the update confirmation
+- **WHEN** a run with `--yes` selects an already-installed automated harness
+- **THEN** the command refreshes that plugin without prompting
 
 ### Requirement: Pluggable step-orchestration seam
 

--- a/public/kiro-plugin/manifest.txt
+++ b/public/kiro-plugin/manifest.txt
@@ -24,6 +24,7 @@ skill chorus-review
 skill chorus-quick-dev
 skill chorus-brainstorm
 skill chorus-openspec-aware
+skill chorus-orchestrate
 skill chorus-docs
 skill chorus-cli
 


### PR DESCRIPTION
## Summary
- ask once whether to refresh already-installed plugins; `--yes` and non-TTY runs accept automatically
- add latest-refresh paths for Claude Code, Codex, opencode, dsh, OpenClaw, and Kiro while preserving backups, keyless configuration, and failure isolation
- add Kiro manifest parity coverage and archive the validated OpenSpec change

## Test plan
- [x] `npm test -- --run cli/__tests__/init-file-template.test.mjs cli/__tests__/init-integration.test.mjs cli/__tests__/init-plugin-install.test.mjs cli/__tests__/init.test.mjs cli/__tests__/init-args.test.mjs` (120 passed)
- [x] `openspec validate --all` (119 passed)
- [x] `git diff --check`

## Chorus
- Idea: `f906f79f-bd3f-483b-ab0b-75f07513e7a4`
- Proposal: `2fc07041-e236-472a-bb60-29a2cd0fae9d`
- Aggregate code review: PASS
