### PR TITLE
fix: align idea assignment targeting and wake deduplication

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1025,7 +1025,7 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 
 ### chorus_pm_assign_idea
 
-**Description**: Assign an Idea to an agent (must hold `idea:write`) or a user, on a human's behalf. Unlike `chorus_claim_idea` — which is a **self-claim** by the calling agent — this assigns the Idea to a **different** actor. Silently takes over any existing assignee; an `open` Idea moves to `elaborating`, any other status is preserved. Assigning to an agent wakes it best-effort via the existing `idea_claimed` wake (an offline agent still gets the assignment persisted — the wake is a no-op); assigning to a user sets the assignee and delivers an assignment notification with **no** daemon wake. Optionally pin an agent assignment to a specific **AgentInstance** via `instanceUuid` (persists as an `agent_instance` assignment and targets that instance at wake time) — valid only when `assigneeType = "agent"`.
+**Description**: Assign an Idea to an agent (must hold `idea:write`) or a user, on a human's behalf. Unlike `chorus_claim_idea` — which is a **self-claim** by the calling agent — this assigns the Idea to another actor. Silently takes over any existing assignee; an `open` Idea moves to `elaborating`, any other status is preserved. Agent assignments automatically use the caller owner's project-fixed cwd target when configured (overriding `instanceUuid`); otherwise `instanceUuid` can pin a specific **AgentInstance**. A new logical agent assignee emits the existing `idea_claimed` wake, while assigning the same owning agent again may update its pin/cwd but is wake-deduplicated. Assigning to a user sets the assignee and delivers an assignment notification with **no** daemon wake.
 
 **Required Permission**: `idea:admin`
 
@@ -1035,24 +1035,34 @@ Available to PM Agent and Admin Agent. Not available to Developer Agent.
 | ideaUuid | string | Yes | Idea UUID |
 | assigneeType | enum | Yes | Assignee type: `agent` or `user` |
 | assigneeUuid | string | Yes | Target Agent UUID or User UUID (per `assigneeType`) |
-| instanceUuid | string | No | AgentInstance UUID to pin an **agent** assignment to (the durable `(agent, host, cwd)` identity from the presence/daemon tools). **Present** → the Idea is assigned as `agent_instance` and the wake targets that instance. **Omitted** → a plain `agent` assignment whose wake-time instance is resolved online-first. Rejected if supplied with `assigneeType = "user"`. |
+| instanceUuid | string | No | AgentInstance UUID to pin an **agent** assignment to (the durable `(agent, host, cwd)` identity from the presence/daemon tools). A configured project-fixed cwd target takes precedence and supplies the effective instance automatically; otherwise this value is used. Rejected if supplied with `assigneeType = "user"`. |
 
 **Validation rules**:
 - Idea must exist in the caller's company
 - `assigneeType = "agent"`: the target Agent must exist, belong to the same company, and hold the effective `idea:write` permission (preset or custom)
 - `assigneeType = "user"`: the target User must exist and belong to the same company; `instanceUuid` must not be supplied
-- When `instanceUuid` is supplied, it must reference an AgentInstance in the same company, otherwise the call is rejected ("Agent instance not found")
+- When no project-fixed target overrides it, `instanceUuid` must reference an AgentInstance in the same company, otherwise the call is rejected ("Agent instance not found")
 
-**Contrast with `chorus_claim_idea`**: `chorus_claim_idea` (gated `idea:write`) is how an agent claims an Idea **for itself** (open → elaborating). `chorus_pm_assign_idea` (gated `idea:admin`) is the MCP surface over the human "assign idea" action — it assigns to **any** eligible agent or user and emits the same actor-bearing `assigned` Activity that wakes an assigned daemon agent.
+**Contrast with `chorus_claim_idea`**: `chorus_claim_idea` (gated `idea:write`) is how an agent claims an Idea **for itself** (open → elaborating). `chorus_pm_assign_idea` (gated `idea:admin`) is the MCP surface over the human "assign idea" action — it assigns to **any** eligible agent or user and emits the actor-bearing `assigned` Activity only when responsibility changes to a new logical assignee.
 
 **Output**:
 ```json
 {
   "uuid": "Idea UUID",
   "status": "elaborating",
-  "assignee": { "type": "agent", "uuid": "..." }
+  "assignee": { "type": "agent_instance", "uuid": "..." },
+  "wakeRequested": true,
+  "target": {
+    "instanceUuid": "...",
+    "resolvedCwdSource": "project_fixed",
+    "resolvedCwdHost": "host.example",
+    "resolvedRuntimeCwd": "/work/project"
+  }
 }
 ```
+
+`wakeRequested` is `false` when an assignment updates the pin/cwd of the same
+logical agent without emitting a duplicate `assigned` Activity.
 
 ### chorus_pm_create_proposal
 

--- a/openspec/changes/archive/2026-08-31-fix-assign-idea-target-wake/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-31-fix-assign-idea-target-wake/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/archive/2026-08-31-fix-assign-idea-target-wake/README.md
+++ b/openspec/changes/archive/2026-08-31-fix-assign-idea-target-wake/README.md
@@ -1,0 +1,3 @@
+# fix-assign-idea-target-wake
+
+Align chorus_pm_assign_idea target resolution and re-assignment wake behavior with the UI path

--- a/openspec/changes/archive/2026-08-31-fix-assign-idea-target-wake/design.md
+++ b/openspec/changes/archive/2026-08-31-fix-assign-idea-target-wake/design.md
@@ -1,0 +1,54 @@
+## Context
+
+The UI assignment action resolves an agent's project cwd target before calling `assignIdea`. When the owner's project preference is fixed, it persists the matching AgentInstance plus cwd provenance and only then emits the actor-bearing `assigned` activity that drives the wake pipeline.
+
+The MCP handler currently validates the target and calls `assignIdea` directly. Without an explicit `instanceUuid`, it persists a plain agent assignment even when the project has a fixed target. Operational evidence shows that this path can persist successfully without reaching the online worker. A later call that adds a pin must be treated as a fresh delegation, even when the logical agent identity is unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make MCP agent assignments use the same project-fixed target resolution as UI assignments.
+- Persist target provenance before the wake-triggering activity.
+- Guarantee a newly responsible agent emits a wake-triggering `assigned` activity while same-agent target updates are deduplicated.
+- Preserve existing authorization, validation, status, and user-assignment behavior.
+
+**Non-Goals:**
+
+- Changing notification preference semantics.
+- Refactoring task assignment or UI assignment.
+- Adding a new wake transport or bypassing the existing activity/notification pipeline.
+
+## Decisions
+
+### Resolve with the caller owner's user context
+
+`resolveProjectAgentCwdTarget` keys project preferences by user. An MCP agent acts on behalf of its owner, so the handler will pass `auth.ownerUuid` as `actorUserUuid`. This mirrors the UI's authenticated user context without inventing agent-scoped cwd preferences.
+
+Alternative: skip resolution and retain wake-time online-first routing. This is rejected because it preserves the observed mismatch and ignores project-fixed routing.
+
+### Project-fixed preference takes precedence over an explicit instance
+
+The handler will use the resolver's AgentInstance whenever `target.source === "project_fixed"`; otherwise it retains the caller's explicit `instanceUuid`. This is the same precedence rule as `claimIdeaToAgentAction` and keeps a project root stable.
+
+Alternative: always prefer the MCP argument. This is rejected because it would keep MCP and UI semantics divergent.
+
+### Keep the existing activity as the deduplicated wake trigger
+
+After assignment succeeds, the handler will create an `assigned` activity only when the logical assignee is new or changes to a different agent. Its value includes the effective instance and project-fixed cwd provenance. A same-owning-agent re-pin persists through `assignIdea` but skips the activity so it cannot create a duplicate notification or daemon turn.
+
+Alternative: add direct daemon wake plumbing. This is rejected because activity-driven notification and turn creation already provide attribution, preferences, and routing.
+
+## Risks / Trade-offs
+
+- [A same-agent re-pin does not restart an idle worker] → This is the selected deduplication semantic; callers that need another turn must use an explicit instruction/mention path.
+- [Owner preference lookup can be stale or offline] → Reuse the resolver's existing availability and durable-instance behavior; assignment persistence remains authoritative.
+- [Mocks may hide resolver integration errors] → Add both handler-level assertions and the real tool-to-daemon-turn integration scenario.
+
+## Migration Plan
+
+No data migration is required. Deploy the handler and tests together. Rollback restores the previous MCP-only behavior without changing stored schema.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-31-fix-assign-idea-target-wake/proposal.md
+++ b/openspec/changes/archive/2026-08-31-fix-assign-idea-target-wake/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`chorus_pm_assign_idea` claims parity with the UI assignment action but does not resolve the project-fixed cwd target before persisting an agent assignment. This can leave a plain-agent assignment whose initial wake is not delivered.
+
+## What Changes
+
+- Resolve agent assignment targets through `resolveProjectAgentCwdTarget` using the calling agent owner's project preferences, matching the UI action.
+- Persist project-fixed instance and cwd provenance before emitting the `assigned` activity.
+- Emit a delegation wake only when the logical agent assignee is new or changes; same-agent pin/cwd updates remain persisted but wake-deduplicated.
+- Update the MCP tool description to document automatic project-fixed pinning and same-agent wake deduplication.
+- Add unit and integration regressions for automatic pinning and same-agent plain-to-pinned wake suppression.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `idea-lifecycle-assignment`: Align MCP agent assignment target resolution and same-assignee wake deduplication with the UI path.
+
+## Impact
+
+- `src/mcp/tools/pm.ts`
+- `src/services/project-agent-cwd.service.ts` integration from the MCP handler
+- MCP assignment unit tests and assignment-to-daemon-turn integration tests
+- No schema, API input, or dependency changes

--- a/openspec/changes/archive/2026-08-31-fix-assign-idea-target-wake/specs/idea-lifecycle-assignment/spec.md
+++ b/openspec/changes/archive/2026-08-31-fix-assign-idea-target-wake/specs/idea-lifecycle-assignment/spec.md
@@ -1,0 +1,79 @@
+## MODIFIED Requirements
+
+### Requirement: MCP-callable idea assignment (`chorus_pm_assign_idea`)
+
+The system SHALL provide an MCP tool `chorus_pm_assign_idea` that assigns an Idea to a
+specified assignee, reusing the same assignment policy, service primitive, activity path, and
+wake pipeline as the existing UI assignment control. The tool SHALL be gated on the
+`idea:admin` permission. It SHALL accept an Idea reference, an assignee type of `user` or
+`agent`, an assignee reference, and — for an `agent` assignee — an optional AgentInstance
+reference that pins the assignment (`assigneeType = "agent_instance"`). For an agent target,
+the tool MUST resolve the owner user's project cwd target before assignment and MUST use a
+project-fixed AgentInstance and cwd provenance when configured, matching the UI assignment
+precedence over an explicitly supplied instance. Assignment SHALL be permitted regardless of
+the Idea's current lifecycle stage or existing assignee, and SHALL silently take over an
+existing assignment so that exactly one responsible assignee remains. A successful agent
+assignment MUST emit an `assigned` Activity and request a wake when the logical assignee is
+new or changes to a different agent. When the Idea already belongs to that same logical agent
+(either directly or through one of its AgentInstances), the tool MUST persist any effective
+instance pin or cwd update but MUST NOT emit another `assigned` Activity or request a duplicate
+wake. The tool SHALL NOT introduce any new status transition: an `open` Idea becomes
+`elaborating`, and any other status is preserved. A target `agent` (or the agent owning a
+pinned instance) MUST satisfy the existing agent-eligibility rule (`idea:write`); a target
+`user` MUST belong to the same company. An emitted `assigned` Activity SHALL be recorded with
+the calling agent as actor.
+
+#### Scenario: Admin agent assigns an open child idea to another agent
+
+- **WHEN** an agent holding `idea:admin` calls `chorus_pm_assign_idea` for an `open` Idea with
+  `assigneeType = "agent"` and a target agent that holds `idea:write`
+- **THEN** the Idea assignee becomes that agent and its status becomes `elaborating`
+- **AND** an `assigned` Activity is recorded with the calling agent as actor
+- **AND** the assigned agent is woken through the existing idea wake path
+
+#### Scenario: Project-fixed target is pinned before wake
+
+- **WHEN** the calling agent owner's project preference fixes the target agent to a cwd
+- **AND** the caller invokes `chorus_pm_assign_idea` without `instanceUuid`
+- **THEN** the Idea is persisted as an `agent_instance` assignment with the resolved cwd
+  provenance before the `assigned` Activity is emitted
+- **AND** the wake targets that resolved instance
+
+#### Scenario: Reassigning the same agent to a new instance is wake-deduplicated
+
+- **WHEN** an Idea is already assigned to an agent
+- **AND** `chorus_pm_assign_idea` successfully assigns that same agent with a new effective
+  instance pin or cwd target
+- **THEN** the updated assignment is persisted
+- **AND** no new `assigned` Activity is emitted
+- **AND** no duplicate daemon wake is requested
+
+#### Scenario: Assigning an elaborated idea backfills the owner without regressing status
+
+- **WHEN** an `elaborated` Idea with no assignee is assigned via the tool
+- **THEN** the Idea assignee is set
+- **AND** its stored lifecycle status remains `elaborated`
+
+#### Scenario: Non-admin caller is rejected
+
+- **WHEN** an agent that lacks `idea:admin` attempts to call `chorus_pm_assign_idea`
+- **THEN** the tool is not available to that agent and no assignment occurs
+
+#### Scenario: Ineligible target agent is rejected
+
+- **WHEN** a caller assigns an Idea to an agent that does not hold `idea:write`
+- **THEN** the assignment fails without changing the Idea assignee or lifecycle status
+
+#### Scenario: Assign to a user target
+
+- **WHEN** a caller assigns an Idea with `assigneeType = "user"` and a same-company user
+- **THEN** the Idea assignee becomes that user
+- **AND** no daemon wake is delivered
+- **AND** the user receives an assignment notification through the existing path
+
+#### Scenario: Pinned instance that is offline stays notify-only
+
+- **WHEN** a caller assigns an Idea to an `agent_instance` that currently has no online
+  connection
+- **THEN** the assignment is persisted
+- **AND** the wake is notify-only, consistent with the HARD assignment-pin offline policy

--- a/openspec/changes/archive/2026-08-31-fix-assign-idea-target-wake/tasks.md
+++ b/openspec/changes/archive/2026-08-31-fix-assign-idea-target-wake/tasks.md
@@ -1,0 +1,10 @@
+## 1. MCP Assignment Target Resolution
+
+- [x] 1.1 Resolve agent targets with the caller owner's project cwd preference and persist project-fixed instance/cwd provenance.
+- [x] 1.2 Emit effective target metadata for new logical assignees, deduplicate same-agent wake activities, and update the tool description.
+
+## 2. Regression Verification
+
+- [x] 2.1 Add MCP handler unit tests proving a project-fixed target overrides a conflicting explicit instance, plus same-agent activity deduplication.
+- [x] 2.2 Add integration coverage proving automatic first-assignment wake and same-agent re-pin wake suppression.
+- [x] 2.3 Run focused assignment suites, type checking, and OpenSpec validation.

--- a/openspec/specs/idea-lifecycle-assignment/spec.md
+++ b/openspec/specs/idea-lifecycle-assignment/spec.md
@@ -61,13 +61,21 @@ specified assignee, reusing the same assignment policy, service primitive, activ
 wake pipeline as the existing UI assignment control. The tool SHALL be gated on the
 `idea:admin` permission. It SHALL accept an Idea reference, an assignee type of `user` or
 `agent`, an assignee reference, and — for an `agent` assignee — an optional AgentInstance
-reference that pins the assignment (`assigneeType = "agent_instance"`). Assignment SHALL be
-permitted regardless of the Idea's current lifecycle stage or existing assignee, and SHALL
-silently take over an existing assignment so that exactly one responsible assignee remains.
-The tool SHALL NOT introduce any new status transition: an `open` Idea becomes `elaborating`,
-and any other status is preserved. A target `agent` (or the agent owning a pinned instance)
-MUST satisfy the existing agent-eligibility rule (`idea:write`); a target `user` MUST belong to
-the same company. An `assigned` Activity SHALL be recorded with the calling agent as actor.
+reference that pins the assignment (`assigneeType = "agent_instance"`). For an agent target,
+the tool MUST resolve the owner user's project cwd target before assignment and MUST use a
+project-fixed AgentInstance and cwd provenance when configured, matching the UI assignment
+precedence over an explicitly supplied instance. Assignment SHALL be permitted regardless of
+the Idea's current lifecycle stage or existing assignee, and SHALL silently take over an
+existing assignment so that exactly one responsible assignee remains. A successful agent
+assignment MUST emit an `assigned` Activity and request a wake when the logical assignee is
+new or changes to a different agent. When the Idea already belongs to that same logical agent
+(either directly or through one of its AgentInstances), the tool MUST persist any effective
+instance pin or cwd update but MUST NOT emit another `assigned` Activity or request a duplicate
+wake. The tool SHALL NOT introduce any new status transition: an `open` Idea becomes
+`elaborating`, and any other status is preserved. A target `agent` (or the agent owning a
+pinned instance) MUST satisfy the existing agent-eligibility rule (`idea:write`); a target
+`user` MUST belong to the same company. An emitted `assigned` Activity SHALL be recorded with
+the calling agent as actor.
 
 #### Scenario: Admin agent assigns an open child idea to another agent
 
@@ -76,6 +84,23 @@ the same company. An `assigned` Activity SHALL be recorded with the calling agen
 - **THEN** the Idea assignee becomes that agent and its status becomes `elaborating`
 - **AND** an `assigned` Activity is recorded with the calling agent as actor
 - **AND** the assigned agent is woken through the existing idea wake path
+
+#### Scenario: Project-fixed target is pinned before wake
+
+- **WHEN** the calling agent owner's project preference fixes the target agent to a cwd
+- **AND** the caller invokes `chorus_pm_assign_idea` without `instanceUuid`
+- **THEN** the Idea is persisted as an `agent_instance` assignment with the resolved cwd
+  provenance before the `assigned` Activity is emitted
+- **AND** the wake targets that resolved instance
+
+#### Scenario: Reassigning the same agent to a new instance is wake-deduplicated
+
+- **WHEN** an Idea is already assigned to an agent
+- **AND** `chorus_pm_assign_idea` successfully assigns that same agent with a new effective
+  instance pin or cwd target
+- **THEN** the updated assignment is persisted
+- **AND** no new `assigned` Activity is emitted
+- **AND** no duplicate daemon wake is requested
 
 #### Scenario: Assigning an elaborated idea backfills the owner without regressing status
 
@@ -148,4 +173,3 @@ stopping at the human proposal / verify gates and never merging automatically.
 - **THEN** the guidance does not instruct `chorus_claim_idea` (which would hard-fail on an
   elaborated Idea)
 - **AND** it directs the agent toward the proposal stage
-

--- a/src/__tests__/fixtures/agentInstanceFixture.ts
+++ b/src/__tests__/fixtures/agentInstanceFixture.ts
@@ -95,6 +95,9 @@ export interface IdeaRow {
   parentUuid: string | null;
   assigneeType: string | null;
   assigneeUuid: string | null;
+  cwdSource?: string | null;
+  cwdHost?: string | null;
+  runtimeCwd?: string | null;
   assignedAt: Date | null;
   assignedByUuid: string | null;
   createdByUuid: string;
@@ -246,6 +249,7 @@ export interface ProjectAgentCwdPreferenceRow {
   agentUuid: string;
   host: string | null;
   cwd: string | null;
+  anchorAgentInstanceUuid?: string | null;
 }
 
 export interface AgentInstanceStore {
@@ -549,6 +553,14 @@ export function buildMockPrisma() {
     agentInstance: makeModel<AgentInstanceRow & Record<string, unknown>>(
       () => agentInstanceStore.agentInstances as (AgentInstanceRow & Record<string, unknown>)[],
       {
+        compoundKeys: {
+          companyUuid_agentUuid_host_cwd: [
+            "companyUuid",
+            "agentUuid",
+            "host",
+            "cwd",
+          ],
+        },
         defaults: () => ({
           uuid: nextUuid("instance"),
           host: "",

--- a/src/__tests__/integration/assign-idea-end-to-end.integration.test.ts
+++ b/src/__tests__/integration/assign-idea-end-to-end.integration.test.ts
@@ -103,6 +103,8 @@ const CREATOR = "user-creator-e2e"; // idea creator (always an idea_claimed reci
 const TARGET_USER = "user-bob-e2e"; // eligible user target (same company)
 const INSTANCE = "instance-pm-host1"; // durable instance owned by PM_AGENT
 const CONN = "conn-pm-host1";
+const CONFLICTING_INSTANCE = "instance-pm-host2";
+const CONFLICTING_CONN = "conn-pm-host2";
 const IDEA = "idea-assign-e2e";
 
 // The caller's AuthContext — idea:admin is what registers chorus_pm_assign_idea.
@@ -182,6 +184,9 @@ function seed(ideaOverrides: Partial<(typeof agentInstanceStore.ideas)[number]> 
     parentUuid: null,
     assigneeType: null,
     assigneeUuid: null,
+    cwdSource: null,
+    cwdHost: null,
+    runtimeCwd: null,
     assignedAt: null,
     assignedByUuid: null,
     createdByUuid: CREATOR,
@@ -195,10 +200,11 @@ function seed(ideaOverrides: Partial<(typeof agentInstanceStore.ideas)[number]> 
 // Drive the real tool, then re-feed the emitted `assigned` activity into the real
 // listener. Returns the tool result plus the (single) captured activity event.
 async function assignAndNotify(params: Record<string, unknown>) {
+  const activityCount = emittedActivity.length;
   const result = await toolHandlers["chorus_pm_assign_idea"](params);
   // The tool emits exactly one "activity" event on success (createActivity). On a
   // rejection (idea/target invalid) none is emitted — handleActivity is then skipped.
-  const activityEvent = emittedActivity.find(
+  const activityEvent = emittedActivity.slice(activityCount).find(
     (e) => e.targetType === "idea" && e.targetUuid === params.ideaUuid && e.action === "assigned",
   );
   if (activityEvent) {
@@ -350,6 +356,123 @@ describe("assign_idea end-to-end — agent_instance pin (AC#1)", () => {
     );
     expect(session?.originConnectionUuid).toBe(CONN);
     expect(session?.agentUuid).toBe(PM_AGENT);
+  });
+
+  it("materializes the owner project-fixed target, overrides a conflicting explicit instance, and directs the wake to the fixed connection", async () => {
+    seed();
+    const now = new Date();
+    agentInstanceStore.agentInstances.push({
+      uuid: CONFLICTING_INSTANCE,
+      companyUuid: COMPANY,
+      agentUuid: PM_AGENT,
+      host: "host-2",
+      cwd: "/work/other",
+      createdAt: now,
+      updatedAt: now,
+    });
+    agentInstanceStore.daemonConnections.push({
+      uuid: CONFLICTING_CONN,
+      companyUuid: COMPANY,
+      agentUuid: PM_AGENT,
+      clientType: "claude-code",
+      clientVersion: "0.17.0",
+      host: "host-2",
+      cwd: "/work/other",
+      startedAt: now,
+      status: "online",
+      connectedAt: now,
+      lastSeenAt: now,
+      disconnectedAt: null,
+      agentInstanceUuid: CONFLICTING_INSTANCE,
+    });
+    agentInstanceStore.projectAgentCwdPreferences.push({
+      uuid: "pref-fixed-pm",
+      companyUuid: COMPANY,
+      userUuid: OWNER,
+      projectUuid: PROJECT,
+      agentUuid: PM_AGENT,
+      host: "host-1",
+      cwd: "/work/pm",
+      anchorAgentInstanceUuid: INSTANCE,
+    });
+
+    const { result } = await assignAndNotify({
+      ideaUuid: IDEA,
+      assigneeType: "agent",
+      assigneeUuid: PM_AGENT,
+      instanceUuid: CONFLICTING_INSTANCE,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(ideaRow()).toMatchObject({
+      assigneeType: "agent_instance",
+      assigneeUuid: INSTANCE,
+      cwdSource: "project_fixed",
+      cwdHost: "host-1",
+      runtimeCwd: "/work/pm",
+    });
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      assignee: { type: "agent_instance", uuid: INSTANCE },
+      target: {
+        instanceUuid: INSTANCE,
+        resolvedCwdSource: "project_fixed",
+        resolvedCwdHost: "host-1",
+        resolvedRuntimeCwd: "/work/pm",
+      },
+    });
+    expect(assignedActivities()[0].value).toMatchObject({
+      instanceUuid: INSTANCE,
+      resolvedCwdSource: "project_fixed",
+      resolvedCwdHost: "host-1",
+      resolvedRuntimeCwd: "/work/pm",
+    });
+    const turn = agentInstanceStore.daemonSessionTurns.at(-1)!;
+    const session = agentInstanceStore.daemonSessions.find(
+      (candidate) => candidate.uuid === turn.sessionUuid,
+    );
+    expect(session?.originConnectionUuid).toBe(CONN);
+  });
+
+  it("same-agent plain-to-project-fixed reassignment persists the pin without another activity or daemon turn", async () => {
+    seed();
+    const first = await assignAndNotify({
+      ideaUuid: IDEA,
+      assigneeType: "agent",
+      assigneeUuid: PM_AGENT,
+    });
+    expect(first.result.isError).toBeFalsy();
+    expect(ideaRow()).toMatchObject({
+      assigneeType: "agent",
+      assigneeUuid: PM_AGENT,
+    });
+
+    agentInstanceStore.projectAgentCwdPreferences.push({
+      uuid: "pref-fixed-after-plain",
+      companyUuid: COMPANY,
+      userUuid: OWNER,
+      projectUuid: PROJECT,
+      agentUuid: PM_AGENT,
+      host: "host-1",
+      cwd: "/work/pm",
+      anchorAgentInstanceUuid: INSTANCE,
+    });
+    const second = await assignAndNotify({
+      ideaUuid: IDEA,
+      assigneeType: "agent",
+      assigneeUuid: PM_AGENT,
+    });
+
+    expect(second.result.isError).toBeFalsy();
+    expect(ideaRow()).toMatchObject({
+      assigneeType: "agent_instance",
+      assigneeUuid: INSTANCE,
+      cwdSource: "project_fixed",
+      cwdHost: "host-1",
+      runtimeCwd: "/work/pm",
+    });
+    expect(JSON.parse(second.result.content[0].text).wakeRequested).toBe(false);
+    expect(assignedActivities()).toHaveLength(1);
+    expect(agentInstanceStore.daemonSessionTurns).toHaveLength(1);
   });
 });
 

--- a/src/mcp/__tests__/pm-assign-idea.test.ts
+++ b/src/mcp/__tests__/pm-assign-idea.test.ts
@@ -28,10 +28,21 @@ const mockUserService = vi.hoisted(() => ({
   getUserByUuid: vi.fn(),
 }));
 
+const mockProjectAgentCwdService = vi.hoisted(() => ({
+  resolveProjectAgentCwdTarget: vi.fn(),
+}));
+
+const mockUuidResolver = vi.hoisted(() => ({
+  isAssignmentOwnedByActor: vi.fn(),
+  resolveAssigneeAgentUuid: vi.fn(),
+}));
+
 vi.mock("@/services/idea.service", () => mockIdeaService);
 vi.mock("@/services/activity.service", () => mockActivityService);
 vi.mock("@/services/agent.service", () => mockAgentService);
 vi.mock("@/services/user.service", () => mockUserService);
+vi.mock("@/services/project-agent-cwd.service", () => mockProjectAgentCwdService);
+vi.mock("@/lib/uuid-resolver", () => mockUuidResolver);
 
 vi.mock("@/lib/prisma", () => ({ prisma: {} }));
 vi.mock("@/services/project.service", () => ({ projectExists: vi.fn() }));
@@ -93,6 +104,7 @@ beforeEach(() => {
     status: "open",
     assigneeType: null,
     assigneeUuid: null,
+    assignee: null,
   });
   mockIdeaService.assignIdea.mockResolvedValue({
     uuid: ideaUuid,
@@ -109,6 +121,18 @@ beforeEach(() => {
   mockUserService.getUserByUuid.mockResolvedValue({
     uuid: targetUserUuid,
     companyUuid,
+  });
+  mockUuidResolver.resolveAssigneeAgentUuid.mockResolvedValue(null);
+  mockProjectAgentCwdService.resolveProjectAgentCwdTarget.mockResolvedValue({
+    actorUserUuid: "owner-1",
+    source: "unconfigured",
+    agentUuid: targetAgentUuid,
+    host: null,
+    cwd: null,
+    availability: "ready",
+    promptPolicy: "select",
+    connectionUuid: "connection-1",
+    agentInstanceUuid: null,
   });
 });
 
@@ -179,6 +203,23 @@ describe("chorus_pm_assign_idea — agent target (AC2/AC4)", () => {
     expect(assignArgs).not.toHaveProperty("instanceUuid");
     const activityValue = mockActivityService.createActivity.mock.calls[0][0].value;
     expect(activityValue).not.toHaveProperty("instanceUuid");
+  });
+
+  it("resolves the target with the caller owner's project context", async () => {
+    await toolHandlers["chorus_pm_assign_idea"]({
+      ideaUuid,
+      assigneeType: "agent",
+      assigneeUuid: targetAgentUuid,
+    });
+
+    expect(
+      mockProjectAgentCwdService.resolveProjectAgentCwdTarget,
+    ).toHaveBeenCalledWith({
+      companyUuid,
+      actorUserUuid: "owner-1",
+      projectUuid,
+      agentUuid: targetAgentUuid,
+    });
   });
 
   it("rejects an ineligible agent (no idea:write) without changing the assignee", async () => {
@@ -278,6 +319,112 @@ describe("chorus_pm_assign_idea — instance pin (AC2)", () => {
 
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toMatch(/Agent instance not found/);
+  });
+
+  it("uses a project-fixed target instead of a conflicting explicit instance and returns its provenance", async () => {
+    mockProjectAgentCwdService.resolveProjectAgentCwdTarget.mockResolvedValue({
+      actorUserUuid: "owner-1",
+      source: "project_fixed",
+      agentUuid: targetAgentUuid,
+      host: "fixed-host",
+      cwd: "/fixed/project",
+      availability: "ready",
+      promptPolicy: "suppress",
+      connectionUuid: "fixed-connection",
+      agentInstanceUuid: "fixed-instance",
+    });
+    mockIdeaService.assignIdea.mockResolvedValue({
+      uuid: ideaUuid,
+      status: "elaborating",
+      assignee: { type: "agent_instance", uuid: "fixed-instance" },
+    });
+
+    const res = await toolHandlers["chorus_pm_assign_idea"]({
+      ideaUuid,
+      assigneeType: "agent",
+      assigneeUuid: targetAgentUuid,
+      instanceUuid: "conflicting-instance",
+    });
+
+    expect(mockIdeaService.assignIdea).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceUuid: "fixed-instance",
+        cwdSource: "project_fixed",
+        cwdHost: "fixed-host",
+        runtimeCwd: "/fixed/project",
+      }),
+    );
+    expect(mockActivityService.createActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: {
+          assigneeType: "agent",
+          assigneeUuid: targetAgentUuid,
+          instanceUuid: "fixed-instance",
+          resolvedCwdSource: "project_fixed",
+          resolvedCwdHost: "fixed-host",
+          resolvedRuntimeCwd: "/fixed/project",
+        },
+      }),
+    );
+    expect(JSON.parse(res.content[0].text)).toMatchObject({
+      assignee: { type: "agent_instance", uuid: "fixed-instance" },
+      target: {
+        instanceUuid: "fixed-instance",
+        resolvedCwdSource: "project_fixed",
+        resolvedCwdHost: "fixed-host",
+        resolvedRuntimeCwd: "/fixed/project",
+      },
+    });
+  });
+
+  it("deduplicates the Activity when a plain-agent assignee is re-pinned", async () => {
+    mockIdeaService.getIdeaByUuid.mockResolvedValue({
+      uuid: ideaUuid,
+      projectUuid,
+      status: "elaborating",
+      assigneeType: "agent",
+      assigneeUuid: targetAgentUuid,
+    });
+    mockUuidResolver.resolveAssigneeAgentUuid.mockResolvedValue(targetAgentUuid);
+
+    const res = await toolHandlers["chorus_pm_assign_idea"]({
+      ideaUuid,
+      assigneeType: "agent",
+      assigneeUuid: targetAgentUuid,
+      instanceUuid,
+    });
+
+    expect(mockIdeaService.assignIdea).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceUuid }),
+    );
+    expect(mockActivityService.createActivity).not.toHaveBeenCalled();
+    expect(JSON.parse(res.content[0].text)).toMatchObject({
+      wakeRequested: false,
+    });
+  });
+
+  it("deduplicates the Activity when an instance-pinned assignee keeps the same owning agent", async () => {
+    mockIdeaService.getIdeaByUuid.mockResolvedValue({
+      uuid: ideaUuid,
+      projectUuid,
+      status: "elaborating",
+      assigneeType: "agent_instance",
+      assigneeUuid: "old-instance",
+    });
+    mockUuidResolver.resolveAssigneeAgentUuid.mockResolvedValue(targetAgentUuid);
+
+    const res = await toolHandlers["chorus_pm_assign_idea"]({
+      ideaUuid,
+      assigneeType: "agent",
+      assigneeUuid: targetAgentUuid,
+      instanceUuid,
+    });
+
+    expect(mockIdeaService.assignIdea).toHaveBeenCalled();
+    expect(mockActivityService.createActivity).not.toHaveBeenCalled();
+    expect(JSON.parse(res.content[0].text)).toMatchObject({
+      wakeRequested: false,
+    });
   });
 });
 

--- a/src/mcp/__tests__/tool-description-slimming.test.ts
+++ b/src/mcp/__tests__/tool-description-slimming.test.ts
@@ -58,6 +58,7 @@ function buildAuth(): AgentAuthContext {
     roles: ["pm_agent"],
     permissions: [
       "idea:write",
+      "idea:admin",
       "proposal:write",
       "document:write",
       "task:write",
@@ -156,5 +157,13 @@ describe("relocated red-lines landed in the right place", () => {
   it("pm_assign_task: instance-pin detail moved into instanceUuid param", () => {
     const instanceUuid = jsonSchema("chorus_pm_assign_task").properties?.instanceUuid;
     expect(instanceUuid?.description).toMatch(/agent_instance/);
+  });
+
+  it("pm_assign_idea: documents project-fixed auto-pinning and same-agent wake deduplication", () => {
+    expect(descOf("chorus_pm_assign_idea")).toMatch(/project-fixed/i);
+    expect(descOf("chorus_pm_assign_idea")).toMatch(/overriding `instanceUuid`/);
+    expect(descOf("chorus_pm_assign_idea")).toMatch(/deduplicated/i);
+    expect(descOf("chorus_pm_assign_idea")).toMatch(/same agent/i);
+    expect(descOf("chorus_pm_assign_idea")).toMatch(/does not request another wake/i);
   });
 });

--- a/src/mcp/tools/pm.ts
+++ b/src/mcp/tools/pm.ts
@@ -20,12 +20,16 @@ import * as elaborationService from "@/services/elaboration.service";
 import { getAgentByUuid } from "@/services/agent.service";
 import { getUserByUuid } from "@/services/user.service";
 import { AlreadyClaimedError, NotClaimedError } from "@/lib/errors";
-import { isAssignmentOwnedByActor } from "@/lib/uuid-resolver";
+import {
+  isAssignmentOwnedByActor,
+  resolveAssigneeAgentUuid,
+} from "@/lib/uuid-resolver";
 import { zArray } from "./schema-utils";
 import { registerPermissionedTool } from "./register-helpers";
 import { hasPermission } from "@/lib/auth";
 import { computeEffectivePermissions } from "@/lib/authz/permissions";
 import { enforceToolClassification } from "./collection-contract";
+import { resolveProjectAgentCwdTarget } from "@/services/project-agent-cwd.service";
 
 export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
   server = enforceToolClassification(server);
@@ -893,7 +897,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
     "idea:admin",
     "chorus_pm_assign_idea",
     {
-      description: "Assign an Idea to an agent (must hold idea:write) or a user, on a human's behalf. Silently takes over any existing assignee; an `open` Idea moves to `elaborating`, any other status is preserved. Optionally pin an agent assignment to a specific AgentInstance via `instanceUuid` (persists as an `agent_instance` assignment and targets that instance at wake time) — only valid when assigneeType=\"agent\". Assigning to an agent wakes it best-effort (offline still persists the assignment); assigning to a user sets the assignee and notifies the user with no daemon wake.",
+      description: "Assign an Idea to an agent (must hold idea:write) or a user, on a human's behalf. Silently takes over any existing assignee; an `open` Idea moves to `elaborating`, any other status is preserved. Agent assignments automatically pin to the caller owner's project-fixed cwd target when configured, overriding `instanceUuid`; otherwise an optional `instanceUuid` persists an `agent_instance` pin. A new logical agent assignee requests a wake; assigning the same agent again may update its pin/cwd but is deduplicated and does not request another wake. Assigning to a user sets the assignee and notifies the user with no daemon wake.",
       inputSchema: z.object({
         ideaUuid: z.string().describe("Idea UUID"),
         assigneeType: z.enum(["agent", "user"]).describe("Assignee type: agent or user"),
@@ -901,7 +905,7 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
         instanceUuid: z
           .string()
           .nullish()
-          .describe("Optional AgentInstance UUID — only valid when assigneeType=\"agent\". Pins the Idea to that durable (agent, host, cwd) instance so the row persists as `agent_instance` and the wake targets that instance; omit for a plain `agent` assignment whose wake-time instance is online-first. The instance must belong to the target agent's company, else the call is rejected. Rejected if supplied with assigneeType=\"user\"."),
+          .describe("Optional AgentInstance UUID — only valid when assigneeType=\"agent\". A configured project-fixed cwd target takes precedence and supplies the effective instance automatically; otherwise this pins the Idea to that durable (agent, host, cwd) instance. When used, the instance must belong to the target agent's company, else the call is rejected. Rejected if supplied with assigneeType=\"user\"."),
       }),
     },
     async ({ ideaUuid, assigneeType, assigneeUuid, instanceUuid }) => {
@@ -948,11 +952,43 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
         }
       }
 
+      // Resolve the same immutable project target snapshot as the UI action. A
+      // project-fixed owner preference deliberately wins over a caller-supplied
+      // instance so MCP and UI cannot route the same project to different roots.
+      const resolvedTarget =
+        assigneeType === "agent" && auth.ownerUuid
+          ? await resolveProjectAgentCwdTarget({
+              companyUuid: auth.companyUuid,
+              actorUserUuid: auth.ownerUuid,
+              projectUuid: idea.projectUuid,
+              agentUuid: assigneeUuid,
+            })
+          : null;
+      const usesProjectFixedTarget =
+        resolvedTarget?.source === "project_fixed";
+      const effectiveInstanceUuid =
+        assigneeType === "agent"
+          ? usesProjectFixedTarget
+            ? resolvedTarget.agentInstanceUuid
+            : instanceUuid
+          : null;
+      const currentAssigneeAgentUuid =
+        assigneeType === "agent"
+          ? await resolveAssigneeAgentUuid(
+              auth.companyUuid,
+              idea.assigneeType,
+              idea.assigneeUuid,
+            )
+          : null;
+      const isSameLogicalAgentAssignee =
+        assigneeType === "agent" &&
+        currentAssigneeAgentUuid === assigneeUuid;
+      const shouldEmitAssignedActivity =
+        assigneeType !== "agent" || !isSameLogicalAgentAssignee;
+
       // Execute the assignment. assignIdea is reassign-safe (silent takeover;
-      // open→elaborating else status preserved) and applies the optional instance
+      // open→elaborating else status preserved) and applies the effective instance
       // pin via resolveAssigneeFields (validates company ownership → agent_instance).
-      // Forward instanceUuid only for a pinned agent assignment so an un-pinned or
-      // user assignment's args are byte-identical to the human path.
       try {
         const updated = await ideaService.assignIdea({
           ideaUuid: idea.uuid,
@@ -961,28 +997,44 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
           assigneeUuid,
           assignedByType: "agent",
           assignedByUuid: auth.actorUuid,
-          ...(assigneeType === "agent" && instanceUuid != null ? { instanceUuid } : {}),
+          ...(effectiveInstanceUuid != null
+            ? { instanceUuid: effectiveInstanceUuid }
+            : {}),
+          cwdSource: usesProjectFixedTarget ? resolvedTarget.source : null,
+          cwdHost: usesProjectFixedTarget ? resolvedTarget.host : null,
+          runtimeCwd: usesProjectFixedTarget ? resolvedTarget.cwd : null,
         });
 
-        // CRITICAL: the actor-bearing `assigned` Activity is what triggers the
-        // idea_claimed wake (agent) / assignment notification (user). assignIdea
-        // emits only an `updated` change event — without this Activity there is NO
-        // wake. Value mirrors claimIdeaToAgentAction: the raw assignee identity
-        // plus the instance uuid (when pinned), for attribution parity with the UI.
-        await activityService.createActivity({
-          companyUuid: auth.companyUuid,
-          projectUuid: idea.projectUuid,
-          targetType: "idea",
-          targetUuid: idea.uuid,
-          actorType: "agent",
-          actorUuid: auth.actorUuid,
-          action: "assigned",
-          value: {
-            assigneeType,
-            assigneeUuid,
-            ...(assigneeType === "agent" && instanceUuid != null ? { instanceUuid } : {}),
-          },
-        });
+        // The actor-bearing `assigned` Activity triggers the idea_claimed wake
+        // (agent) / assignment notification (user). Keep that side effect for a
+        // newly responsible agent, but deduplicate same-owning-agent re-pins:
+        // assignIdea still persists the effective target while no second daemon
+        // turn is born merely because its instance/cwd changed.
+        if (shouldEmitAssignedActivity) {
+          await activityService.createActivity({
+            companyUuid: auth.companyUuid,
+            projectUuid: idea.projectUuid,
+            targetType: "idea",
+            targetUuid: idea.uuid,
+            actorType: "agent",
+            actorUuid: auth.actorUuid,
+            action: "assigned",
+            value: {
+              assigneeType,
+              assigneeUuid,
+              ...(effectiveInstanceUuid != null
+                ? { instanceUuid: effectiveInstanceUuid }
+                : {}),
+              ...(usesProjectFixedTarget
+                ? {
+                    resolvedCwdSource: resolvedTarget.source,
+                    resolvedCwdHost: resolvedTarget.host,
+                    resolvedRuntimeCwd: resolvedTarget.cwd,
+                  }
+                : {}),
+            },
+          });
+        }
 
         return {
           content: [{ type: "text", text: JSON.stringify({
@@ -990,6 +1042,22 @@ export function registerPmTools(server: McpServer, auth: AgentAuthContext) {
             status: updated.status,
             assignee: updated.assignee
               ? { type: updated.assignee.type, uuid: updated.assignee.uuid }
+              : null,
+            wakeRequested:
+              assigneeType === "agent" && shouldEmitAssignedActivity,
+            target: assigneeType === "agent"
+              ? {
+                  instanceUuid: effectiveInstanceUuid ?? null,
+                  resolvedCwdSource: usesProjectFixedTarget
+                    ? resolvedTarget.source
+                    : null,
+                  resolvedCwdHost: usesProjectFixedTarget
+                    ? resolvedTarget.host
+                    : null,
+                  resolvedRuntimeCwd: usesProjectFixedTarget
+                    ? resolvedTarget.cwd
+                    : null,
+                }
               : null,
           }, null, 2) }],
         };


### PR DESCRIPTION
## Summary
- resolve `chorus_pm_assign_idea` agent targets through the caller owner's project-fixed cwd preference before wake
- let project-fixed targets override conflicting explicit instance pins
- preserve same-agent pin/cwd updates while deduplicating their `assigned` activity, notification, and daemon turn
- update MCP docs and archive the validated OpenSpec change

## Review focus
- logical-assignee comparison resolves `agent_instance` rows to their owning agent before deduplication
- first assignment and takeover from another assignee still emit the directed wake
- same-agent plain → project-fixed updates persist without a second wake

## Test plan
- [x] 75 focused Vitest tests
- [x] `pnpm exec tsc --noEmit --pretty false`
- [x] production-source ESLint
- [x] `openspec validate --all --strict` (121 items)
- [x] `git diff --check`

## Chorus
- Idea: `dedcbcf8-0b3b-4949-8ca4-0bde2d238e3f`
- Follow-up task: `9d5ffd9e-45ab-4bbe-a4ff-a7f459bed23c`

Deployment will follow review and green CI.