### PR TITLE
fix(cli): resume sessions for non-ASCII cwd

### DIFF
--- a/cli/__tests__/claude-spawner.test.mjs
+++ b/cli/__tests__/claude-spawner.test.mjs
@@ -14,6 +14,7 @@ import {
   escapeCwd,
   transcriptPath,
   isNewSession,
+  SESSION_CONFLICT_FAILURE,
 } from "../claude-spawner.mjs";
 import { writeMcpConfig, buildMcpConfig } from "../mcp-config.mjs";
 
@@ -94,15 +95,42 @@ describe("isValidSessionId", () => {
 });
 
 describe("escapeCwd (verified Claude Code transcript-dir rule)", () => {
-  it("POSIX: replaces both / and . with - (verified on disk)", () => {
+  it("POSIX: preserves established ASCII path fixtures byte-for-byte", () => {
     expect(escapeCwd("/home/ubuntu/dev/ai-pm", "linux")).toBe("-home-ubuntu-dev-ai-pm");
     // a leading-dot segment yields the verified double dash
     expect(escapeCwd("/home/ubuntu/.claude-mem/observer", "linux")).toBe(
       "-home-ubuntu--claude-mem-observer"
     );
   });
-  it("Windows: also escapes backslashes and the drive colon (best-effort)", () => {
+
+  it("normalizes spaces, underscores, CJK, and astral Unicode like Claude Code 2.1.251", () => {
+    expect(escapeCwd("/home/u/my project", "linux")).toBe("-home-u-my-project");
+    expect(escapeCwd("/home/u/proj_name", "linux")).toBe("-home-u-proj-name");
+    expect(escapeCwd("/home/ubuntu/dev/养育", "linux")).toBe("-home-ubuntu-dev---");
+    // Claude's non-unicode regex replaces each UTF-16 surrogate code unit.
+    expect(escapeCwd("/home/u/😀", "linux")).toBe("-home-u---");
+  });
+
+  it("Windows: preserves the established separator and drive-colon fixture", () => {
     expect(escapeCwd("C:\\Users\\me\\dev\\ai-pm", "win32")).toBe("C--Users-me-dev-ai-pm");
+  });
+
+  it("keeps escaped keys through 200 characters and truncates keys over the boundary", () => {
+    expect(escapeCwd("a".repeat(200), "linux")).toBe("a".repeat(200));
+    expect(escapeCwd("a".repeat(201), "linux")).toBe(`${"a".repeat(200)}-rkvsv5`);
+  });
+
+  it("hashes the original cwd after truncating the escaped key", () => {
+    // Both inputs escape to the same 201-character value. Distinct suffixes prove
+    // Claude hashes the original slash/underscore code unit, not the escaped key.
+    const escapedPrefix = `-${"a".repeat(199)}`;
+    expect(escapeCwd(`/${"a".repeat(200)}`, "linux")).toBe(`${escapedPrefix}-b6ymvl`);
+    expect(escapeCwd(`_${"a".repeat(200)}`, "linux")).toBe(`${escapedPrefix}-awnd41`);
+  });
+
+  it("uses original UTF-16 code units for a long cwd hash", () => {
+    const cwd = `/tmp/😀/${"x".repeat(195)}`;
+    expect(escapeCwd(cwd, "linux")).toBe(`-tmp----${"x".repeat(192)}-ty71zh`);
   });
 });
 
@@ -126,6 +154,16 @@ describe("transcriptPath / isNewSession", () => {
     const deps = { env: {}, platform: "linux", home: "/home/u" };
     expect(isNewSession(SID, cwd, { ...deps, exists: (p) => p !== expected })).toBe(true);
     expect(isNewSession(SID, cwd, { ...deps, exists: (p) => p === expected })).toBe(false);
+  });
+
+  it.each([
+    ["/home/ubuntu/dev/养育", "-home-ubuntu-dev---"],
+    ["/home/ubuntu/dev/my project", "-home-ubuntu-dev-my-project"],
+  ])("finds an existing transcript for cwd %s", (cwd, escapedCwd) => {
+    const expected = `/home/u/.claude/projects/${escapedCwd}/${SID}.jsonl`;
+    const deps = { env: {}, platform: "linux", home: "/home/u", exists: (p) => p === expected };
+    expect(transcriptPath(SID, cwd, deps)).toBe(expected);
+    expect(isNewSession(SID, cwd, deps)).toBe(false);
   });
 });
 
@@ -327,6 +365,52 @@ describe("ClaudeSpawner.wake", () => {
     const result = await p;
     expect(result.exitCode).toBe(2);
     expect(warns.join("")).toMatch(/exited with code 2/);
+  });
+
+  it("classifies a split Session ID already-in-use stderr signature on non-zero exit", async () => {
+    const child = makeFakeChild();
+    const spawner = new ClaudeSpawner({
+      claudePath: "/c",
+      spawnImpl: () => child,
+      logger: silent,
+    });
+    const p = spawner.wake({ prompt: "x", sessionId: SID, isNew: true });
+    child.stderr.emit("data", `Error: Session ID ${SID} is already `);
+    child.stderr.emit("data", "in use by another process\n");
+    child.emit("close", 1);
+
+    expect(await p).toEqual({
+      sessionId: SID,
+      backendSessionId: SID,
+      exitCode: 1,
+      isNew: true,
+      failureClassification: SESSION_CONFLICT_FAILURE,
+    });
+  });
+
+  it("leaves unrelated stderr and zero exits unclassified", async () => {
+    for (const { stderr, code } of [
+      { stderr: "authentication failed", code: 1 },
+      { stderr: `Session ID ${SID} is already in use`, code: 0 },
+    ]) {
+      const child = makeFakeChild();
+      const spawner = new ClaudeSpawner({
+        claudePath: "/c",
+        spawnImpl: () => child,
+        logger: silent,
+      });
+      const p = spawner.wake({ prompt: "x", sessionId: SID, isNew: true });
+      child.stderr.emit("data", stderr);
+      child.emit("close", code);
+      const result = await p;
+      expect(result).not.toHaveProperty("failureClassification");
+      expect(result).toMatchObject({
+        sessionId: SID,
+        backendSessionId: SID,
+        exitCode: code,
+        isNew: true,
+      });
+    }
   });
 
   it("does NOT crash on a spawn 'error' event", async () => {

--- a/cli/__tests__/codex-spawner.test.mjs
+++ b/cli/__tests__/codex-spawner.test.mjs
@@ -358,14 +358,21 @@ describe("CodexSpawner.wake — spawn orchestration", () => {
     expect(setThreadId).not.toHaveBeenCalled();
   });
 
-  it("resume wake: a known anchor produces `exec resume <thread_id>` (ignores passed isNew)", async () => {
+  it.each([
+    "/workspaces/项目 alpha",
+    "/workspaces/space only",
+  ])("resume wake: a known anchor ignores the shared new-session probe under cwd %s", async (cwd) => {
     const child = makeFakeChild();
     const { spawner, calls } = makeSpawner({ child, getThreadId: () => TID });
-    // pass isNew:true but the map has a thread id → spawner must resume
-    const p = spawner.wake({ prompt: "again", sessionId: ANCHOR, isNew: true });
+    // pass isNew:true (the shared Claude probe missed) but the map has a thread
+    // id → Codex must resume independently and pass the cwd through verbatim.
+    const p = spawner.wake({ prompt: "again", sessionId: ANCHOR, isNew: true, cwd });
     child.emit("close", 0);
-    await p;
+    const result = await p;
+    expect(spawner.sessionDecision).toEqual({ probeIsAuthoritative: false });
     expect(calls.argv.slice(0, 3)).toEqual(["exec", "resume", TID]);
+    expect(calls.opts.cwd).toBe(cwd);
+    expect(result).toMatchObject({ backendSessionId: TID, isNew: false });
   });
 
   it("forwards each parsed event to onMessage", async () => {

--- a/cli/__tests__/daemon-integration.test.mjs
+++ b/cli/__tests__/daemon-integration.test.mjs
@@ -8,7 +8,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EventEmitter } from "node:events";
 import { buildDaemon, runDaemon } from "../daemon.mjs";
-import { transcriptPath } from "../claude-spawner.mjs";
+import { transcriptPath, SESSION_CONFLICT_FAILURE } from "../claude-spawner.mjs";
 
 const silent = { info() {}, warn() {}, error() {} };
 
@@ -894,6 +894,70 @@ describe("integration checkpoint (子3): interrupt + resume + crash recovery", (
       rmSync(configDir, { recursive: true, force: true });
       rmSync(cwd, { recursive: true, force: true });
     }
+  });
+
+  it("bounds a classified new-session conflict to one resume fallback and suppresses its automatic crash redispatch", async () => {
+    const warnings = [];
+    const logger = {
+      ...silent,
+      warn: (message) => warnings.push(message),
+    };
+    const reportInterrupt = vi.fn(async () => {});
+    const calls = [];
+    const spawner = {
+      wake: vi.fn(async (params) => {
+        calls.push(params);
+        params.onChild?.(fakeChild(45000 + calls.length));
+        return {
+          sessionId: params.sessionId,
+          backendSessionId: params.sessionId,
+          exitCode: 1,
+          isNew: params.isNew,
+          failureClassification: SESSION_CONFLICT_FAILURE,
+        };
+      }),
+    };
+    const TASK_NOTIF_LOCAL = { ...TASK_NOTIF, uuid: "n-session-conflict" };
+    let captured;
+    const daemon = buildDaemon(
+      { url: "https://c", apiKey: "cho_x" },
+      {
+        logger,
+        mcpClient: mcpFor([TASK_NOTIF_LOCAL]),
+        fetchImpl: lineageFetch(),
+        spawner,
+        cwd: "/work/dir",
+        reportInterrupt,
+        makeSseListener: (opts) => (captured = new MockSse(opts)),
+      },
+    );
+
+    await daemon.start();
+    captured.deliver({ type: "connection_registered", connectionUuid: CONN });
+    captured.deliver({
+      type: "new_notification",
+      notificationUuid: "n-session-conflict",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(spawner.wake).toHaveBeenCalledTimes(2);
+    expect(calls.map((call) => call.isNew)).toEqual([true, false]);
+    expect(reportInterrupt).toHaveBeenCalledTimes(1);
+    expect(reportInterrupt).toHaveBeenCalledWith("task", TASK_UUID, "crash");
+
+    captured.deliver({
+      type: "control",
+      command: "resume",
+      targetConnectionUuid: CONN,
+      entityType: "task",
+      entityUuid: TASK_UUID,
+      resumeReason: "crash",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(spawner.wake).toHaveBeenCalledTimes(2);
+    expect(warnings.join("\n")).toMatch(/suppressed automatic crash resume/);
+    await daemon.stop();
   });
 
   // --- AC2: a child that ignores SIGINT escalates to a forceful tree-kill ---

--- a/cli/__tests__/dsh-spawner.test.mjs
+++ b/cli/__tests__/dsh-spawner.test.mjs
@@ -10,6 +10,8 @@ import {
 const CREDS = { url: "https://chorus.test", apiKey: "cho_secret" };
 const UUID = "11111111-2222-4333-8444-555555555555";
 const SID = "chorus-11111111222243338444555555555555";
+const UUID2 = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const SID2 = "chorus-aaaaaaaabbbb4ccc8dddeeeeeeeeeeee";
 
 function response(id, result) {
   return `${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`;
@@ -40,7 +42,7 @@ function fakeChild(onRequest) {
   return child;
 }
 
-function successfulRuntime() {
+function successfulRuntime(sessionId = SID) {
   return fakeChild((request, child) => {
     queueMicrotask(() => {
       if (request.method === "initialize") {
@@ -55,14 +57,14 @@ function successfulRuntime() {
         child.stdout.emit(
           "data",
           notification("session.event", {
-            sessionId: SID,
+            sessionId,
             event: {
               type: "agent/inbox/spliced",
               data: { inserted: [{ id: "msg-1" }] },
             },
           }) +
             notification("session.event", {
-              sessionId: SID,
+              sessionId,
               event: {
                 type: "user/message",
                 data: { message: { role: "user", content: [{ type: "text", text: "hello" }] } },
@@ -85,7 +87,7 @@ function successfulRuntime() {
         child.stdout.emit(
           "data",
           notification("session.event", {
-            sessionId: SID,
+            sessionId,
             event: {
               type: "assistant/message",
               data: {
@@ -95,7 +97,7 @@ function successfulRuntime() {
             },
           }) +
             notification("session.event", {
-              sessionId: SID,
+              sessionId,
               event: {
                 type: "assistant/message",
                 data: {
@@ -117,7 +119,7 @@ function successfulRuntime() {
         child.stdout.emit("data", response(request.id, { messageId: "msg-1" }));
         child.stdout.emit(
           "data",
-          notification("session.status", { sessionId: SID, status: "idle" }),
+          notification("session.status", { sessionId, status: "idle" }),
         );
       } else if (request.method === "shutdown") {
         child.stdout.emit("data", response(request.id, {}));
@@ -265,6 +267,51 @@ describe("DshSpawner.wake", () => {
         source: "dsh",
       },
     });
+  });
+
+  it("passes CJK/space cwd values verbatim while isolating every runtime session", async () => {
+    const fixtures = [
+      { cwd: "/workspaces/项目 alpha", uuid: UUID, sid: SID },
+      { cwd: "/workspaces/space only", uuid: UUID2, sid: SID2 },
+    ];
+    const calls = [];
+    let index = 0;
+    const { spawner } = makeSpawner({
+      uuidFn: () => fixtures[index].uuid,
+      spawnImpl: (command, argv, opts) => {
+        const fixture = fixtures[index++];
+        const child = successfulRuntime(fixture.sid);
+        calls.push({ command, argv, opts, child });
+        return child;
+      },
+    });
+
+    const results = [];
+    for (const fixture of fixtures) {
+      results.push(await spawner.wake({
+        prompt: "continue",
+        sessionId: "shared-claude-anchor",
+        cwd: fixture.cwd,
+        isNew: false,
+      }));
+    }
+
+    expect(spawner.sessionDecision).toEqual({ probeIsAuthoritative: false });
+    expect(results.map((result) => result.backendSessionId)).toEqual([SID, SID2]);
+    for (const [fixtureIndex, fixture] of fixtures.entries()) {
+      const call = calls[fixtureIndex];
+      expect(call.opts.cwd).toBe(fixture.cwd);
+      expect(call.opts.env.DSH_CWD).toBe(fixture.cwd);
+      const requests = call.child.stdin.writes.map((line) => JSON.parse(line));
+      expect(requests[0].params.cwd).toBe(fixture.cwd);
+      expect(requests[1].params.sessionId).toBe(fixture.sid);
+      expect(requests[1].params.sessionId).not.toBe("shared-claude-anchor");
+      expect(results[fixtureIndex]).toMatchObject({
+        sessionId: fixture.sid,
+        backendSessionId: fixture.sid,
+        isNew: true,
+      });
+    }
   });
 
   it("contains callback exceptions and logs stderr diagnostics", async () => {

--- a/cli/__tests__/kiro-spawner.test.mjs
+++ b/cli/__tests__/kiro-spawner.test.mjs
@@ -246,18 +246,25 @@ describe("KiroSpawner.wake — spawn orchestration", () => {
     expect(setSessionId).not.toHaveBeenCalled();
   });
 
-  it("resume wake: a known anchor produces `--resume-id <sessionId>` (ignores passed isNew)", async () => {
+  it.each([
+    "/workspaces/项目 alpha",
+    "/workspaces/space only",
+  ])("resume wake: a known anchor ignores the shared new-session probe under cwd %s", async (cwd) => {
     const child = makeFakeChild();
     const setSessionId = vi.fn();
     const { spawner, calls } = makeSpawner({ child, getSessionId: () => SID, setSessionId });
-    // pass isNew:true but the map has a session id → spawner must resume
-    const p = spawner.wake({ prompt: "again", sessionId: ANCHOR, isNew: true });
+    // pass isNew:true (the shared Claude probe missed) but the map has a session
+    // id → Kiro must resume independently and pass the cwd through verbatim.
+    const p = spawner.wake({ prompt: "again", sessionId: ANCHOR, isNew: true, cwd });
     child.emit("close", 0);
     const result = await p;
+    expect(spawner.sessionDecision).toEqual({ probeIsAuthoritative: false });
     expect(calls.argv).toContain("--resume-id");
     expect(calls.argv[calls.argv.indexOf("--resume-id") + 1]).toBe(SID);
+    expect(calls.opts.cwd).toBe(cwd);
     // resume returns the known id; does NOT re-persist (not a new run)
     expect(result.sessionId).toBe(SID);
+    expect(result.isNew).toBe(false);
     expect(setSessionId).not.toHaveBeenCalled();
   });
 

--- a/cli/__tests__/wake-orchestration.test.mjs
+++ b/cli/__tests__/wake-orchestration.test.mjs
@@ -8,7 +8,7 @@ import { createNoopUploadHooks } from "../upload-hooks.mjs";
 import { Waker } from "../waker.mjs";
 import { EventRouter } from "../event-router.mjs";
 import { WakeQueue } from "../wake-queue.mjs";
-import { ClaudeSpawner } from "../claude-spawner.mjs";
+import { ClaudeSpawner, SESSION_CONFLICT_FAILURE } from "../claude-spawner.mjs";
 import { EventEmitter } from "node:events";
 
 const silent = { info() {}, warn() {}, error() {} };
@@ -631,6 +631,148 @@ describe("Waker.wake full loop", () => {
     expect(snap).toHaveLength(1);
     expect(snap[0].rootIdeaUuid).toBe(ROOT_IDEA);
     expect(snap[0].status).toBe("queued");
+  });
+});
+
+describe("Waker deterministic Claude session-conflict recovery", () => {
+  const FAKE_CHILD_1 = { pid: 6101 };
+  const FAKE_CHILD_2 = { pid: 6102 };
+
+  it("retries a classified new-session conflict exactly once as resume with shared flow and one running transition", async () => {
+    const childrenDuringRun = [];
+    const spawner = {
+      wake: vi.fn(async (params) => {
+        const attempt = spawner.wake.mock.calls.length;
+        const child = attempt === 1 ? FAKE_CHILD_1 : FAKE_CHILD_2;
+        params.onChild?.(child);
+        childrenDuringRun.push(waker.executions.get("task:task-1")?.child);
+        params.onMessage?.({ type: "system", session_id: params.sessionId });
+        return attempt === 1
+          ? {
+              sessionId: params.sessionId,
+              backendSessionId: params.sessionId,
+              exitCode: 1,
+              isNew: true,
+              failureClassification: SESSION_CONFLICT_FAILURE,
+            }
+          : {
+              sessionId: params.sessionId,
+              backendSessionId: params.sessionId,
+              exitCode: 0,
+              isNew: false,
+            };
+      }),
+    };
+    const advanceTurn = vi.fn(async () => {});
+    const reportInterrupt = vi.fn(async () => {});
+    const { waker } = makeWaker({ spawner, advanceTurn, reportInterrupt });
+    const resolved = await waker.keyFor(TASK_NOTIF);
+
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+
+    expect(spawner.wake).toHaveBeenCalledTimes(2);
+    const [first, retry] = spawner.wake.mock.calls.map((call) => call[0]);
+    expect([first.isNew, retry.isNew]).toEqual([true, false]);
+    for (const field of ["prompt", "sessionId", "cwd", "mcpConfigPath"]) {
+      expect(retry[field]).toBe(first[field]);
+    }
+    expect(retry.onChild).toBe(first.onChild);
+    expect(retry.onMessage).toBe(first.onMessage);
+    expect(childrenDuringRun).toEqual([FAKE_CHILD_1, FAKE_CHILD_2]);
+    expect(advanceTurn.mock.calls.map((call) => call[0].status)).toEqual([
+      "running",
+      "ended",
+    ]);
+    expect(reportInterrupt).not.toHaveBeenCalled();
+    expect(waker.deterministicConflictGuards.has(resolved.key)).toBe(false);
+  });
+
+  it("guards only repeated synthetic crash resumes after fallback exhaustion, with clearing and isolation", async () => {
+    const warns = [];
+    const spawner = {
+      wake: vi.fn(async (params) => {
+        params.onChild?.({ pid: 6200 + spawner.wake.mock.calls.length });
+        const attempt = spawner.wake.mock.calls.length;
+        if (attempt <= 2) {
+          return {
+            sessionId: params.sessionId,
+            backendSessionId: params.sessionId,
+            exitCode: 1,
+            isNew: params.isNew,
+            failureClassification: SESSION_CONFLICT_FAILURE,
+          };
+        }
+        return {
+          sessionId: params.sessionId,
+          backendSessionId: params.sessionId,
+          exitCode: attempt === 4 ? 2 : 0,
+          isNew: params.isNew,
+        };
+      }),
+    };
+    const reportInterrupt = vi.fn(async () => {});
+    const { waker } = makeWaker({ spawner, reportInterrupt });
+    waker.logger = { ...silent, warn: (message) => warns.push(message) };
+    const resolved = await waker.keyFor(TASK_NOTIF);
+
+    await waker.wake(TASK_NOTIF, resolved.key, resolved);
+    expect(spawner.wake).toHaveBeenCalledTimes(2);
+    expect(waker.deterministicConflictGuards.has(resolved.key)).toBe(true);
+    expect(reportInterrupt).toHaveBeenCalledWith("task", "task-1", "crash");
+
+    const automaticCrashResume = {
+      ...TASK_NOTIF,
+      action: "resource_resumed",
+      resumedFrom: "crash",
+    };
+    await waker.wake(automaticCrashResume, resolved.key, resolved);
+    expect(spawner.wake).toHaveBeenCalledTimes(2);
+    expect(warns.join("\n")).toMatch(/suppressed automatic crash resume/);
+
+    const otherSession = {
+      key: "idea:22222222-2222-4222-8222-222222222222",
+      rootIdeaUuid: "22222222-2222-4222-8222-222222222222",
+      directIdeaUuid: "22222222-2222-4222-8222-222222222222",
+    };
+    await waker.wake(
+      { ...TASK_NOTIF, entityUuid: "task-2" },
+      otherSession.key,
+      otherSession,
+    );
+    expect(spawner.wake).toHaveBeenCalledTimes(3);
+
+    // An ordinary unclassified crash still runs and reports normally despite the
+    // deterministic guard belonging to this lane.
+    reportInterrupt.mockClear();
+    await waker.wake(
+      { ...TASK_NOTIF, action: "mentioned", message: "check this" },
+      resolved.key,
+      resolved,
+    );
+    expect(spawner.wake).toHaveBeenCalledTimes(4);
+    expect(reportInterrupt).toHaveBeenCalledWith("task", "task-1", "crash");
+
+    // A user-interrupt resume is not the automatic crash-resume shape and remains
+    // unaffected by the guard.
+    await waker.wake(
+      { ...TASK_NOTIF, action: "resource_resumed", resumedFrom: "user" },
+      resolved.key,
+      resolved,
+    );
+    expect(spawner.wake).toHaveBeenCalledTimes(5);
+    expect(waker.deterministicConflictGuards.has(resolved.key)).toBe(true);
+
+    await waker.wake(
+      {
+        ...TASK_NOTIF,
+        action: "human_instruction",
+        instructionText: "try recovery again",
+      },
+      resolved.key,
+      resolved,
+    );
+    expect(spawner.wake).toHaveBeenCalledTimes(6);
+    expect(waker.deterministicConflictGuards.has(resolved.key)).toBe(false);
   });
 });
 

--- a/cli/claude-spawner.mjs
+++ b/cli/claude-spawner.mjs
@@ -3,7 +3,7 @@
 // engineering point of the daemon: parsing stream-json is plain JS and
 // platform-neutral; the real work is spawning, and it is all Windows.
 //
-// Verified against Claude Code CLI 2.1.177:
+// Verified against Claude Code CLI 2.1.251:
 //   • `-p/--print` + `--output-format stream-json` emits NDJSON (one JSON object
 //     per line); every line carries `session_id`.
 //   • `--session-id <uuid>` sets the session id for a fresh run, and
@@ -32,6 +32,28 @@ const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
 /** Matches a canonical lowercase UUID (any version). Chorus idea uuids are v4. */
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
+/** Backend-neutral failure classification consumed by the wake orchestrator. */
+export const SESSION_CONFLICT_FAILURE = "session_conflict";
+
+const STDERR_BUFFER_LIMIT = 64 * 1024;
+const SESSION_CONFLICT_RE = /\bsession id\b[^\r\n]{0,200}\bis already in use\b/i;
+const CLAUDE_PROJECT_KEY_CAP = 200;
+
+/**
+ * Claude Code 2.1.251's Java-style signed 32-bit string hash, rendered as the
+ * absolute value in base36. Iterating by index intentionally hashes UTF-16 code
+ * units (including each surrogate in an astral character) rather than code points.
+ * @param {string} value
+ * @returns {string}
+ */
+function projectKeyHash(value) {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = ((hash << 5) - hash + value.charCodeAt(index)) | 0;
+  }
+  return Math.abs(hash).toString(36);
+}
+
 /**
  * True iff `id` is a well-formed, lowercase UUID. The daemon anchors the Claude
  * session id on a Chorus idea uuid (already lowercase v4); we validate before
@@ -45,22 +67,27 @@ export function isValidSessionId(id) {
 }
 
 /**
- * Claude Code's transcript directory for a working directory. Verified against the
- * live install: claude escapes the ABSOLUTE cwd by replacing both `/` and `.` with
- * `-` (e.g. `/home/u/dev/ai-pm` → `-home-u-dev-ai-pm`,
- * `/home/u/.cfg/x` → `-home-u--cfg-x`). On Windows the separators/drive differ, so
- * we escape backslashes and colons too; the rule there is best-effort and must be
- * re-verified against a Windows claude before claiming Windows resume support.
+ * Claude Code's transcript directory for a working directory. Verified against
+ * Claude Code 2.1.251's live Linux install and on-disk transcripts: every
+ * non-ASCII-alphanumeric UTF-16 code unit becomes `-`. That includes separators,
+ * dots, spaces, underscores, and non-ASCII characters; existing hyphens remain
+ * byte-identical because replacing `-` with `-` is a no-op. Escaped keys longer
+ * than 200 characters use the first 200 characters plus `-` and the base36
+ * Java-style signed 32-bit hash of the original cwd. The same expression produces
+ * the established Windows fixture, though the Windows on-disk layout remains
+ * best-effort until verified on a Windows Claude installation.
  * @param {string} cwd  Absolute working directory.
  * @param {NodeJS.Platform} [platform]
  * @returns {string}
  */
 export function escapeCwd(cwd, platform = process.platform) {
-  // Replace path separators and dots with `-`. On POSIX that's `/` and `.`; on
-  // Windows also `\` and the drive-colon. Collapsing both `/` and `.` is what
-  // produces the verified double-dash on a leading-dot segment.
-  const re = platform === "win32" ? /[\\/.:]/g : /[/.]/g;
-  return cwd.replace(re, "-");
+  // `platform` remains in the signature for fixture/API compatibility. Claude's
+  // observed sanitizer is platform-independent; platform path syntax supplies
+  // the differing separator/drive characters that this expression normalizes.
+  void platform;
+  const escaped = cwd.replace(/[^a-zA-Z0-9]/g, "-");
+  if (escaped.length <= CLAUDE_PROJECT_KEY_CAP) return escaped;
+  return `${escaped.slice(0, CLAUDE_PROJECT_KEY_CAP)}-${projectKeyHash(cwd)}`;
 }
 
 /**
@@ -284,7 +311,8 @@ export class ClaudeSpawner {
    *   so the waker can store the handle in its execution registry for the interrupt
    *   path BEFORE this promise resolves. It is invoked once, synchronously, only on a
    *   successful spawn; a spawn failure never calls it.
-   * @returns {Promise<{ sessionId: string, backendSessionId: string|null, exitCode: number|null, isNew: boolean }>}
+   * @returns {Promise<{ sessionId: string, backendSessionId: string|null, exitCode: number|null, isNew: boolean,
+   *                     failureClassification?: "session_conflict" }>}
    *   `backendSessionId` is the Claude `--resume` anchor (the input `sessionId`) on a
    *   terminal resolution after a spawn, so the conversation UI can offer a resumable
    *   id — mirrors codex-spawner's shape. `null` on the pre-spawn failure paths (no
@@ -369,6 +397,8 @@ export class ClaudeSpawner {
       }
 
       let stdoutBuf = "";
+      let stderrBuf = "";
+      let sessionConflictSeen = false;
       let observedSessionId = id;
 
       child.stdout?.setEncoding?.("utf8");
@@ -392,7 +422,10 @@ export class ClaudeSpawner {
 
       child.stderr?.setEncoding?.("utf8");
       child.stderr?.on("data", (chunk) => {
-        const text = String(chunk).trim();
+        const rawText = String(chunk);
+        stderrBuf = (stderrBuf + rawText).slice(-STDERR_BUFFER_LIMIT);
+        if (SESSION_CONFLICT_RE.test(stderrBuf)) sessionConflictSeen = true;
+        const text = rawText.trim();
         if (text) this.logger.warn(`[Chorus] claude stderr: ${text}`);
       });
 
@@ -411,7 +444,11 @@ export class ClaudeSpawner {
         }
         // backendSessionId is the `--resume` anchor (`id`), NOT observedSessionId (see
         // the process-error handler above for why the anchor is the resumable value).
-        resolve({ sessionId: observedSessionId, backendSessionId: id, exitCode: code, isNew });
+        const result = { sessionId: observedSessionId, backendSessionId: id, exitCode: code, isNew };
+        if (code !== null && code !== 0 && sessionConflictSeen) {
+          result.failureClassification = SESSION_CONFLICT_FAILURE;
+        }
+        resolve(result);
       });
 
       // Guard against an ASYNC stdin error (EPIPE): if claude exits/closes

--- a/cli/kiro-spawner.mjs
+++ b/cli/kiro-spawner.mjs
@@ -222,6 +222,7 @@ export function pickNewSessionId(before, after) {
 export class KiroSpawner {
   /** @param {KiroSpawnerOptions} [opts] */
   constructor(opts = {}) {
+    this.sessionDecision = { probeIsAuthoritative: false };
     this.kiroPath = opts.kiroPath ?? null;
     this.spawnImpl = opts.spawnImpl ?? spawn;
     this.logger = opts.logger ?? NOOP_LOGGER;

--- a/cli/waker.mjs
+++ b/cli/waker.mjs
@@ -21,7 +21,7 @@
 
 import { buildBatchPrompt } from "./prompts.mjs";
 import { writeMcpConfig } from "./mcp-config.mjs";
-import { isNewSession } from "./claude-spawner.mjs";
+import { isNewSession, SESSION_CONFLICT_FAILURE } from "./claude-spawner.mjs";
 import { killProcessTree, DEFAULT_SIGINT_TIMEOUT_MS } from "./process-killer.mjs";
 
 const NOOP_LOGGER = { info() {}, warn() {}, error() {} };
@@ -31,7 +31,7 @@ export class Waker {
    * @param {{
    *   creds: { url: string, apiKey: string },
    *   lineage: { resolve: (event: any) => Promise<{ rootIdeaUuid: string|null, directIdeaUuid: string|null }> },
-   *   spawner: { wake: (params: any) => Promise<{ sessionId: string, exitCode: number|null, isNew: boolean }> },
+   *   spawner: { wake: (params: any) => Promise<{ sessionId: string, backendSessionId?: string|null, exitCode: number|null, isNew: boolean, failureClassification?: string }> },
    *   cwd?: string,  The connection/session-bound working directory this Waker serves; resolveCwd() is the single source the probe + spawn + resume use. `undefined` ⇒ the process default cwd (HARD-1 / single-path).
    *   validateRuntimeCwd?: (cwd: string) => Promise<{normalizedPath?: string}>,
    *   hooks?: import("./upload-hooks.mjs").UploadHooks,
@@ -101,6 +101,13 @@ export class Waker {
     // wake's exit path reads + clears it to decide reason=user vs reason=crash.
     /** @type {Set<string>} */
     this.interrupting = new Set();
+    // Session/entity lanes whose deterministic Claude conflict survived the one-shot
+    // resume fallback. Only a synthetic crash resume for the same lane is suppressed;
+    // unrelated wakes continue, and a fresh human instruction clears the lane so one
+    // new bounded recovery cycle is allowed. Daemon-local by design: construction
+    // (including daemon restart) starts with an empty guard.
+    /** @type {Set<string>} */
+    this.deterministicConflictGuards = new Set();
     // Daemon graceful-shutdown flag (fix-daemon-exit-orphan-running-turn). Set once
     // by interruptAll() and never cleared — a shutting-down Waker is on its way out.
     // The wake exit path reads it to report the TURN as interrupted(shutdown), and to
@@ -359,7 +366,28 @@ export class Waker {
    */
   async wakeBatch(notifications, key, attribution) {
     let cfg;
-    const list = Array.isArray(notifications) ? notifications : [];
+    const receivedList = Array.isArray(notifications) ? notifications : [];
+    const hasFreshHumanInstruction = receivedList.some(
+      (n) => n?.action === "human_instruction",
+    );
+    if (hasFreshHumanInstruction && this.deterministicConflictGuards.delete(key)) {
+      this.logger.info(
+        `[Chorus] cleared deterministic session-conflict guard for ${key} on fresh human instruction`,
+      );
+    }
+    const list =
+      !hasFreshHumanInstruction && this.deterministicConflictGuards.has(key)
+        ? receivedList.filter((n) => {
+            const suppress =
+              n?.action === "resource_resumed" && n?.resumedFrom === "crash";
+            if (suppress) {
+              this.logger.warn(
+                `[Chorus] suppressed automatic crash resume for ${key}: deterministic session conflict fallback already exhausted`,
+              );
+            }
+            return !suppress;
+          })
+        : receivedList;
     // Physical batch size — how many wakes were coalesced into this one turn. Drives the
     // session-anchor synthesis (a coalesced batch shows ONE synthesized idea row) and the
     // arrival log label. Independent of the wire count below.
@@ -390,7 +418,7 @@ export class Waker {
     // all leave the executions map when the batch settles so the server reconcile ends the
     // queued rows the batch coalesced away (a coalesced batch shows only ONE running row).
     const drainedExecKeys = [];
-    for (const n of list) {
+    for (const n of receivedList) {
       const e = this.#entityOf(n);
       if (e) drainedExecKeys.push(this.#execKey(e.entityType, e.entityUuid));
     }
@@ -515,7 +543,39 @@ export class Waker {
       // it even before spawner.wake() returns. (Do NOT reference the awaited
       // `result` inside onMessage — it's in the temporal dead zone there.)
       let observedSessionId = sessionId ?? "";
-      const result = await this.spawner.wake({
+      const onChild = (child) => {
+        const entry = execKey ? this.executions.get(execKey) : null;
+        if (entry && entry.status === "running") entry.child = child;
+        if (sessionId && !turnAdvancedToRunning) {
+          turnAdvancedToRunning = true;
+          // Fire-and-forget; #advanceTurn swallows + logs its own failures so a
+          // turn-report error never crashes the spawn callback (no-silent-errors).
+          // The coalescedCount rides this → running edge so the server settles the
+          // (count − 1) same-session pending turns coalesced into this one (a single
+          // wake reports 1, which the client omits from the wire).
+          runningTurnUuidPromise = this.#advanceTurn(
+            sessionId,
+            "running",
+            entity,
+            null,
+            null,
+            null,
+            null,
+            coalescedCount,
+          );
+        }
+      };
+      const onMessage = (message) => {
+        if (message && typeof message.session_id === "string") observedSessionId = message.session_id;
+        // Fire-and-forget transcript hook (子1): keeps only user/assistant text and
+        // batch-POSTs to /api/daemon/transcript for the current turn. Warn-not-throw
+        // inside the hook; the trailing .catch is belt-and-braces so a rejected hook
+        // promise can never surface as an unhandled rejection in the wake path.
+        this.hooks
+          ?.onTranscriptMessage?.({ rootIdeaKey: key, sessionId: observedSessionId, message })
+          .catch(() => {});
+      };
+      const wakeParams = {
         prompt,
         sessionId,
         isNew,
@@ -526,39 +586,30 @@ export class Waker {
         // a re-keyed/dropped entry never throws here. ALSO advance the server turn
         // pending→running here (子1) — same hook keying, no parallel registry — since
         // this is the precise moment the subprocess actually started.
-        onChild: (child) => {
-          const entry = execKey ? this.executions.get(execKey) : null;
-          if (entry && entry.status === "running") entry.child = child;
-          if (sessionId) {
-            turnAdvancedToRunning = true;
-            // Fire-and-forget; #advanceTurn swallows + logs its own failures so a
-            // turn-report error never crashes the spawn callback (no-silent-errors).
-            // The coalescedCount rides this → running edge so the server settles the
-            // (count − 1) same-session pending turns coalesced into this one (a single
-            // wake reports 1, which the client omits from the wire).
-            runningTurnUuidPromise = this.#advanceTurn(
-              sessionId,
-              "running",
-              entity,
-              null,
-              null,
-              null,
-              null,
-              coalescedCount,
-            );
-          }
-        },
-        onMessage: (message) => {
-          if (message && typeof message.session_id === "string") observedSessionId = message.session_id;
-          // Fire-and-forget transcript hook (子1): keeps only user/assistant text and
-          // batch-POSTs to /api/daemon/transcript for the current turn. Warn-not-throw
-          // inside the hook; the trailing .catch is belt-and-braces so a rejected hook
-          // promise can never surface as an unhandled rejection in the wake path.
-          this.hooks
-            ?.onTranscriptMessage?.({ rootIdeaKey: key, sessionId: observedSessionId, message })
-            .catch(() => {});
-        },
-      });
+        onChild,
+        onMessage,
+      };
+      let result = await this.spawner.wake(wakeParams);
+
+      // Claude can still reject a new-session launch when its durable session exists
+      // but the transcript probe missed it. Retry that classified conflict exactly once
+      // as a resume. The shared callbacks preserve transcript flow and replace the live
+      // child for interrupt handling; onChild's gate keeps pending→running exactly once.
+      if (
+        isNew &&
+        result?.failureClassification === SESSION_CONFLICT_FAILURE
+      ) {
+        this.logger.warn(
+          `[Chorus] new-session conflict for ${key}; retrying once with resume`,
+        );
+        result = await this.spawner.wake({ ...wakeParams, isNew: false });
+        if (result?.failureClassification === SESSION_CONFLICT_FAILURE) {
+          this.deterministicConflictGuards.add(key);
+          this.logger.warn(
+            `[Chorus] deterministic session conflict fallback exhausted for ${key}; future automatic crash resumes will be suppressed`,
+          );
+        }
+      }
 
       if (result && !probeIsAuthoritative) {
         this.logger.info(

--- a/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/README.md
+++ b/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/README.md
@@ -1,0 +1,3 @@
+# fix-claude-cwd-session-resume
+
+Make Claude daemon sessions resume reliably from non-ASCII and space-containing working directories, with one-shot recovery and deterministic loop protection.

--- a/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/design.md
+++ b/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/design.md
@@ -1,0 +1,72 @@
+## Context
+
+`Waker` resolves one cwd, calls `isNewSession(sessionId, cwd)`, and passes the resulting `isNew` decision to the selected backend spawner. Claude uses `~/.claude/projects/<escaped-cwd>/<session-id>.jsonl` as the probe. The current `escapeCwd()` implementation replaces `/` and `.` on POSIX (plus Windows separators and `:`), but live Claude Code stores CJK and spaces as `-` too. The daemon therefore probes a directory that does not exist and repeatedly chooses `--session-id`.
+
+Codex and Kiro do not rely on this probe for their authoritative decision. Their spawners declare the shared probe non-authoritative and use persisted `anchor → backend session id` maps, so the audit does not currently identify an analogous fix.
+
+The selected elaboration policy is full defense: correct the probe, retry a recognized conflict once with `--resume`, then stop automatic redispatch if that fallback fails.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make second and later Claude wakes resume from cwd values containing CJK characters or spaces.
+- Preserve byte-identical escaping outcomes for existing ASCII path fixtures.
+- Recover once from stale or imperfect transcript discovery without turning every non-zero Claude exit into a retry.
+- Prevent a deterministic conflict from hammering the daemon after the fallback is exhausted.
+- Keep backend-specific session discovery inside backend contracts and verify Codex/Kiro remain unaffected.
+
+**Non-Goals:**
+
+- Replacing Claude's on-disk transcript probe with a new persistent session database.
+- Retrying arbitrary Claude failures or adding a general-purpose retry framework.
+- Changing Codex or Kiro session identity unless the implementation audit finds an actual analogous defect.
+- Claiming Windows compatibility without checking the installed Windows Claude Code layout.
+
+## Decisions
+
+### 1. Derive the escaped directory from Claude's observed rule
+
+Update `escapeCwd()` so every character Claude normalizes in a project-directory key is replaced one-for-one with `-`. Before freezing the expression, compare representative ASCII, dot, hyphen, underscore, space, CJK, and (where available) Windows paths against the installed Claude Code project directories. Unit fixtures then become the compatibility contract.
+
+This retains the stateless transcript probe and its daemon-restart behavior. Persisting a second Claude session map was rejected because it would duplicate Claude's own durable store and introduce migration/staleness concerns.
+
+### 2. Return a structured conflict classification from the Claude spawner
+
+The Claude spawner will retain a bounded stderr buffer for the current subprocess and classify only the established “Session ID … is already in use” signature. Its wake result will carry a backend-neutral optional failure classification while preserving existing `exitCode`, `sessionId`, `backendSessionId`, and `isNew` fields.
+
+Structured classification is preferred over having `Waker` parse logs. The spawner owns backend stderr semantics, while `Waker` owns orchestration policy. Unrelated stderr and non-zero exits remain ordinary crashes.
+
+### 3. Let Waker perform one fallback without duplicating turn lifecycle transitions
+
+When the first Claude attempt was launched as new and returns the session-conflict classification, `Waker` will invoke the same spawner once more with `isNew: false`, the same prompt, cwd, MCP config, message callback, and session anchor.
+
+The retry's child callback updates the execution registry so interrupt remains functional, but it does not repeat the already-completed pending-to-running turn transition. The fallback result becomes the authoritative result for terminal turn/execution reporting. No recursive retry path is allowed.
+
+Keeping the retry in `Waker` preserves backend separation and makes the one-attempt budget explicit. Hiding a second subprocess entirely inside `ClaudeSpawner` was rejected because the shared `onChild` lifecycle contract must track the active retry child.
+
+### 4. Suppress only repeated automatic crash resumes after fallback exhaustion
+
+If the recognized conflict survives the one-time `--resume` fallback, `Waker` records a daemon-local terminal guard for the direct session/entity key. A subsequent synthetic crash resume for the same key is logged and discarded rather than spawned. A fresh human instruction clears the guard and permits one new recovery cycle; daemon restart also resets the in-memory guard, bounding any reconnect behavior to one cycle per process instead of a tight loop.
+
+The guard is scoped to the deterministic signature. User interrupts, ordinary crashes, clean exits, and unrelated sessions retain existing behavior. This is preferred over global backoff because the selected policy is “resume once, then stop,” and over permanently blocking the session because a human must retain a recovery path.
+
+### 5. Keep the backend audit testable
+
+Implementation will verify that Codex and Kiro still declare the shared Claude probe non-authoritative and select resume state from their own persisted maps. If that invariant has changed by implementation time, the task expands to a compatible fix and regression test in the affected backend as authorized by elaboration.
+
+## Risks / Trade-offs
+
+- **Claude changes its private project-directory encoding again** → Keep observed fixtures and the stderr fallback; update the compatibility helper when a new live version is verified.
+- **The stderr wording changes** → Match narrowly but case-insensitively around the stable session-id/in-use phrase and retain the corrected primary probe as the normal path.
+- **A retry child is not registered for interrupt** → Reuse the execution-child update callback while gating the turn-running transition to the first successful spawn.
+- **A false-positive terminal guard delays recovery** → Scope it to a classified conflict after a failed resume fallback and clear it on a fresh human instruction.
+- **In-memory suppression resets on daemon restart** → This still prevents the observed tight same-process hammer; each restarted process remains bounded to one recovery cycle.
+
+## Migration Plan
+
+No data migration is required. Deploy the CLI change with tests, restart affected daemons, and verify a CJK/space cwd performs a fresh first wake followed by `--resume`. Rollback is a code rollback; existing Claude transcripts and backend session maps are unchanged.
+
+## Open Questions
+
+- What exact escaping expression does the installed Claude Code version use for underscore and astral Unicode on each supported platform? Resolve empirically during implementation and encode the findings as fixtures.

--- a/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/proposal.md
+++ b/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Claude-backed daemon sessions currently infer new-versus-resume state by probing a cwd-derived transcript directory. The probe escapes only path separators and dots, while Claude Code also escapes spaces and non-ASCII characters, so a first wake succeeds but later wakes reuse `--session-id`, fail with “Session ID already in use,” and can enter a deterministic crash redispatch loop.
+
+## What Changes
+
+- Align the daemon's Claude transcript-directory escaping with the installed Claude Code behavior, including CJK and space-containing working directories while preserving existing ASCII results.
+- Classify Claude's “Session ID already in use” response and retry the same wake exactly once with `--resume`.
+- Stop automatic crash redispatch for that session if the one-time resume fallback also fails; a fresh human instruction can start a new recovery attempt.
+- Add focused unit and orchestration coverage for CJK, spaces, unchanged ASCII paths, successful fallback, failed fallback, and loop suppression.
+- Audit Codex and Kiro session discovery. Both already use backend-owned persisted session maps rather than Claude's cwd-to-transcript probe, so no analogous escaping change is required unless implementation-time verification finds a regression.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `daemon-spawner-interface`: Require Claude transcript discovery to match backend cwd escaping and expose a structured deterministic session-conflict outcome for bounded recovery.
+- `daemon-interrupt-resume`: Require one-shot resume recovery and suppression of repeated automatic crash redispatch after a deterministic session conflict.
+
+## Impact
+
+- Affected modules: `cli/claude-spawner.mjs`, `cli/waker.mjs`, and their unit/integration tests; the control/router boundary may receive a narrow loop-suppression hook.
+- No database, public HTTP API, dependency, Codex session-map, or Kiro session-map migration is expected.
+- The implementation must verify the escaping rule against the installed Claude Code version before finalizing fixtures, particularly cross-platform behavior.

--- a/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/specs/daemon-interrupt-resume/spec.md
+++ b/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/specs/daemon-interrupt-resume/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Deterministic Claude session conflicts receive one bounded resume fallback
+
+When a Claude wake launched with `--session-id` returns the deterministic session-conflict classification, the daemon MUST retry that wake exactly once with `--resume` using the same session anchor, cwd, prompt, MCP configuration, and transcript callback. The retry MUST track its live child for interrupt handling without repeating the turn's pending-to-running lifecycle transition. No fallback is permitted for an unclassified failure or for a conflict returned by the fallback itself.
+
+#### Scenario: Resume fallback succeeds
+
+- **WHEN** a new-session Claude launch reports that its session ID is already in use and the one-time `--resume` retry exits cleanly
+- **THEN** the daemon MUST complete the wake from the retry result without reporting a crash
+
+#### Scenario: Resume fallback also fails
+
+- **WHEN** a new-session Claude launch reports that its session ID is already in use and the one-time `--resume` retry also fails
+- **THEN** the daemon MUST record the final interrupted outcome and MUST NOT spawn a third attempt in that recovery cycle
+
+#### Scenario: Ordinary crash receives no fallback
+
+- **WHEN** Claude exits non-zero without the deterministic session-conflict classification
+- **THEN** the daemon MUST preserve the existing crash-reporting behavior and MUST NOT issue the one-time resume fallback
+
+### Requirement: Exhausted deterministic conflicts do not enter automatic redispatch loops
+
+After the one-time resume fallback for a session conflict is exhausted, the daemon MUST suppress subsequent synthetic automatic crash resumes for the same direct session/entity key in that daemon process. It MUST emit a visible diagnostic when suppressing a wake. A fresh human instruction for that key MUST clear the guard and permit a new bounded recovery cycle. The guard MUST NOT affect other sessions, user-interrupt resumes, or unrelated crash types.
+
+#### Scenario: Automatic crash resume is suppressed after exhaustion
+
+- **WHEN** the resume fallback has failed for a deterministic session conflict and an automatic crash resume is redispatched for the same key
+- **THEN** the daemon MUST log the suppression and MUST NOT spawn another Claude process
+
+#### Scenario: Fresh human instruction permits recovery
+
+- **WHEN** a session key is guarded after an exhausted deterministic conflict and a fresh human instruction arrives for that key
+- **THEN** the daemon MUST clear the guard and permit one new bounded recovery cycle
+
+#### Scenario: Other sessions remain unaffected
+
+- **WHEN** one session key is guarded after an exhausted deterministic conflict
+- **THEN** wakes and resume behavior for every other session key MUST continue unchanged

--- a/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/specs/daemon-spawner-interface/spec.md
+++ b/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/specs/daemon-spawner-interface/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Claude transcript discovery matches backend cwd encoding
+
+The Claude daemon backend MUST derive its project transcript directory using the cwd encoding observed from the supported Claude Code installation. The encoding MUST correctly locate transcripts for working directories containing spaces and non-ASCII characters and MUST preserve the established output for existing ASCII path, separator, dot, and platform fixtures. The transcript probe and spawned Claude process MUST use the same resolved cwd.
+
+#### Scenario: CJK cwd resumes an existing transcript
+
+- **WHEN** a Claude session transcript exists under Claude Code's encoded project directory for a cwd containing CJK characters
+- **THEN** the daemon MUST find that transcript and launch the next wake with `--resume` rather than `--session-id`
+
+#### Scenario: Space-containing cwd resumes an existing transcript
+
+- **WHEN** a Claude session transcript exists under Claude Code's encoded project directory for a cwd containing spaces
+- **THEN** the daemon MUST find that transcript and launch the next wake with `--resume` rather than `--session-id`
+
+#### Scenario: Existing ASCII encoding remains compatible
+
+- **WHEN** the daemon encodes an existing ASCII path fixture containing separators, dots, and hyphens
+- **THEN** the resulting project directory key MUST remain byte-identical to the verified Claude Code result
+
+### Requirement: Claude session conflicts are reported structurally
+
+The Claude spawner MUST classify a non-zero subprocess result whose stderr states that the supplied session ID is already in use as a deterministic session conflict. The classification MUST be returned through the spawner result without parsing daemon log output and MUST NOT classify unrelated stderr or non-zero exits as session conflicts.
+
+#### Scenario: New-session launch conflicts with a registered ID
+
+- **WHEN** Claude exits non-zero and stderr reports that the supplied session ID is already in use
+- **THEN** the spawner result MUST identify a deterministic session conflict while preserving the exit code and session identity fields
+
+#### Scenario: Unrelated Claude failure is not classified
+
+- **WHEN** Claude exits non-zero for an error that does not match the session-ID-in-use signature
+- **THEN** the spawner result MUST NOT identify a deterministic session conflict
+
+### Requirement: Non-Claude backends retain authoritative session maps
+
+Codex and Kiro MUST continue to decide new-versus-resume state from their backend-owned persisted session mappings rather than Claude's cwd-derived transcript probe. If either backend acquires a cwd-derived store assumption, its encoding MUST be independently verified and covered by backend-specific tests.
+
+#### Scenario: Codex and Kiro ignore the Claude transcript probe
+
+- **WHEN** the shared Waker dispatches a Codex or Kiro wake
+- **THEN** the selected spawner MUST derive resume state from its persisted backend session mapping and MUST NOT treat the Claude transcript probe as authoritative

--- a/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/tasks.md
+++ b/openspec/changes/archive/2026-08-30-fix-claude-cwd-session-resume/tasks.md
@@ -1,0 +1,11 @@
+## 1. Claude Session Discovery and Recovery
+
+- [x] 1.1 Verify Claude Code's project-directory encoding against the installed version, update `escapeCwd()` and its documentation, and add CJK, space, ASCII compatibility, transcript-path, and backend-audit regression tests.
+- [x] 1.2 Add bounded stderr capture and structured session-conflict classification to the Claude spawner without changing unrelated exit behavior.
+- [x] 1.3 Implement Waker's single `--resume` fallback with shared cwd/prompt/config callbacks, retry-child interrupt tracking, and exactly-once turn-running transition semantics.
+
+## 2. Deterministic Loop Protection and Integration
+
+- [x] 2.1 Add a per-session terminal guard that suppresses repeated synthetic crash resumes after fallback exhaustion, clears on fresh human instruction, and emits visible diagnostics.
+- [x] 2.2 Add orchestration/integration tests proving successful fallback, failed-fallback terminal behavior, no third spawn, guard isolation, guard clearing, and unchanged ordinary crash/user-resume behavior.
+- [x] 2.3 Run focused CLI tests plus the broader daemon test suite and document the verified Claude version and Codex/Kiro audit outcome in code comments or test fixtures.

--- a/openspec/specs/daemon-interrupt-resume/spec.md
+++ b/openspec/specs/daemon-interrupt-resume/spec.md
@@ -468,3 +468,41 @@ For fix-forward compatibility with residual per-instance sessions created before
 - **WHEN** the composer derives its controllable execution
 - **THEN** it MUST match only its own `daemon_session:<sessionId>` execution as before, with no idea-prefix derivation
 
+### Requirement: Deterministic Claude session conflicts receive one bounded resume fallback
+
+When a Claude wake launched with `--session-id` returns the deterministic session-conflict classification, the daemon MUST retry that wake exactly once with `--resume` using the same session anchor, cwd, prompt, MCP configuration, and transcript callback. The retry MUST track its live child for interrupt handling without repeating the turn's pending-to-running lifecycle transition. No fallback is permitted for an unclassified failure or for a conflict returned by the fallback itself.
+
+#### Scenario: Resume fallback succeeds
+
+- **WHEN** a new-session Claude launch reports that its session ID is already in use and the one-time `--resume` retry exits cleanly
+- **THEN** the daemon MUST complete the wake from the retry result without reporting a crash
+
+#### Scenario: Resume fallback also fails
+
+- **WHEN** a new-session Claude launch reports that its session ID is already in use and the one-time `--resume` retry also fails
+- **THEN** the daemon MUST record the final interrupted outcome and MUST NOT spawn a third attempt in that recovery cycle
+
+#### Scenario: Ordinary crash receives no fallback
+
+- **WHEN** Claude exits non-zero without the deterministic session-conflict classification
+- **THEN** the daemon MUST preserve the existing crash-reporting behavior and MUST NOT issue the one-time resume fallback
+
+### Requirement: Exhausted deterministic conflicts do not enter automatic redispatch loops
+
+After the one-time resume fallback for a session conflict is exhausted, the daemon MUST suppress subsequent synthetic automatic crash resumes for the same direct session/entity key in that daemon process. It MUST emit a visible diagnostic when suppressing a wake. A fresh human instruction for that key MUST clear the guard and permit a new bounded recovery cycle. The guard MUST NOT affect other sessions, user-interrupt resumes, or unrelated crash types.
+
+#### Scenario: Automatic crash resume is suppressed after exhaustion
+
+- **WHEN** the resume fallback has failed for a deterministic session conflict and an automatic crash resume is redispatched for the same key
+- **THEN** the daemon MUST log the suppression and MUST NOT spawn another Claude process
+
+#### Scenario: Fresh human instruction permits recovery
+
+- **WHEN** a session key is guarded after an exhausted deterministic conflict and a fresh human instruction arrives for that key
+- **THEN** the daemon MUST clear the guard and permit one new bounded recovery cycle
+
+#### Scenario: Other sessions remain unaffected
+
+- **WHEN** one session key is guarded after an exhausted deterministic conflict
+- **THEN** wakes and resume behavior for every other session key MUST continue unchanged
+

--- a/openspec/specs/daemon-spawner-interface/spec.md
+++ b/openspec/specs/daemon-spawner-interface/spec.md
@@ -22,3 +22,64 @@ The daemon SHALL define a backend-agnostic spawner contract `wake({ prompt, sess
 - **WHEN** a spawner cannot locate its backend executable or the spawn fails
 - **THEN** the wake resolves with `exitCode: null` and a visible error log, and the daemon continues serving subsequent notifications
 
+### Requirement: Claude transcript discovery matches backend cwd encoding
+
+The Claude daemon backend MUST derive its project transcript directory using the cwd encoding observed from the supported Claude Code installation. For Claude Code 2.1.251, the encoding MUST replace every non-ASCII-alphanumeric UTF-16 code unit with `-`. If the escaped key exceeds 200 characters, the encoding MUST return its first 200 characters followed by `-` and the base36 absolute value of the Java-style signed 32-bit rolling hash of the original cwd (`hash = hash * 31 + charCode`). The encoding MUST correctly locate transcripts for working directories containing spaces and non-ASCII characters and MUST preserve the established output for existing ASCII path, separator, dot, and platform fixtures. The transcript probe and spawned Claude process MUST use the same resolved cwd.
+
+#### Scenario: CJK cwd resumes an existing transcript
+
+- **WHEN** a Claude session transcript exists under Claude Code's encoded project directory for a cwd containing CJK characters
+- **THEN** the daemon MUST find that transcript and launch the next wake with `--resume` rather than `--session-id`
+
+#### Scenario: Space-containing cwd resumes an existing transcript
+
+- **WHEN** a Claude session transcript exists under Claude Code's encoded project directory for a cwd containing spaces
+- **THEN** the daemon MUST find that transcript and launch the next wake with `--resume` rather than `--session-id`
+
+#### Scenario: Existing ASCII encoding remains compatible
+
+- **WHEN** the daemon encodes an existing ASCII path fixture containing separators, dots, and hyphens
+- **THEN** the resulting project directory key MUST remain byte-identical to the verified Claude Code result
+
+#### Scenario: Long cwd uses Claude's bounded project key
+
+- **WHEN** the escaped cwd key exceeds 200 characters
+- **THEN** the daemon MUST use the first 200 escaped characters plus the base36 hash suffix computed from the original cwd
+
+#### Scenario: Project key at the boundary is not hashed
+
+- **WHEN** the escaped cwd key is exactly 200 characters
+- **THEN** the daemon MUST preserve the complete escaped key without a hash suffix
+
+### Requirement: Claude session conflicts are reported structurally
+
+The Claude spawner MUST classify a non-zero subprocess result whose stderr states that the supplied session ID is already in use as a deterministic session conflict. The classification MUST be returned through the spawner result without parsing daemon log output and MUST NOT classify unrelated stderr or non-zero exits as session conflicts.
+
+#### Scenario: New-session launch conflicts with a registered ID
+
+- **WHEN** Claude exits non-zero and stderr reports that the supplied session ID is already in use
+- **THEN** the spawner result MUST identify a deterministic session conflict while preserving the exit code and session identity fields
+
+#### Scenario: Unrelated Claude failure is not classified
+
+- **WHEN** Claude exits non-zero for an error that does not match the session-ID-in-use signature
+- **THEN** the spawner result MUST NOT identify a deterministic session conflict
+
+### Requirement: Non-Claude backends retain authoritative session identity
+
+Codex and Kiro MUST continue to decide new-versus-resume state from their backend-owned persisted session mappings rather than Claude's cwd-derived transcript probe. DSH MUST create an isolated runtime session for every wake while passing the resolved cwd verbatim, and OpenClaw MUST derive its stable session key from the Chorus business key and reuse the matching session entry. Working directories containing spaces or non-ASCII characters MUST NOT participate in any of these backend session identities.
+
+#### Scenario: Codex and Kiro ignore the Claude transcript probe
+
+- **WHEN** the shared Waker dispatches a Codex or Kiro wake for a known anchor under a cwd containing spaces or non-ASCII characters, even when the Claude transcript probe reports a new session
+- **THEN** the selected spawner MUST derive resume state from its persisted backend session mapping and MUST NOT treat the Claude transcript probe as authoritative
+
+#### Scenario: DSH isolates runtime sessions from cwd
+
+- **WHEN** the shared Waker dispatches a DSH wake under a cwd containing spaces or non-ASCII characters
+- **THEN** DSH MUST pass that cwd verbatim and MUST use a fresh isolated runtime session identifier rather than deriving session identity from the cwd or Chorus anchor
+
+#### Scenario: OpenClaw reuses the business-key session
+
+- **WHEN** OpenClaw dispatches a wake under a cwd containing spaces or non-ASCII characters for a Chorus business key with an existing session entry
+- **THEN** OpenClaw MUST derive the same stable session key from the business key and MUST reuse the existing session entry independently of the cwd

--- a/packages/openclaw-plugin/src/__tests__/daemon-client.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/daemon-client.test.ts
@@ -397,6 +397,40 @@ describe("session-key continuity", () => {
     expect(runEmbeddedAgent.mock.calls[0][0].sessionKey).toBe(expectedKey);
   });
 
+  it.each([
+    "/workspaces/项目 alpha",
+    "/workspaces/space only",
+  ])("reuses the business-key session entry independently of cwd %s", async (cwd) => {
+    const rest = makeRestClient();
+    const getSessionEntry = vi.fn(() => ({
+      sessionId: "sid-existing",
+      sessionFile: "f.jsonl",
+    }));
+    const runEmbeddedAgent = vi.fn(async () => ({ meta: {} }));
+    const ctx = makeRunContext({ runEmbeddedAgent, getSessionEntry });
+    ctx.workspaceDir = cwd;
+    const { client } = build({ rest, runContext: ctx });
+
+    await client.runWake({
+      prompt: "p",
+      contextKey: "ctx",
+      entityType: "idea",
+      entityUuid: "idea-9",
+      directIdeaUuid: "idea-9",
+    });
+
+    const expectedKey = deriveSessionKey("idea-9", "agent:main:main");
+    expect(getSessionEntry).toHaveBeenCalledWith({
+      sessionKey: expectedKey,
+      agentId: "main",
+    });
+    expect(runEmbeddedAgent.mock.calls[0][0]).toMatchObject({
+      sessionId: "sid-existing",
+      sessionKey: expectedKey,
+      workspaceDir: cwd,
+    });
+  });
+
   it("opens a NEW session with a SAFE session id (the business key) when getSessionEntry returns none", async () => {
     // Regression for a defect surfaced by a live OpenClaw gateway run (T5): when no
     // OpenClaw session exists yet for the derived key, the fallback session id MUST be


### PR DESCRIPTION
## Summary
- match Claude Code 2.1.251 project-key escaping for CJK, spaces, punctuation, astral Unicode, and long cwd values
- retry a classified session conflict exactly once with `--resume`, then suppress deterministic synthetic crash redispatch until fresh human input
- lock Codex, Kiro, DSH, and OpenClaw session identity to their backend-owned, cwd-independent models

## Verification
- [x] CLI backend and orchestration suites: 187/187
- [x] OpenClaw tests: 151/151 (3 configured skips)
- [x] focused daemon integration
- [x] OpenClaw typecheck and scoped ESLint
- [x] OpenSpec strict validation: 120/120
- [x] independent aggregate review: PASS, 0 blockers

## Notes
- The broad daemon integration suite retains two pre-existing live-daemon/configuration entry failures unrelated to this diff.
- No merge is requested; this PR targets `develop` for human review.

Chorus idea: `59d00576-1e16-4ac0-8818-f70a4d9febd0`