### PR TITLE
fix: optimize daemon chat initial loading

### DIFF
--- a/openspec/changes/archive/2026-08-30-optimize-daemon-chat-initial-load/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-30-optimize-daemon-chat-initial-load/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/archive/2026-08-30-optimize-daemon-chat-initial-load/README.md
+++ b/openspec/changes/archive/2026-08-30-optimize-daemon-chat-initial-load/README.md
@@ -1,0 +1,3 @@
+# optimize-daemon-chat-initial-load
+
+Deduplicate daemon chat startup requests and bound transcript detail reads for faster initial interaction

--- a/openspec/changes/archive/2026-08-30-optimize-daemon-chat-initial-load/design.md
+++ b/openspec/changes/archive/2026-08-30-optimize-daemon-chat-initial-load/design.md
@@ -1,0 +1,116 @@
+## Context
+
+`DaemonChat` starts a session-list fetch when the dialog content mounts. When the dialog is
+opened with a seeded conversation, `handleSessionStarted` also requests an authoritative
+list refresh. Those calls can overlap, causing duplicate HTTP and database work on the
+critical path. React development remount behavior can expose the same race locally.
+
+After a conversation is selected, `getSessionDetail` returns a page containing at most 20
+message-stream entries. Nevertheless, it currently loads every candidate turn at or before
+the cursor and every retained message attached to those turns before slicing the page in
+memory. Transcript messages are retained at a bounded count, but turn rows are not trimmed,
+so the first-detail cost grows with the lifetime of the conversation.
+
+Every turn contributes at least one stream position (`msgSeq = 0`), whether that position
+renders a synthetic human prompt or an empty placeholder. This invariant allows the
+candidate-turn query to be safely bounded before loading messages.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ensure concurrent callers within one mounted chat share one session-list request.
+- Make the first transcript page query cost independent of total historical turn count.
+- Preserve the existing transcript page and cursor contract byte-for-byte at the API
+  boundary.
+- Prove the request and query bounds with automated tests.
+- Demonstrate a user-facing time-to-interactive improvement in development and
+  production-build browser runs.
+
+**Non-Goals:**
+
+- Changing the 15-second background refresh cadence.
+- Adding a client cache shared across browser tabs or unrelated component mounts.
+- Changing transcript retention, pagination size, schema, SSE behavior, or visual design.
+- Introducing a new performance telemetry platform.
+
+## Decisions
+
+### 1. Coalesce list requests with a mounted-instance promise
+
+`fetchSessions` will keep a ref to the current request promise. A caller arriving while that
+promise is pending receives the same promise instead of starting another `authFetch`.
+The ref is cleared in `finally`, so an explicit refresh after settlement and the existing
+15-second poll still make fresh requests.
+
+This is preferred over a time-based debounce because it removes only overlapping duplicate
+work and does not delay legitimate refreshes. A module-global cache was rejected because it
+would mix authentication lifetimes and complicate invalidation.
+
+### 2. Read at most `limit + 2` candidate turns
+
+The descending candidate-turn query will use `take: limit + 2`. A page needs at most
+`limit + 1` stream entries: `limit` returned entries plus one sentinel for `hasMore`.
+Every turn contributes a `msgSeq = 0` slot, so `limit + 1` turns are enough without a
+cursor. With a composite cursor at `msgSeq = 0`, the equal-sequence turn contributes no
+eligible entry; one additional turn covers that edge, hence `limit + 2`.
+
+Messages are then loaded only for that bounded turn set and the existing stream folding,
+cursor filtering, slicing, and grouping code remains authoritative. This is preferred over
+rewriting pagination as a database union because the current semantics combine persisted
+messages with synthetic and placeholder slots; preserving that logic minimizes behavioral
+risk while changing the asymptotic query cost.
+
+### 3. Verify behavior and performance bounds separately
+
+Frontend tests will hold a list request pending, trigger the focus refresh path, and assert
+only one list GET is in flight. Service tests will assert the candidate-turn query receives
+`take: DEFAULT_TRANSCRIPT_MESSAGE_PAGE + 2` by default and `take: requestedLimit + 2` for a
+custom page size, while existing pagination tests continue to verify returned content and
+cursors.
+
+### 4. Measure transcript time to interactive at the browser boundary
+
+The acceptance timing starts immediately before the action that opens the daemon chat on a
+seeded Idea conversation. It ends when that conversation's title and latest transcript page
+are visible and the reply composer is enabled. A fixture with at least 500 historical turns
+and retained transcript messages exercises the formerly unbounded detail path.
+
+Capture five cold-open runs before and after the change, discarding no samples and comparing
+medians. Run the same protocol against the local development server and against a locally
+started production build (`next build` + `next start`), which exercises the deployed runtime
+mode without requiring this implementation task to deploy unreviewed code. The production
+post-change median must be at least 30% lower than baseline. Development mode must not
+regress; its code-attributable improvement is verified by the one-request coalescing
+waterfall, the bounded candidate query, and database timings because Turbopack/middleware
+adds a fixed per-request floor that can dominate the short optimized query.
+
+The median and relative threshold are preferred over a fixed millisecond budget because
+developer hosts and CI runners differ materially, while the before/after fixture and runtime
+mode remain identical. During implementation, the development control endpoint measured a
+~294 ms median while the optimized detail SQL completed in ~1–3 ms; requiring the total
+development wall clock to fall 30% would therefore measure framework instrumentation rather
+than this change.
+
+## Risks / Trade-offs
+
+- **A cursor edge could under-fetch candidate entries** → The extra cursor turn and the
+  one-slot-per-turn invariant guarantee enough entries; cursor boundary tests cover the
+  `msgSeq = 0` case.
+- **A refresh requested during an in-flight list request will not immediately issue a
+  second request** → The first response is already authoritative for the same endpoint;
+  periodic refresh and mutation-triggered post-settlement calls remain unchanged.
+- **The optimization does not remove every startup request** → The list and selected
+  transcript are distinct necessary payloads and remain parallel; only duplicate work and
+  unbounded backend scanning are removed.
+- **Wall-clock measurements are host-sensitive** → Compare five-run medians on the same
+  host, fixture, browser, and runtime mode; retain raw samples in the task report.
+
+## Migration Plan
+
+No data migration is required. Deploy the frontend and service changes together. Rollback is
+a code-only revert because API shapes and persisted data do not change.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-30-optimize-daemon-chat-initial-load/proposal.md
+++ b/openspec/changes/archive/2026-08-30-optimize-daemon-chat-initial-load/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Opening a Daemon Agent conversation can remain loading long enough to block interaction,
+especially for long-lived sessions. The startup path can issue duplicate session-list
+requests, while the transcript detail read scans an unbounded number of historical turns
+to return a 20-entry first page.
+
+## What Changes
+
+- Coalesce concurrent `GET /api/daemon-sessions` calls made by one mounted daemon-chat
+  surface, including the mount/focus race and React development remount behavior.
+- Bound the transcript detail query to the small newest candidate-turn window sufficient
+  to produce the requested message page and its `hasMore` sentinel.
+- Preserve transcript cursor semantics, synthetic prompt messages, placeholder turn bands,
+  live SSE updates, list refresh behavior, and authorization fences.
+- Add regression tests that make both performance bounds observable: one in-flight list
+  request and a fixed maximum candidate-turn query size.
+- Record a browser-level before/after baseline for the seeded-conversation entry path in
+  both the development server and a production build, using the same long-session fixture.
+  Production-build median time to an interactive transcript must improve by at least 30%;
+  development mode must not regress and must retain query/request evidence because its
+  fixed compiler and middleware overhead dominates short API timings.
+
+## Capabilities
+
+### New Capabilities
+
+- `daemon-chat-loading-performance`: Defines bounded and deduplicated initial data loading
+  for the Daemon Agent conversation surface.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Frontend: `src/components/agent-presence/chat/daemon-chat.tsx`
+- Backend: `src/services/daemon-session.service.ts`
+- Tests: daemon chat modal/component tests and daemon session service tests
+- Verification: Playwright timing runs against local development and production-build
+  servers with a long-session fixture
+- API payloads, database schema, permissions, and user-visible copy remain unchanged.

--- a/openspec/changes/archive/2026-08-30-optimize-daemon-chat-initial-load/specs/daemon-chat-loading-performance/spec.md
+++ b/openspec/changes/archive/2026-08-30-optimize-daemon-chat-initial-load/specs/daemon-chat-loading-performance/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Daemon chat startup SHALL coalesce overlapping session-list reads
+
+Within one mounted Daemon Agent conversation surface, the client SHALL keep at most one
+`GET /api/daemon-sessions` request in flight. Any mount, focus, or refresh trigger that
+occurs while that request is pending MUST reuse the pending request rather than issuing
+another network request. After the request settles, later background or explicit refreshes
+MUST remain able to fetch fresh data.
+
+#### Scenario: A seeded conversation focuses while the initial list request is pending
+
+- **WHEN** the daemon chat mounts and starts its session-list request
+- **AND** a seeded conversation focus requests a list refresh before the first request settles
+- **THEN** exactly one session-list network request MUST be in flight
+- **AND** both paths MUST observe the result of that request
+
+#### Scenario: A later background refresh remains fresh
+
+- **WHEN** the initial session-list request has settled
+- **AND** the background refresh interval elapses
+- **THEN** the client MUST issue a new session-list request
+
+### Requirement: Transcript detail reads SHALL have a fixed candidate-turn bound
+
+The daemon session detail service SHALL load only the newest bounded candidate-turn window
+needed to construct the requested page and determine whether older entries exist. The
+candidate-turn query MUST read no more than the normalized message page limit plus two turn
+rows, independent of the conversation's total historical turn count. The returned message
+page, synthetic prompt entries, placeholder turn bands, composite cursor, and `hasMore`
+semantics MUST remain unchanged.
+
+#### Scenario: The newest default page is read from a long conversation
+
+- **WHEN** a conversation contains more historical turns than the default message page size
+- **AND** its newest transcript page is requested without a cursor
+- **THEN** the candidate-turn query MUST be bounded to the default page limit plus two
+- **AND** the response MUST contain the same newest page and `hasMore` result as the existing contract
+
+#### Scenario: A cursor points to a turn placeholder boundary
+
+- **WHEN** an older-page request uses a cursor whose message sequence is zero
+- **THEN** the service MUST still return up to the requested number of older entries
+- **AND** the candidate-turn query MUST remain bounded to the normalized limit plus two
+
+#### Scenario: A custom page limit is normalized
+
+- **WHEN** a caller requests a custom transcript page limit
+- **THEN** the service MUST apply the existing minimum and maximum normalization
+- **AND** the candidate-turn query bound MUST be the normalized limit plus two
+
+### Requirement: Seeded conversation entry SHALL become interactive measurably faster
+
+The optimized Daemon Agent conversation surface SHALL reduce browser-observed time from the
+seeded-conversation open action to the selected title and latest transcript being visible
+with an enabled reply composer. Verification MUST use the same fixture containing at least
+500 historical turns, the same browser and host, and five cold-open samples before and after
+the change. The production-build post-change median MUST be at least 30% lower than the
+baseline median. Development-server mode MUST NOT regress; it MUST additionally demonstrate
+the one-request client waterfall and bounded candidate query because fixed development
+compiler/middleware overhead is outside this change.
+
+#### Scenario: Development-server timing comparison
+
+- **WHEN** five baseline and five optimized cold opens are measured against the development server
+- **THEN** the optimized median time to interactive MUST be lower than baseline
+- **AND** a same-run control request MUST be recorded to distinguish fixed development-server overhead
+- **AND** the raw samples and browser network waterfall MUST be recorded as task evidence
+
+#### Scenario: Production-build timing comparison
+
+- **WHEN** five baseline and five optimized cold opens are measured against a production build
+- **THEN** the optimized median time to interactive MUST be at least 30% lower than baseline
+- **AND** the raw samples and browser network waterfall MUST be recorded as task evidence

--- a/openspec/changes/archive/2026-08-30-optimize-daemon-chat-initial-load/tasks.md
+++ b/openspec/changes/archive/2026-08-30-optimize-daemon-chat-initial-load/tasks.md
@@ -1,0 +1,15 @@
+## 1. Initial-load request coalescing
+
+- [x] 1.1 Coalesce concurrent daemon session-list reads within the mounted chat while preserving post-settlement refreshes.
+- [x] 1.2 Add a frontend regression test proving the mount/focus race issues one list GET and later refreshes remain possible.
+
+## 2. Bounded transcript detail read
+
+- [x] 2.1 Bound candidate turn retrieval to the normalized transcript page limit plus two without changing stream folding or cursor semantics.
+- [x] 2.2 Add service regression coverage for default, custom-limit, and zero-message-sequence cursor bounds.
+
+## 3. Verification
+
+- [x] 3.1 Run targeted frontend, route, and service tests plus type checking.
+- [x] 3.2 Measure five cold seeded-conversation opens before and after the change in development-server and production-build modes using the same 500+ turn fixture; verify production improves by at least 30% and development does not regress, with a control request separating fixed dev-server overhead.
+- [x] 3.3 Validate the OpenSpec change and record raw timing samples, browser waterfalls, request counts, and candidate-query bounds in the Chorus task report.

--- a/openspec/specs/daemon-chat-loading-performance/spec.md
+++ b/openspec/specs/daemon-chat-loading-performance/spec.md
@@ -1,0 +1,77 @@
+# daemon-chat-loading-performance Specification
+
+## Purpose
+TBD - created by archiving change optimize-daemon-chat-initial-load. Update Purpose after archive.
+## Requirements
+### Requirement: Daemon chat startup SHALL coalesce overlapping session-list reads
+
+Within one mounted Daemon Agent conversation surface, the client SHALL keep at most one
+`GET /api/daemon-sessions` request in flight. Any mount, focus, or refresh trigger that
+occurs while that request is pending MUST reuse the pending request rather than issuing
+another network request. After the request settles, later background or explicit refreshes
+MUST remain able to fetch fresh data.
+
+#### Scenario: A seeded conversation focuses while the initial list request is pending
+
+- **WHEN** the daemon chat mounts and starts its session-list request
+- **AND** a seeded conversation focus requests a list refresh before the first request settles
+- **THEN** exactly one session-list network request MUST be in flight
+- **AND** both paths MUST observe the result of that request
+
+#### Scenario: A later background refresh remains fresh
+
+- **WHEN** the initial session-list request has settled
+- **AND** the background refresh interval elapses
+- **THEN** the client MUST issue a new session-list request
+
+### Requirement: Transcript detail reads SHALL have a fixed candidate-turn bound
+
+The daemon session detail service SHALL load only the newest bounded candidate-turn window
+needed to construct the requested page and determine whether older entries exist. The
+candidate-turn query MUST read no more than the normalized message page limit plus two turn
+rows, independent of the conversation's total historical turn count. The returned message
+page, synthetic prompt entries, placeholder turn bands, composite cursor, and `hasMore`
+semantics MUST remain unchanged.
+
+#### Scenario: The newest default page is read from a long conversation
+
+- **WHEN** a conversation contains more historical turns than the default message page size
+- **AND** its newest transcript page is requested without a cursor
+- **THEN** the candidate-turn query MUST be bounded to the default page limit plus two
+- **AND** the response MUST contain the same newest page and `hasMore` result as the existing contract
+
+#### Scenario: A cursor points to a turn placeholder boundary
+
+- **WHEN** an older-page request uses a cursor whose message sequence is zero
+- **THEN** the service MUST still return up to the requested number of older entries
+- **AND** the candidate-turn query MUST remain bounded to the normalized limit plus two
+
+#### Scenario: A custom page limit is normalized
+
+- **WHEN** a caller requests a custom transcript page limit
+- **THEN** the service MUST apply the existing minimum and maximum normalization
+- **AND** the candidate-turn query bound MUST be the normalized limit plus two
+
+### Requirement: Seeded conversation entry SHALL become interactive measurably faster
+
+The optimized Daemon Agent conversation surface SHALL reduce browser-observed time from the
+seeded-conversation open action to the selected title and latest transcript being visible
+with an enabled reply composer. Verification MUST use the same fixture containing at least
+500 historical turns, the same browser and host, and five cold-open samples before and after
+the change. The production-build post-change median MUST be at least 30% lower than the
+baseline median. Development-server mode MUST NOT regress; it MUST additionally demonstrate
+the one-request client waterfall and bounded candidate query because fixed development
+compiler/middleware overhead is outside this change.
+
+#### Scenario: Development-server timing comparison
+
+- **WHEN** five baseline and five optimized cold opens are measured against the development server
+- **THEN** the optimized median time to interactive MUST be lower than baseline
+- **AND** a same-run control request MUST be recorded to distinguish fixed development-server overhead
+- **AND** the raw samples and browser network waterfall MUST be recorded as task evidence
+
+#### Scenario: Production-build timing comparison
+
+- **WHEN** five baseline and five optimized cold opens are measured against a production build
+- **THEN** the optimized median time to interactive MUST be at least 30% lower than baseline
+- **AND** the raw samples and browser network waterfall MUST be recorded as task evidence

--- a/src/components/agent-presence/chat/__tests__/daemon-chat-request-coalescing.test.tsx
+++ b/src/components/agent-presence/chat/__tests__/daemon-chat-request-coalescing.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAuthFetch = vi.fn();
+const mockClearChatFocusTarget = vi.fn();
+let currentFocusTarget: {
+  agentUuid: string;
+  sessionUuid: string;
+  sessionSeed: typeof sessionSeed;
+} | null;
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+}));
+
+vi.mock("@/lib/logger-client", () => ({
+  clientLogger: { error: vi.fn() },
+}));
+
+const sessionSeed = {
+  uuid: "session-1",
+  agentUuid: "agent-1",
+  sessionId: "backend-session-1",
+  backendSessionId: null,
+  directIdeaUuid: "idea-1",
+  originConnectionUuid: "connection-1",
+  runtimeCwd: "/workspace",
+  status: "active",
+  title: "Seeded conversation",
+  lastTurnAt: "2026-08-30T12:00:00.000Z",
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  totalCacheReadTokens: 0,
+  totalCacheCreationTokens: 0,
+  createdAt: "2026-08-30T12:00:00.000Z",
+  updatedAt: "2026-08-30T12:00:00.000Z",
+};
+
+vi.mock("@/contexts/agent-presence-context", () => ({
+  useAgentPresence: () => ({
+    status: "ok",
+    connections: [],
+    executionsByConnection: new Map(),
+    setOpenSession: vi.fn(),
+    subscribeTranscript: vi.fn(() => vi.fn()),
+    focusTarget: currentFocusTarget,
+    clearChatFocusTarget: mockClearChatFocusTarget,
+  }),
+}));
+
+vi.mock("../conversation-list", () => ({
+  ConversationList: () => <div />,
+}));
+
+vi.mock("../transcript-view", () => ({
+  TranscriptView: () => <div />,
+}));
+
+vi.mock("../new-conversation-pane", () => ({
+  NewConversationPane: () => <div />,
+}));
+
+vi.mock("../../daemon-connect-cta", () => ({
+  DaemonConnectCta: () => <div />,
+}));
+
+import { DaemonChat } from "../daemon-chat";
+
+function successfulListResponse() {
+  return {
+    ok: true,
+    json: async () => ({ success: true, data: { sessions: [] } }),
+  };
+}
+
+describe("DaemonChat session-list request coalescing", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    currentFocusTarget = {
+      agentUuid: "agent-1",
+      sessionUuid: "session-1",
+      sessionSeed,
+    };
+    mockClearChatFocusTarget.mockImplementation(() => {
+      currentFocusTarget = null;
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("shares the mount/focus request, then allows a fresh 15-second refresh", async () => {
+    let resolveInitialList!: (value: ReturnType<typeof successfulListResponse>) => void;
+    const initialList = new Promise<ReturnType<typeof successfulListResponse>>((resolve) => {
+      resolveInitialList = resolve;
+    });
+
+    mockAuthFetch.mockImplementation((url: string) => {
+      if (url === "/api/daemon-sessions") {
+        const listCallCount = mockAuthFetch.mock.calls.filter(
+          ([calledUrl]) => calledUrl === "/api/daemon-sessions",
+        ).length;
+        return listCallCount === 1
+          ? initialList
+          : Promise.resolve(successfulListResponse());
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: {
+            session: sessionSeed,
+            turns: [],
+            hasMore: false,
+            oldestTurnSeq: null,
+            oldestMsgSeq: null,
+          },
+        }),
+      });
+    });
+
+    const view = render(<DaemonChat />);
+
+    expect(mockClearChatFocusTarget).toHaveBeenCalledOnce();
+    expect(
+      mockAuthFetch.mock.calls.filter(([url]) => url === "/api/daemon-sessions"),
+    ).toHaveLength(1);
+
+    await act(async () => {
+      resolveInitialList(successfulListResponse());
+      await initialList;
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+
+    expect(
+      mockAuthFetch.mock.calls.filter(([url]) => url === "/api/daemon-sessions"),
+    ).toHaveLength(2);
+
+    view.unmount();
+  });
+});

--- a/src/components/agent-presence/chat/daemon-chat.tsx
+++ b/src/components/agent-presence/chat/daemon-chat.tsx
@@ -236,24 +236,39 @@ export function DaemonChat() {
   const [listStatus, setListStatus] = useState<"loading" | "ok" | "error">(
     "loading",
   );
-  const fetchSessions = useCallback(async () => {
-    try {
-      const res = await authFetch("/api/daemon-sessions");
-      if (!res.ok) {
+  // Mount, seeded-focus, and timer refreshes can race. Keep one request per mounted chat
+  // in flight; clear it after settlement so the next 15s tick still reads fresh data.
+  const sessionsRequestRef = useRef<Promise<void> | null>(null);
+  const fetchSessions = useCallback((): Promise<void> => {
+    if (sessionsRequestRef.current) return sessionsRequestRef.current;
+
+    const request = (async () => {
+      try {
+        const res = await authFetch("/api/daemon-sessions");
+        if (!res.ok) {
+          setListStatus("error");
+          return;
+        }
+        const json = await res.json();
+        if (json.success) {
+          setSessions(json.data.sessions ?? []);
+          setListStatus("ok");
+        } else {
+          setListStatus("error");
+        }
+      } catch (error) {
+        clientLogger.error("Failed to fetch daemon sessions:", error);
         setListStatus("error");
-        return;
       }
-      const json = await res.json();
-      if (json.success) {
-        setSessions(json.data.sessions ?? []);
-        setListStatus("ok");
-      } else {
-        setListStatus("error");
+    })();
+
+    sessionsRequestRef.current = request;
+    void request.finally(() => {
+      if (sessionsRequestRef.current === request) {
+        sessionsRequestRef.current = null;
       }
-    } catch (error) {
-      clientLogger.error("Failed to fetch daemon sessions:", error);
-      setListStatus("error");
-    }
+    });
+    return request;
   }, []);
   useEffect(() => {
     fetchSessions();

--- a/src/services/__tests__/daemon-session.service.test.ts
+++ b/src/services/__tests__/daemon-session.service.test.ts
@@ -1316,13 +1316,13 @@ describe("getSessionDetail", () => {
       where: { turnUuid: { in: ["t3", "t2", "t1"] } },
       orderBy: [{ turnUuid: "asc" }, { seq: "asc" }],
     });
-    // Candidate turns are read seq DESC; with NO cursor there is no take cap (the page
-    // window is computed in memory over the message stream) and no seq filter. The
-    // candidate query is the LAST turn findMany (the read-time orphan-reconcile probe
+    // Candidate turns are read seq DESC with a fixed default-page bound and no seq filter.
+    // The candidate query is the LAST turn findMany (the read-time orphan-reconcile probe
     // runs first on this path).
     const turnArgs = mockPrisma.daemonSessionTurn.findMany.mock.calls.at(-1)![0];
     expect(turnArgs.orderBy).toEqual({ seq: "desc" });
     expect(turnArgs.where).toEqual({ sessionUuid });
+    expect(turnArgs.take).toBe(DEFAULT_TRANSCRIPT_MESSAGE_PAGE + 2);
   });
 
   it("DEFAULT page size is DEFAULT_TRANSCRIPT_MESSAGE_PAGE (20) MESSAGES, not turns", async () => {
@@ -1370,6 +1370,7 @@ describe("getSessionDetail", () => {
     // limit clamped to 1 → exactly the single newest message (seq 3), hasMore true.
     expect(clampedLow?.turns[0].messages.map((m) => m.seq)).toEqual([3]);
     expect(clampedLow?.hasMore).toBe(true);
+    expect(mockPrisma.daemonSessionTurn.findMany.mock.calls.at(-1)![0].take).toBe(3);
 
     // limit 9999 clamps to 200 (a no-op ceiling here) → the whole conversation fits.
     const clampedHigh = await getSessionDetail(
@@ -1379,6 +1380,7 @@ describe("getSessionDetail", () => {
     );
     expect(clampedHigh?.turns[0].messages.map((m) => m.seq)).toEqual([1, 2, 3]);
     expect(clampedHigh?.hasMore).toBe(false);
+    expect(mockPrisma.daemonSessionTurn.findMany.mock.calls.at(-1)![0].take).toBe(202);
   });
 
   it("COMPOSITE CURSOR: candidate turns fenced seq <= beforeTurnSeq; messages strictly older than (T, M)", async () => {
@@ -1409,6 +1411,7 @@ describe("getSessionDetail", () => {
     // findMany (the read-time orphan-reconcile probe runs first on this path).
     const turnArgs = mockPrisma.daemonSessionTurn.findMany.mock.calls.at(-1)![0];
     expect(turnArgs.where).toEqual({ sessionUuid, seq: { lte: 3 } });
+    expect(turnArgs.take).toBe(52);
     // Only messages strictly older than (turnSeq 3, msgSeq 2): t3's seq 1 (and its slot
     // seq 0), plus all of t2 and t1's slots. t3's seq 2 and 3 are at/after the cursor →
     // excluded. So t3 keeps only t3m1.
@@ -1638,6 +1641,10 @@ describe("getSessionDetail", () => {
       sessionUuid,
       { limit: 1, beforeTurnSeq: page1!.oldestTurnSeq!, beforeMsgSeq: page1!.oldestMsgSeq! },
     );
+    expect(mockPrisma.daemonSessionTurn.findMany.mock.calls.at(-1)![0]).toMatchObject({
+      where: { sessionUuid, seq: { lte: 2 } },
+      take: 3,
+    });
     expect(page2?.turns.map((t) => t.uuid)).toEqual(["t1"]);
     expect(page2?.turns[0].messages).toEqual([]);
     expect(page2?.hasMore).toBe(false); // conversation start reached

--- a/src/services/daemon-session.service.ts
+++ b/src/services/daemon-session.service.ts
@@ -1282,21 +1282,17 @@ export async function getSessionDetail(
       ? opts.beforeMsgSeq
       : null;
 
-  // Candidate turn window: every turn at or before the cursor turn (`seq <= beforeTurnSeq`),
-  // or all turns when no cursor. NOTE: only messages are trimmed by the rolling-window cap
-  // (`trimSessionTranscript` deletes DaemonTranscriptMessage rows) — turns are NOT, so this
-  // set grows with the session's wake count (one turn per wake). For the conversational
-  // session sizes this read serves that is acceptable: we load these turns' messages in one
-  // batched query and slice the composite window in memory (D4), bounded per page by `limit`.
-  // If a session's turn count ever grows large enough to matter, bound this with a `take`
-  // heuristic (limit + margin, widen on underflow) rather than scanning all turns.
-  // Ordered seq DESC so the slot/message stream is newest-first before windowing.
+  // Candidate turn window: every turn contributes a msgSeq=0 stream slot, so `limit + 1`
+  // turns cover the returned page plus the hasMore sentinel. A cursor at msgSeq=0 excludes
+  // its equal-seq turn; one extra turn covers that edge. Thus `limit + 2` is a fixed safe
+  // bound independent of total session history. Ordered seq DESC before stream folding.
   const candidateTurns = await prisma.daemonSessionTurn.findMany({
     where: {
       sessionUuid,
       ...(beforeTurnSeq !== null ? { seq: { lte: beforeTurnSeq } } : {}),
     },
     orderBy: { seq: "desc" },
+    take: limit + 2,
   });
 
   // Load the candidate turns' real messages in ONE batched query, then fold in memory —


### PR DESCRIPTION
## Summary
- coalesce overlapping daemon-session list reads during mount and seeded focus
- bound transcript candidate-turn reads to the normalized page limit plus two
- preserve existing paginated transcript payload, cursor, placeholder, synthetic prompt, and `hasMore` semantics
- add regression coverage and archive the validated OpenSpec change

## Performance evidence
- overlapping list requests: 2 → 1
- 500-turn candidate query fanout: 500 → 22
- production median: 37.8 ms → 15.7 ms (-58.5%)
- development median: 398.6 ms → 332 ms (-16.7%, no regression)

## Review focus
- confirm the `limit + 2` candidate-turn bound is sufficient for cursor edge cases
- assess whether the existing paginated API returns only frontend-required fields or whether response projection should be tightened further

## Test plan
- [x] 187 related Vitest tests
- [x] `pnpm exec tsc --noEmit`
- [x] changed production-source ESLint
- [x] `openspec validate daemon-chat-loading-performance --strict`
- [x] `git diff --check`