### PR TITLE
feat: automate coordinated npm releases

### DIFF
--- a/.claude/skills/plugin-maintenance/SKILL.md
+++ b/.claude/skills/plugin-maintenance/SKILL.md
@@ -174,6 +174,39 @@ dsh tracks the **app version** (currently `0.16.3`), NOT the 0.9.x skill sequenc
 17. Every skill under `packages/chorus-dsh/skills/*/SKILL.md` — `metadata.version: "X.Y.Z"` (the `chorus/` overview + all `-chorus`-suffixed stage/reviewer skills).
    - **Do NOT** hardcode a version in `bin/chorus-mcp-call.mjs` — its `clientInfo.version` is auto-read from `package.json`, so it never drifts.
 
+### Coordinated npm release identity
+
+When cutting an application release, the three public npm packages are one
+lockstep release unit. Set the same `X.Y.Z` in:
+
+1. root `package.json` (`@chorus-aidlc/chorus`);
+2. `packages/openclaw-plugin/package.json`
+   (`@chorus-aidlc/chorus-openclaw-plugin`) and refresh its standalone
+   `package-lock.json`;
+3. `packages/chorus-dsh/package.json`
+   (`@chorus-aidlc/chorus-dsh`).
+
+Publishing GitHub Release `vX.Y.Z` triggers
+`.github/workflows/publish-npm.yml`. The workflow completes all three package
+build/pack contracts before any upload, then publishes CLI → OpenClaw → dsh.
+The older interactive package publish scripts are maintenance tools, not the CI
+release entry point.
+
+For all three npm package settings, Trusted Publisher must use the exact
+workflow filename `publish-npm.yml` in the matching GitHub repository. Leave
+the npm Environment field blank while the workflow job has no `environment`;
+if an Environment is introduced, configure the exact same case-sensitive name
+on npm and on the workflow job. Keep `id-token: write`, do not add
+`NPM_TOKEN`, `NODE_AUTH_TOKEN`, or a setup-node token placeholder, and do not
+disable npm's automatic provenance. A public-repository publish is accepted
+only after the workflow observes its SLSA provenance attestation.
+
+For partial publication, repair the external problem and choose **Re-run jobs**
+on the same failed Actions run. Do not create a replacement Release/version.
+The rerun skips exact versions already confirmed in npm and resumes in fixed
+order. A failed registry lookup is not a skip and must stop the run; the job
+summary identifies `failed` and `not-attempted` packages for diagnosis.
+
 ### Standalone skills — independent versioning
 15. `public/skill/*/SKILL.md` — bump only the standalone skills that changed, using their own version sequence.
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -71,12 +71,23 @@ Based on the commits identified in Step 1, draft the new CHANGELOG section and *
 
 After user approval, write the approved content into `CHANGELOG.md` — add the new section at the top, below the `# Changelog` header and above the previous release section.
 
-### 4. Bump version in package.json (on develop)
+### 4. Bump all three npm package versions (on develop)
 
 ```bash
-# Edit package.json "version" field
-# e.g., "0.1.0" → "0.1.1"
+# Keep the coordinated release identity in lockstep:
+# package.json
+# packages/openclaw-plugin/package.json
+# packages/chorus-dsh/package.json
+
+# Refresh OpenClaw's standalone lockfile after editing its package version:
+cd packages/openclaw-plugin
+npm install --package-lock-only --ignore-scripts --no-audit --no-fund
+cd ../..
 ```
+
+The GitHub Release tag, root Chorus CLI, OpenClaw plugin, and dsh plugin MUST
+all use the same `X.Y.Z`. The coordinated publication preflight rejects any
+name or version drift before an npm registry write.
 
 Follow [semver](https://semver.org/):
 - **patch** (0.1.0 → 0.1.1): bug fixes, minor additions
@@ -87,7 +98,10 @@ Follow [semver](https://semver.org/):
 
 ```bash
 # Commit the release prep on develop
-git add CHANGELOG.md package.json
+git add CHANGELOG.md package.json \
+  packages/openclaw-plugin/package.json \
+  packages/openclaw-plugin/package-lock.json \
+  packages/chorus-dsh/package.json
 git commit -m "chore: bump version to vX.Y.Z and update CHANGELOG"
 git push origin develop
 
@@ -123,6 +137,34 @@ EOF
 
 **Important:** The `--notes` should contain **only** the new version's content, not the entire CHANGELOG file.
 
+Publishing the GitHub Release triggers
+`.github/workflows/publish-npm.yml`. That workflow prepares and validates all
+three tarballs before publishing, then publishes Chorus CLI → OpenClaw → dsh
+through npm Trusted Publishing/OIDC. Do not run the legacy interactive publish
+scripts as an additional release step.
+
+### 6.1 Trusted Publisher contract and recovery
+
+Each npm package's Trusted Publisher settings must match:
+
+- repository owner/name: the GitHub repository that contains this workflow;
+- workflow filename: `publish-npm.yml` (exact filename);
+- Environment: blank when the workflow has no `environment`, or the exact same
+  Environment name on both npm and the `publish` job.
+
+The workflow file path is `.github/workflows/publish-npm.yml`; npm's Trusted
+Publisher form takes the filename, not the full path. The job runs on a
+GitHub-hosted runner with `id-token: write`, does not use `NPM_TOKEN` or
+`NODE_AUTH_TOKEN`, and leaves provenance enabled. Public-repository publishes
+must expose an SLSA provenance attestation after upload.
+
+If a run partially publishes the fixed sequence, fix the external failure and
+use **Re-run jobs** on the same failed GitHub Actions run. Do not create another
+tag or GitHub Release and do not bump the version. The rerun queries every exact
+`name@version`, records existing versions as `skipped-already-published`, and
+continues with the first missing package. Registry lookup errors remain fatal;
+never assume an ambiguous lookup means “not published.”
+
 ### 7. Sync develop with main and verify
 
 ```bash
@@ -143,10 +185,13 @@ gh release view vX.Y.Z
 - [ ] `git log v<PREV>..develop` reviewed — no commits missed
 - [ ] CHANGELOG draft presented to user and **approved**
 - [ ] CHANGELOG.md written with approved content
-- [ ] package.json version bumped
+- [ ] Root, OpenClaw, and dsh package versions are the same `X.Y.Z`
+- [ ] OpenClaw `package-lock.json` refreshed for `X.Y.Z`
 - [ ] Changes committed and pushed to `develop`
 - [ ] PR from `develop` → `main` created, CI passed, and merged
 - [ ] `gh release create` with tag targeting `main`
+- [ ] `publish-npm.yml` run passed for all three packages (published or safely skipped)
+- [ ] Public-package provenance attestations were verified by the workflow
 - [ ] Release notes contain only the new version's section
 - [ ] `develop` synced with `main` after merge
 - [ ] `gh release view` confirms everything looks correct

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,67 @@
+name: Publish coordinated npm release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Prepare and publish all npm packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout immutable release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: ''
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '9.15.0'
+          run_install: false
+
+      - name: Set up supported npm CLI
+        run: npm install --global 'npm@^11.5.1'
+
+      - name: Verify trusted-publishing toolchain
+        shell: bash
+        run: |
+          node --version
+          npm --version
+          node -e '
+            const [major, minor] = process.versions.node.split(".").map(Number);
+            if (major < 22 || (major === 22 && minor < 14)) {
+              throw new Error("Trusted Publishing requires Node.js 22.14.0 or newer");
+            }
+          '
+          node -e '
+            const [major, minor] = require("child_process")
+              .execFileSync("npm", ["--version"], { encoding: "utf8" })
+              .trim()
+              .split(".")
+              .map(Number);
+            if (major < 11 || (major === 11 && minor < 5)) {
+              throw new Error("Trusted Publishing requires npm 11.5.1 or newer");
+            }
+          '
+
+      - name: Prepare and validate all package tarballs
+        run: node scripts/coordinated-npm-release/prepare.mjs '${{ github.event.release.tag_name }}'
+
+      - name: Publish validated tarballs in manifest order
+        env:
+          CHORUS_RELEASE_EXPECT_PROVENANCE: ${{ !github.event.repository.private }}
+        run: node scripts/coordinated-npm-release/publish.mjs '${{ github.event.release.tag_name }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Run tests with coverage
         run: pnpm test:coverage -- --reporter=json --outputFile=coverage/test-results.json
 
+      - name: Run coordinated package-contract tests
+        run: pnpm test:release-contract
+
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ node_modules
 !.yarn/releases
 !.yarn/versions
 package-lock.json
+# OpenClaw is an npm-managed package published via `npm ci`; its lockfile is tracked.
+!packages/openclaw-plugin/package-lock.json
 
 # testing
 /coverage
@@ -68,6 +70,7 @@ packages/chorus-cdk/lib/*.d.ts
 
 # npm pack output
 *.tgz
+/.release-artifacts/
 
 #demo
 dev-story-demo/

--- a/cli/__tests__/credentials.test.mjs
+++ b/cli/__tests__/credentials.test.mjs
@@ -1,5 +1,6 @@
 // cli/__tests__/credentials.test.mjs
 // Covers cli-auth spec "Layered credential and address resolution".
+import { resolve } from "node:path";
 import { describe, it, expect } from "vitest";
 import { resolveCredentials, loginFilePath, claudeSettingsPath } from "../credentials.mjs";
 
@@ -152,7 +153,32 @@ describe("path helpers", () => {
   it("loginFilePath ends with .chorus/daemon.json", () => {
     expect(loginFilePath().replace(/\\/g, "/")).toMatch(/\.chorus\/daemon\.json$/);
   });
+  it("loginFilePath honors an explicit daemon config path", () => {
+    const previous = process.env.CHORUS_DAEMON_CONFIG_PATH;
+    try {
+      process.env.CHORUS_DAEMON_CONFIG_PATH = "/tmp/chorus-test/.chorus/daemon.json";
+      expect(loginFilePath().replace(/\\/g, "/")).toBe(
+        resolve("/tmp/chorus-test/.chorus/daemon.json").replace(/\\/g, "/"),
+      );
+    } finally {
+      if (previous === undefined) delete process.env.CHORUS_DAEMON_CONFIG_PATH;
+      else process.env.CHORUS_DAEMON_CONFIG_PATH = previous;
+    }
+  });
   it("claudeSettingsPath ends with .claude/settings.json", () => {
     expect(claudeSettingsPath().replace(/\\/g, "/")).toMatch(/\.claude\/settings\.json$/);
+  });
+  it("claudeSettingsPath honors an explicit settings path", () => {
+    const previous = process.env.CHORUS_CLAUDE_SETTINGS_PATH;
+    try {
+      process.env.CHORUS_CLAUDE_SETTINGS_PATH =
+        "/tmp/chorus-test/.claude/settings.json";
+      expect(claudeSettingsPath().replace(/\\/g, "/")).toBe(
+        resolve("/tmp/chorus-test/.claude/settings.json").replace(/\\/g, "/"),
+      );
+    } finally {
+      if (previous === undefined) delete process.env.CHORUS_CLAUDE_SETTINGS_PATH;
+      else process.env.CHORUS_CLAUDE_SETTINGS_PATH = previous;
+    }
   });
 });

--- a/cli/credentials.mjs
+++ b/cli/credentials.mjs
@@ -18,15 +18,19 @@
 
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 /** Absolute path to the login file written by `chorus login`. */
 export function loginFilePath() {
+  const override = process.env.CHORUS_DAEMON_CONFIG_PATH?.trim();
+  if (override) return resolve(override);
   return join(homedir(), ".chorus", "daemon.json");
 }
 
 /** Absolute path to the Claude Code user settings file (plugin fallback source). */
 export function claudeSettingsPath() {
+  const override = process.env.CHORUS_CLAUDE_SETTINGS_PATH?.trim();
+  if (override) return resolve(override);
   return join(homedir(), ".claude", "settings.json");
 }
 

--- a/docs/acceptance/coordinated-npm-release.md
+++ b/docs/acceptance/coordinated-npm-release.md
@@ -1,0 +1,108 @@
+# Coordinated npm release acceptance — v0.17.0
+
+Date: 2026-08-31
+
+This acceptance used the release tag identity `v0.17.0` and did not publish or
+create any npm version.
+
+## Automated release invariants
+
+Command:
+
+```bash
+node --test scripts/coordinated-npm-release/__tests__/coordinated-npm-release.test.mjs
+```
+
+Result: 11 assertions across 9 scenarios passed. The test creates isolated
+temporary repositories, uses real `npm pack`, and replaces only registry and
+publish calls with a local fake npm executable. Coverage includes:
+
+- exact `vX.Y.Z` parsing and name/version drift before package work;
+- no publish handoff when the final package prepare fails;
+- all three contract-shaped tarballs and their fixed CLI → OpenClaw → dsh order;
+- exact-version already-published recovery;
+- fatal registry lookup errors and publish failures stopping later packages;
+- `published`, `skipped-already-published`, `failed`, and `not-attempted`
+  summary states;
+- automatic provenance handling: no provenance-disable publish option and an
+  SLSA `dist.attestations` check after every new publish;
+- Release-only trigger, minimal OIDC permissions, supported runner/toolchain,
+  and absence of npm token configuration.
+
+## Full three-package prepare
+
+Command:
+
+```bash
+node scripts/coordinated-npm-release/prepare.mjs v0.17.0
+```
+
+Result: passed as one complete prepare gate.
+
+- Chorus CLI: lint and typecheck passed; 345 test files and 5,499 tests passed
+  (existing suite skips remained); production Next.js build and prepack passed;
+  the packed CLI installed into a fresh prefix and `chorus --version` returned
+  `0.17.0`.
+- OpenClaw plugin: standalone install, clean, typecheck, 151 tests, build,
+  packed manifest, runtime entry, and `chorus-openclaw-plugin` ID checks passed.
+- dsh plugin: install, lint, typecheck, 31 tests, dsh contract, build,
+  15-skill package validation, package-specific pack check, and packed manifest
+  checks passed.
+
+The ordered handoff was written only after all three packages passed:
+
+| Package | Files | Packed size | SHA-256 |
+| --- | ---: | ---: | --- |
+| `@chorus-aidlc/chorus` | 2,551 | 32,313,024 bytes | `023da7446bb7155e16576b9c2d1013493e23ef06b441bba583a9b43586485160` |
+| `@chorus-aidlc/chorus-openclaw-plugin` | 84 | 180,942 bytes | `b75bfd72232556fbe04c763e34122fc749110ddf16ee8d8e0f551f356e2912ff` |
+| `@chorus-aidlc/chorus-dsh` | 23 | 94,879 bytes | `f2bcb2f0546eb48d7a648350366b0664a1eaaacd25aee302376162f8e7ffc234` |
+
+Required package identities, versions, executable/runtime entries, plugin
+metadata, dsh exports, skill bundle, and forbidden-file rules were checked by
+the package-specific prepare contracts.
+
+## npm CLI no-publish dry-runs
+
+Commands:
+
+```bash
+npm publish .release-artifacts/npm/chorus-aidlc-chorus-0.17.0.tgz --dry-run --ignore-scripts --access public --json
+npm publish .release-artifacts/npm/chorus-aidlc-chorus-openclaw-plugin-0.17.0.tgz --dry-run --ignore-scripts --access public --json
+npm publish .release-artifacts/npm/chorus-aidlc-chorus-dsh-0.17.0.tgz --dry-run --ignore-scripts --access public --json
+```
+
+All three exited successfully and reported the expected scoped package name,
+version `0.17.0`, tarball filename, entry count, integrity, and public access.
+`--dry-run` and `--ignore-scripts` ensured that these checks created no registry
+version and did not rerun package lifecycle scripts against the accepted bytes.
+
+## Specification and repository checks
+
+```bash
+openspec validate automate-coordinated-npm-releases --strict
+node --check scripts/coordinated-npm-release/__tests__/coordinated-npm-release.test.mjs
+git diff --check
+```
+
+All passed.
+
+## External prerequisites not simulated locally
+
+The following require GitHub/npm control-plane state and can only be verified
+on an actual GitHub Release run:
+
+- each of the three npm packages must trust the correct GitHub repository and
+  exact workflow filename `publish-npm.yml`;
+- npm's optional Environment setting must be blank for the current workflow,
+  or exactly match a future job `environment`;
+- GitHub must issue the OIDC identity to the hosted runner under
+  `id-token: write`;
+- npm must accept that identity and emit public-package SLSA provenance;
+- GitHub's **Re-run jobs** operation must retain the same Release/tag context
+  after a partial publication.
+
+The automated suite verifies the local side of each contract, including
+tokenless workflow configuration, default automatic provenance handling,
+post-publish attestation lookup, idempotent exact-version skips, and auditable
+failed/not-attempted recovery summaries. A real publish was intentionally not
+executed.

--- a/openspec/changes/archive/2026-08-31-automate-coordinated-npm-releases/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-31-automate-coordinated-npm-releases/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/archive/2026-08-31-automate-coordinated-npm-releases/README.md
+++ b/openspec/changes/archive/2026-08-31-automate-coordinated-npm-releases/README.md
@@ -1,0 +1,3 @@
+# automate-coordinated-npm-releases
+
+Automate coordinated publication of Chorus CLI, OpenClaw plugin, and dsh plugin through GitHub Actions and npm Trusted Publishing

--- a/openspec/changes/archive/2026-08-31-automate-coordinated-npm-releases/design.md
+++ b/openspec/changes/archive/2026-08-31-automate-coordinated-npm-releases/design.md
@@ -1,0 +1,125 @@
+## Context
+
+仓库包含三个独立 npm 发布单元：
+
+- 根目录 `@chorus-aidlc/chorus`，提供 `chorus` CLI；
+- `packages/openclaw-plugin` 中的 `@chorus-aidlc/chorus-openclaw-plugin`；
+- `packages/chorus-dsh` 中的 `@chorus-aidlc/chorus-dsh`。
+
+三者源码版本当前同步，但安装和校验方式不同。根包和两个插件各自带有构建或发布前钩子，现有根包与 OpenClaw 发布脚本还包含 `npm whoami` 和交互确认，不适合作为无 token、无交互的 CI 入口。现有 release 流程在 `main` 合并后创建 `vX.Y.Z` GitHub Release，因此 Release `published` 是最贴近当前人工批准边界的自动发布触发点。
+
+npm Trusted Publishing 已分别为三个包绑定同一个 GitHub Actions workflow。该机制要求 GitHub 托管 runner、`id-token: write`、Node 22.14.0+ 和 npm 11.5.1+；npm CLI 在 `npm publish` 时自动使用 OIDC，不需要 `NODE_AUTH_TOKEN` 或 `NPM_TOKEN`。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 由一个 workflow 协同发布三个 npm 包，并保持版本与 GitHub Release tag 一致。
+- 在任何 registry 写入前完成所有可前置的质量和包内容校验。
+- 不在 GitHub Secrets、环境变量或仓库文件中存储 npm 发布 token。
+- 在部分包已成功发布后允许安全重跑，并清楚报告发布或跳过结果。
+- 保留明确的发布顺序和失败即停止语义，便于诊断和审计。
+
+**Non-Goals:**
+
+- 提供 npm registry 的跨包原子事务；npm 本身不支持多包原子发布。
+- 自动生成版本号、CHANGELOG、tag 或 GitHub Release；这些仍由现有 release 流程和人工批准负责。
+- 自动回滚或 unpublish 已公开的版本。
+- 更改三个包的运行时功能、npm 名称或安装方式。
+- 在本次变更中自动修改 npm 网站上的 Trusted Publisher 配置。
+
+## Decisions
+
+### 由 GitHub Release `published` 触发
+
+workflow 监听：
+
+```yaml
+on:
+  release:
+    types: [published]
+```
+
+运行必须检出 `github.event.release.tag_name` 对应的不可变 tag，而不是可移动分支。脚本去掉前导 `v` 得到预期版本，并要求三个 `package.json` 的 `name` 与 `version` 精确匹配受支持清单和该版本。
+
+选择 GitHub Release 而不是每次推 tag，是因为现有 release 流程把 Release 创建放在 CHANGELOG 审核、PR 合并和 tag 确认之后；它提供了更清晰的人工批准边界。可保留 `workflow_dispatch` 作为同一 Release/tag 的重跑入口，但不得允许任意未发布分支绕过版本和 tag 校验。
+
+### 一个 workflow、一个 OIDC 权限边界
+
+三个 npm package 的 Trusted Publisher 均绑定 `.github/workflows/publish-npm.yml`。workflow 使用：
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+并运行在 `ubuntu-latest`。Node 使用受支持的 24.x，随后显式校验 npm CLI 至少为 11.5.1。`actions/setup-node` 配置 npm registry，但 workflow、脚本和环境不得引用 `NPM_TOKEN` 或 `NODE_AUTH_TOKEN`。
+
+如果 npm Trusted Publisher 配置指定了 Environment，job 的 `environment` 必须与之精确匹配；如果 npm 侧留空，则 workflow 也不强制 Environment。本实现不得假定或创建 GitHub secret。
+
+### 先全量验证和打包，再上传
+
+流程分为两个阶段：
+
+1. **Prepare**：安装根 workspace 与独立 OpenClaw 包依赖；对三个发布单元执行各自适用的 lint/typecheck/test/build/package checks；生成 tarball；检查 tarball 元数据、必需入口和禁止文件；保存确定的 tarball 路径与摘要。
+2. **Publish**：只有三个 prepare 全部成功后，才按固定清单顺序上传已经验证的 tarball。
+
+这避免根包成功发布后才发现插件无法构建。上传 tarball 而不是重新从工作目录打包，保证发布的是 prepare 阶段验收过的字节。实现必须验证 `npm publish <tarball>` 在 Trusted Publishing 下产生正常 provenance；不得通过关闭 provenance 来规避配置错误。
+
+现有交互式 `scripts/npm-publish.sh` 和 `packages/openclaw-plugin/bin/publish.sh` 不作为 CI 入口，因为 `npm whoami`、本地登录检查和提示与 OIDC 无交互执行冲突。
+
+### 固定顺序、幂等恢复
+
+发布顺序固定为：
+
+1. `@chorus-aidlc/chorus`
+2. `@chorus-aidlc/chorus-openclaw-plugin`
+3. `@chorus-aidlc/chorus-dsh`
+
+上传每个包前，脚本查询精确的 `<name>@<version>`。若 registry 已存在该版本，则记录为 `skipped-already-published` 并继续；若不存在，则执行 `npm publish <tarball> --access public`。除“明确不存在”外的 registry 查询错误必须失败，不能被误判为未发布。
+
+任何 publish 失败立即终止后续上传。维护者修复外部问题后，可从 GitHub Actions 重跑同一 Release；已成功的包被跳过，其余包继续。npm 不支持多包事务，因此不尝试自动 unpublish。
+
+### 脚本承载可测试逻辑，YAML 只负责编排
+
+版本解析、包清单、registry 状态分类、tarball 映射和发布循环放入仓库脚本，workflow 仅负责事件、权限、工具链和调用。脚本提供 dry-run 或可注入的 npm 命令边界，以便测试以下行为：
+
+- tag 与三个版本不一致时在发布前失败；
+- 包名或目录漂移时失败；
+- 三个 tarball 全部准备成功后才进入 publish；
+- 已发布版本被跳过；
+- registry 网络/权限错误和 publish 错误立即停止；
+- 日志不包含认证凭证。
+
+## Module Contracts
+
+- **Release manifest**：唯一清单按顺序映射 `directory -> expected package name -> tarball path`；校验、测试和 publish 共用该清单，避免三个阶段各自维护包列表。
+- **Version input**：规范版本来自 Release tag `vX.Y.Z`；内部脚本只接收去除 `v` 后的精确 semver，并与每个 manifest 条目比较。
+- **Prepare result**：每个包返回 package name、version、绝对 tarball path 和 SHA-256；任何条目失败则没有 publish 阶段。
+- **Registry lookup**：仅“目标版本不存在”映射为 `missing`；存在映射为 `published`；其他错误映射为 `error` 并终止。
+- **Publish result**：每个条目仅有 `published` 或 `skipped-already-published`；失败通过非零退出码表示，不伪造成功摘要。
+
+## Risks / Trade-offs
+
+- [npm 不支持三个包原子发布] → 在上传前完成全量 prepare，并用幂等重跑缩小和恢复部分发布窗口。
+- [Trusted Publisher 的 workflow 文件名或 Environment 与 npm 配置不匹配] → 固定 workflow 文件名，在文档中记录精确配置，并让 OIDC 失败直接阻断发布。
+- [GitHub Release 被创建时源码版本未同步] → 发布前比较 tag、三个包名和版本，任何不一致都在 registry 写入前失败。
+- [registry 查询暂时失败被错误当作“未发布”] → 明确区分 404/不存在与网络、认证、限流错误，后者直接终止。
+- [prepare 后 publish 又触发 lifecycle 脚本造成字节变化] → 发布 prepare 阶段生成的 tarball，并用测试确认 publish tarball 不重新生成内容。
+- [第三方 GitHub Action 或缓存污染发布输入] → 使用官方 checkout/setup-node action，发布构建禁用 package-manager cache，并固定 lockfile 安装。
+- [源码仓库为私有时自动 provenance 不可用] → OIDC 发布仍可工作；测试和文档不把 provenance badge 作为私有仓库发布成功的必要条件。
+
+## Migration Plan
+
+1. 新增可测试的协同发布脚本和 package manifest，完成三个包的 prepare、版本校验和幂等 publish。
+2. 新增 `.github/workflows/publish-npm.yml`，配置 GitHub Release 触发、OIDC 权限和受支持工具链。
+3. 增加脚本/静态 workflow 测试，并执行三包 dry-run/pack 验收。
+4. 更新 release 与插件维护文档，要求发布准备同步三个版本并说明 Actions 重跑恢复流程。
+5. 在非生产版本或受控 Release 上验证 Trusted Publishing；确认三个 npm package 设置绑定精确 workflow 文件名后启用正式发布。
+
+回滚时删除或禁用 workflow 即可停止后续自动发布，不影响已发布包。已经写入 npm registry 的版本不可由自动化回滚；如出现部分发布，修复后重跑同一 Release 完成剩余包。
+
+## Open Questions
+
+无。npm Trusted Publisher 已配置；触发方式、版本同步、固定顺序、完整门禁和失败恢复策略已在 elaboration 中确定。

--- a/openspec/changes/archive/2026-08-31-automate-coordinated-npm-releases/proposal.md
+++ b/openspec/changes/archive/2026-08-31-automate-coordinated-npm-releases/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Chorus CLI、OpenClaw 插件和 dsh 插件目前需要维护者分别执行 npm 发布，认证依赖本地登录且三个发布单元容易出现版本或发布状态不一致。npm Trusted Publishing 已为三个包配置完成，因此现在可以把 GitHub Release 之后的校验、打包和发布收敛为一个无长期 npm token 的自动化流程。
+
+## What Changes
+
+- 新增一个由 GitHub Release `published` 事件触发的 GitHub Actions workflow，在同一次运行中处理 `@chorus-aidlc/chorus`、`@chorus-aidlc/chorus-openclaw-plugin` 和 `@chorus-aidlc/chorus-dsh`。
+- 使用 GitHub Actions OIDC 和 npm Trusted Publishing 获取短期发布身份；workflow 不读取或保存 `NPM_TOKEN`。
+- 在任何上传发生前校验 release tag、三个 `package.json` 的统一版本、工具链版本，并完成三个包的测试、构建、pack 和包内容检查。
+- 将已验证的 tarball 按固定顺序发布；发布前查询 npm registry，安全跳过已存在的同名同版本包，使部分成功的运行可以重跑。
+- 更新 Chorus release 流程和维护文档，使三包版本同步、GitHub Release 创建和自动 npm 发布成为同一发布契约。
+- 增加静态和 dry-run 测试，验证 workflow 权限、无 token 配置、包清单、版本门禁、失败停止及幂等恢复行为。
+
+## Capabilities
+
+### New Capabilities
+
+- `coordinated-npm-release`: 定义三个 Chorus npm 包通过 GitHub Release、OIDC Trusted Publishing、全量预检和幂等串行上传完成协同发布的行为。
+
+### Modified Capabilities
+
+无。
+
+## Impact
+
+- GitHub Actions：新增 `.github/workflows/publish-npm.yml`，需要 `contents: read` 与 `id-token: write`，并使用 GitHub 托管 runner。
+- 发布脚本：新增适合无交互 CI 的三包预检、打包、版本探测和上传编排；现有本地交互式脚本可继续作为维护者工具，但不作为 CI 入口。
+- npm 包：仓库根目录、`packages/openclaw-plugin`、`packages/chorus-dsh` 的版本和发布校验被纳入统一契约。
+- 文档与测试：release skill、维护说明及 workflow/脚本测试需要反映自动发布和安全重跑流程。
+- 外部系统：依赖 npm Trusted Publishing 配置、GitHub OIDC、npm registry 和 GitHub Release 事件；不新增长期凭证。

--- a/openspec/changes/archive/2026-08-31-automate-coordinated-npm-releases/specs/coordinated-npm-release/spec.md
+++ b/openspec/changes/archive/2026-08-31-automate-coordinated-npm-releases/specs/coordinated-npm-release/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Release-triggered coordinated publication
+The repository SHALL run one coordinated npm publication workflow when a GitHub Release is published, and the workflow MUST process exactly `@chorus-aidlc/chorus`, `@chorus-aidlc/chorus-openclaw-plugin`, and `@chorus-aidlc/chorus-dsh`.
+
+#### Scenario: Published GitHub Release starts publication
+- **WHEN** a maintainer publishes a GitHub Release for tag `vX.Y.Z`
+- **THEN** the coordinated workflow checks out that tag and prepares all three supported npm packages for version `X.Y.Z`
+
+#### Scenario: Non-release repository activity
+- **WHEN** commits or pull requests are created without publishing a GitHub Release
+- **THEN** the coordinated npm publication workflow does not publish any package
+
+### Requirement: Lockstep release identity
+The workflow MUST verify before any registry write that the release tag is a valid `vX.Y.Z` version and that all three supported package manifests have their expected package names and the exact version `X.Y.Z`.
+
+#### Scenario: All package identities match
+- **WHEN** the Release tag and all three package manifests contain the same valid version and expected names
+- **THEN** the workflow may continue to package preparation
+
+#### Scenario: A version or package name differs
+- **WHEN** any package version differs from the Release tag or any package name differs from the supported manifest
+- **THEN** the workflow fails before publishing any package
+
+### Requirement: Tokenless trusted publication
+The workflow SHALL authenticate npm publication through GitHub Actions OIDC and npm Trusted Publishing, MUST grant only `contents: read` and `id-token: write` permissions needed by the release job, and MUST NOT require an npm access token in repository or environment secrets.
+
+#### Scenario: Trusted Publisher is correctly configured
+- **WHEN** the workflow runs on a GitHub-hosted runner with a supported Node and npm CLI and invokes `npm publish`
+- **THEN** npm obtains a short-lived OIDC-backed publishing credential without `NPM_TOKEN` or `NODE_AUTH_TOKEN`
+
+#### Scenario: OIDC trust configuration does not match
+- **WHEN** npm rejects the workflow identity because repository, workflow filename, Environment, or allowed action differs from the Trusted Publisher configuration
+- **THEN** publication fails and the workflow does not fall back to a stored npm token
+
+### Requirement: Complete pre-publication gate
+The workflow MUST complete applicable lint, typecheck, test, build, package-content validation, and tarball creation for all three packages before uploading the first package.
+
+#### Scenario: All package gates pass
+- **WHEN** every package passes its required checks and produces a validated tarball
+- **THEN** the workflow enters the publication phase using those validated tarballs
+
+#### Scenario: Any package gate fails
+- **WHEN** a check, build, package validation, or tarball creation fails for any supported package
+- **THEN** the workflow stops before any npm registry write
+
+### Requirement: Deterministic sequential publication
+The workflow MUST publish validated tarballs in the fixed order Chorus CLI, OpenClaw plugin, then dsh plugin, and MUST stop attempting later unpublished packages after an upload failure.
+
+#### Scenario: All versions are unpublished
+- **WHEN** all three validated package versions are absent from npm
+- **THEN** the workflow publishes the three tarballs in the configured order and reports each as published
+
+#### Scenario: A package upload fails
+- **WHEN** npm rejects or cannot complete one package upload
+- **THEN** the workflow fails immediately and does not attempt later unpublished packages
+
+### Requirement: Idempotent recovery after partial publication
+Before each upload, the workflow MUST query the exact package name and version, skip only versions confirmed as already published, and treat lookup errors other than confirmed absence as fatal.
+
+#### Scenario: Rerun after one package succeeded
+- **WHEN** the workflow is rerun for the same Release and the first package version already exists while the remaining versions do not
+- **THEN** the workflow records the first package as `skipped-already-published` and continues with the remaining packages in order
+
+#### Scenario: Registry lookup is unavailable or unauthorized
+- **WHEN** the workflow cannot reliably determine whether a package version exists because of a network, authorization, or rate-limit error
+- **THEN** the workflow fails without attempting that package upload
+
+### Requirement: Auditable release result
+The workflow MUST expose a final summary containing the Release version and the published or skipped state of every processed package, and MUST avoid logging credentials or OIDC tokens.
+
+#### Scenario: Successful fresh publication
+- **WHEN** all three packages are newly published
+- **THEN** the job summary identifies all three package names and versions as published
+
+#### Scenario: Successful recovery rerun
+- **WHEN** one or more packages are skipped because their exact versions already exist and all remaining packages publish successfully
+- **THEN** the job summary distinguishes skipped packages from newly published packages without exposing authentication material

--- a/openspec/changes/archive/2026-08-31-automate-coordinated-npm-releases/tasks.md
+++ b/openspec/changes/archive/2026-08-31-automate-coordinated-npm-releases/tasks.md
@@ -1,0 +1,9 @@
+## 1. Coordinated Release Automation
+
+- [x] 1.1 Implement the non-interactive release manifest and scripts that validate the GitHub Release version against all three package identities, run every package's applicable quality and package-content gates, create deterministic tarballs before publication, and publish them in fixed order with strict registry-error classification and idempotent skip behavior.
+- [x] 1.2 Add `.github/workflows/publish-npm.yml` with GitHub Release triggering, GitHub-hosted Node/npm setup, minimal OIDC permissions, no npm token references, full prepare-before-publish orchestration, and an auditable package result summary.
+
+## 2. Verification and Release Integration
+
+- [x] 2.1 Add automated tests for version/name drift, all-three prepare gating, exact package order, already-published recovery, lookup and publish failure stopping, workflow permission/token invariants, tarball contents, and dry-run behavior.
+- [x] 2.2 Update release and plugin-maintenance guidance so release preparation synchronizes all three package versions, documents the exact Trusted Publisher workflow contract, and explains GitHub Actions rerun recovery; execute the complete three-package dry-run and record verification evidence.

--- a/openspec/specs/coordinated-npm-release/spec.md
+++ b/openspec/specs/coordinated-npm-release/spec.md
@@ -1,0 +1,81 @@
+# coordinated-npm-release Specification
+
+## Purpose
+TBD - created by archiving change automate-coordinated-npm-releases. Update Purpose after archive.
+## Requirements
+### Requirement: Release-triggered coordinated publication
+The repository SHALL run one coordinated npm publication workflow when a GitHub Release is published, and the workflow MUST process exactly `@chorus-aidlc/chorus`, `@chorus-aidlc/chorus-openclaw-plugin`, and `@chorus-aidlc/chorus-dsh`.
+
+#### Scenario: Published GitHub Release starts publication
+- **WHEN** a maintainer publishes a GitHub Release for tag `vX.Y.Z`
+- **THEN** the coordinated workflow checks out that tag and prepares all three supported npm packages for version `X.Y.Z`
+
+#### Scenario: Non-release repository activity
+- **WHEN** commits or pull requests are created without publishing a GitHub Release
+- **THEN** the coordinated npm publication workflow does not publish any package
+
+### Requirement: Lockstep release identity
+The workflow MUST verify before any registry write that the release tag is a valid `vX.Y.Z` version and that all three supported package manifests have their expected package names and the exact version `X.Y.Z`.
+
+#### Scenario: All package identities match
+- **WHEN** the Release tag and all three package manifests contain the same valid version and expected names
+- **THEN** the workflow may continue to package preparation
+
+#### Scenario: A version or package name differs
+- **WHEN** any package version differs from the Release tag or any package name differs from the supported manifest
+- **THEN** the workflow fails before publishing any package
+
+### Requirement: Tokenless trusted publication
+The workflow SHALL authenticate npm publication through GitHub Actions OIDC and npm Trusted Publishing, MUST grant only `contents: read` and `id-token: write` permissions needed by the release job, and MUST NOT require an npm access token in repository or environment secrets.
+
+#### Scenario: Trusted Publisher is correctly configured
+- **WHEN** the workflow runs on a GitHub-hosted runner with a supported Node and npm CLI and invokes `npm publish`
+- **THEN** npm obtains a short-lived OIDC-backed publishing credential without `NPM_TOKEN` or `NODE_AUTH_TOKEN`
+
+#### Scenario: OIDC trust configuration does not match
+- **WHEN** npm rejects the workflow identity because repository, workflow filename, Environment, or allowed action differs from the Trusted Publisher configuration
+- **THEN** publication fails and the workflow does not fall back to a stored npm token
+
+### Requirement: Complete pre-publication gate
+The workflow MUST complete applicable lint, typecheck, test, build, package-content validation, and tarball creation for all three packages before uploading the first package.
+
+#### Scenario: All package gates pass
+- **WHEN** every package passes its required checks and produces a validated tarball
+- **THEN** the workflow enters the publication phase using those validated tarballs
+
+#### Scenario: Any package gate fails
+- **WHEN** a check, build, package validation, or tarball creation fails for any supported package
+- **THEN** the workflow stops before any npm registry write
+
+### Requirement: Deterministic sequential publication
+The workflow MUST publish validated tarballs in the fixed order Chorus CLI, OpenClaw plugin, then dsh plugin, and MUST stop attempting later unpublished packages after an upload failure.
+
+#### Scenario: All versions are unpublished
+- **WHEN** all three validated package versions are absent from npm
+- **THEN** the workflow publishes the three tarballs in the configured order and reports each as published
+
+#### Scenario: A package upload fails
+- **WHEN** npm rejects or cannot complete one package upload
+- **THEN** the workflow fails immediately and does not attempt later unpublished packages
+
+### Requirement: Idempotent recovery after partial publication
+Before each upload, the workflow MUST query the exact package name and version, skip only versions confirmed as already published, and treat lookup errors other than confirmed absence as fatal.
+
+#### Scenario: Rerun after one package succeeded
+- **WHEN** the workflow is rerun for the same Release and the first package version already exists while the remaining versions do not
+- **THEN** the workflow records the first package as `skipped-already-published` and continues with the remaining packages in order
+
+#### Scenario: Registry lookup is unavailable or unauthorized
+- **WHEN** the workflow cannot reliably determine whether a package version exists because of a network, authorization, or rate-limit error
+- **THEN** the workflow fails without attempting that package upload
+
+### Requirement: Auditable release result
+The workflow MUST expose a final summary containing the Release version and the published or skipped state of every processed package, and MUST avoid logging credentials or OIDC tokens.
+
+#### Scenario: Successful fresh publication
+- **WHEN** all three packages are newly published
+- **THEN** the job summary identifies all three package names and versions as published
+
+#### Scenario: Successful recovery rerun
+- **WHEN** one or more packages are skipped because their exact versions already exist and all remaining packages publish successfully
+- **THEN** the job summary distinguishes skipped packages from newly published packages without exposing authentication material

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "landing:build": "pnpm --filter chorus-landing run build",
     "landing:preview": "pnpm --filter chorus-landing run preview",
     "test": "vitest run",
+    "test:release-contract": "node --test scripts/coordinated-npm-release/__tests__/coordinated-npm-release.test.mjs",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "prepack": "pnpm build && node scripts/prepack-pglite.mjs"

--- a/packages/chorus-dsh/scripts/check-pack.sh
+++ b/packages/chorus-dsh/scripts/check-pack.sh
@@ -13,7 +13,7 @@ tar -tzf "$tarball" >"$tmp/files.txt"
 for file in package/bin/chorus-mcp-call.mjs package/dist/chorus-dsh.mjs package/dist/index.d.ts package/dist/persona.mjs package/dist/persona.d.ts package/cordis.patch.yml package/README.md; do
   grep -Fx "$file" "$tmp/files.txt" >/dev/null
 done
-test "$(grep -Ec '^package/skills/[^/]+/SKILL[.]md$' "$tmp/files.txt")" -eq 14
+test "$(grep -Ec '^package/skills/[^/]+/SKILL[.]md$' "$tmp/files.txt")" -eq 15
 
 if grep -Eq 'install-dsh|agent-presets|instructions/AGENTS|public/chorus-dsh' "$tmp/files.txt"; then
   echo "legacy installer or copied-home artifact found in tarball" >&2

--- a/packages/openclaw-plugin/package-lock.json
+++ b/packages/openclaw-plugin/package-lock.json
@@ -1,0 +1,8697 @@
+{
+  "name": "@chorus-aidlc/chorus-openclaw-plugin",
+  "version": "0.17.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@chorus-aidlc/chorus-openclaw-plugin",
+      "version": "0.17.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.26.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.0",
+        "vitest": "^3.2.0"
+      },
+      "peerDependencies": {
+        "openclaw": ">=2026.0.0"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "0.14.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.73.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock": {
+      "version": "3.1001.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.16",
+        "@aws-sdk/credential-provider-node": "^3.972.15",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.16",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/token-providers": "3.1001.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.1",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/core": "^3.23.7",
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/hash-node": "^4.2.10",
+        "@smithy/invalid-dependency": "^4.2.10",
+        "@smithy/middleware-content-length": "^4.2.10",
+        "@smithy/middleware-endpoint": "^4.4.21",
+        "@smithy/middleware-retry": "^4.4.38",
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/middleware-stack": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/node-http-handler": "^4.4.13",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-body-length-node": "^4.2.2",
+        "@smithy/util-defaults-mode-browser": "^4.3.37",
+        "@smithy/util-defaults-mode-node": "^4.2.40",
+        "@smithy/util-endpoints": "^3.3.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-retry": "^4.2.10",
+        "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1001.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.16",
+        "@aws-sdk/credential-provider-node": "^3.972.15",
+        "@aws-sdk/eventstream-handler-node": "^3.972.9",
+        "@aws-sdk/middleware-eventstream": "^3.972.6",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.16",
+        "@aws-sdk/middleware-websocket": "^3.972.11",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/token-providers": "3.1001.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.1",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/core": "^3.23.7",
+        "@smithy/eventstream-serde-browser": "^4.2.10",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.10",
+        "@smithy/eventstream-serde-node": "^4.2.10",
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/hash-node": "^4.2.10",
+        "@smithy/invalid-dependency": "^4.2.10",
+        "@smithy/middleware-content-length": "^4.2.10",
+        "@smithy/middleware-endpoint": "^4.4.21",
+        "@smithy/middleware-retry": "^4.4.38",
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/middleware-stack": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/node-http-handler": "^4.4.13",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-body-length-node": "^4.2.2",
+        "@smithy/util-defaults-mode-browser": "^4.3.37",
+        "@smithy/util-defaults-mode-node": "^4.2.40",
+        "@smithy/util-endpoints": "^3.3.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-retry": "^4.2.10",
+        "@smithy/util-stream": "^4.5.16",
+        "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.973.16",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/xml-builder": "^3.972.9",
+        "@smithy/core": "^3.23.7",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/signature-v4": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.14",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.16",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.16",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.16",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/node-http-handler": "^4.4.13",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.16",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.14",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.16",
+        "@aws-sdk/credential-provider-env": "^3.972.14",
+        "@aws-sdk/credential-provider-http": "^3.972.16",
+        "@aws-sdk/credential-provider-login": "^3.972.14",
+        "@aws-sdk/credential-provider-process": "^3.972.14",
+        "@aws-sdk/credential-provider-sso": "^3.972.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.14",
+        "@aws-sdk/nested-clients": "^3.996.4",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/credential-provider-imds": "^4.2.10",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.14",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.16",
+        "@aws-sdk/nested-clients": "^3.996.4",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.15",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.14",
+        "@aws-sdk/credential-provider-http": "^3.972.16",
+        "@aws-sdk/credential-provider-ini": "^3.972.14",
+        "@aws-sdk/credential-provider-process": "^3.972.14",
+        "@aws-sdk/credential-provider-sso": "^3.972.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.14",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/credential-provider-imds": "^4.2.10",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.14",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.16",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.14",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.16",
+        "@aws-sdk/nested-clients": "^3.996.4",
+        "@aws-sdk/token-providers": "3.1001.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.14",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.16",
+        "@aws-sdk/nested-clients": "^3.996.4",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.9",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/eventstream-codec": "^4.2.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.6",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.6",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.6",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.6",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.4",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.16",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.16",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@smithy/core": "^3.23.7",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.11",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-format-url": "^3.972.6",
+        "@smithy/eventstream-codec": "^4.2.10",
+        "@smithy/eventstream-serde-browser": "^4.2.10",
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/signature-v4": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-hex-encoding": "^4.2.1",
+        "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.4",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.16",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.16",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.1",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/core": "^3.23.7",
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/hash-node": "^4.2.10",
+        "@smithy/invalid-dependency": "^4.2.10",
+        "@smithy/middleware-content-length": "^4.2.10",
+        "@smithy/middleware-endpoint": "^4.4.21",
+        "@smithy/middleware-retry": "^4.4.38",
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/middleware-stack": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/node-http-handler": "^4.4.13",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-body-length-node": "^4.2.2",
+        "@smithy/util-defaults-mode-browser": "^4.3.37",
+        "@smithy/util-defaults-mode-node": "^4.2.40",
+        "@smithy/util-endpoints": "^3.3.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-retry": "^4.2.10",
+        "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.6",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1001.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.16",
+        "@aws-sdk/nested-clients": "^3.996.4",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.4",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.3",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-endpoints": "^3.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.6",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/querystring-builder": "^4.2.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.4",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.6",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/types": "^4.13.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.16",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.9",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "fast-xml-parser": "5.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.3",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.1",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@buape/carbon": {
+      "version": "0.0.0-beta-20260216184201",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^25.0.9",
+        "discord-api-types": "0.38.37"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workers-types": "4.20260120.0",
+        "@discordjs/voice": "0.19.0",
+        "@hono/node-server": "1.19.9",
+        "@types/bun": "1.3.9",
+        "@types/ws": "8.18.1",
+        "ws": "8.19.0"
+      }
+    },
+    "node_modules/@buape/carbon/node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@buape/carbon/node_modules/discord-api-types": {
+      "version": "0.38.37",
+      "license": "MIT",
+      "peer": true,
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.8",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@cacheable/utils": "^2.4.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/node-cache": {
+      "version": "1.7.6",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cacheable": "^2.3.1",
+        "hookified": "^1.14.0",
+        "keyv": "^5.5.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.4.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hashery": "^1.5.0",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@clack/core": "1.1.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260120.0",
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@discordjs/node-pre-gyp": {
+      "version": "0.4.5",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/agent-base": {
+      "version": "6.0.2",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/chownr": {
+      "version": "2.0.0",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/minipass": {
+      "version": "5.0.0",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/minizlib": {
+      "version": "2.1.2",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/tar": {
+      "version": "6.2.1",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/yallist": {
+      "version": "4.0.0",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@discordjs/opus": {
+      "version": "0.10.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@discordjs/node-pre-gyp": "^0.4.5",
+        "node-addon-api": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@discordjs/voice": {
+      "version": "0.19.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/ws": "^8.18.1",
+        "discord-api-types": "^0.38.16",
+        "prism-media": "^1.3.5",
+        "tslib": "^2.8.1",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/voice/node_modules/opusscript": {
+      "version": "0.0.8",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@discordjs/voice/node_modules/prism-media": {
+      "version": "1.3.5",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "@discordjs/opus": ">=0.8.0 <1.0.0",
+        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
+        "node-opus": "^0.3.3",
+        "opusscript": "^0.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@discordjs/opus": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "node-opus": {
+          "optional": true
+        },
+        "opusscript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.43.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@grammyjs/runner": {
+      "version": "2.0.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.20.0 || >=14.13.1"
+      },
+      "peerDependencies": {
+        "grammy": "^1.13.1"
+      }
+    },
+    "node_modules/@grammyjs/transformer-throttler": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bottleneck": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      },
+      "peerDependencies": {
+        "grammy": "^1.0.0"
+      }
+    },
+    "node_modules/@grammyjs/types": {
+      "version": "3.25.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@homebridge/ciao": {
+      "version": "1.3.5",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "fast-deep-equal": "^3.1.3",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1"
+      },
+      "bin": {
+        "ciao-bcs": "lib/bonjour-conformance-testing.js"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.10",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.5",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@larksuiteoapi/node-sdk": {
+      "version": "1.59.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "axios": "~1.13.3",
+        "lodash.identity": "^3.0.0",
+        "lodash.merge": "^4.6.2",
+        "lodash.pickby": "^4.6.0",
+        "protobufjs": "^7.2.6",
+        "qs": "^6.14.2",
+        "ws": "^8.19.0"
+      }
+    },
+    "node_modules/@line/bot-sdk": {
+      "version": "10.6.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^24.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "axios": "^1.7.4"
+      }
+    },
+    "node_modules/@line/bot-sdk/node_modules/@types/node": {
+      "version": "24.11.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@line/bot-sdk/node_modules/undici-types": {
+      "version": "7.16.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@lydell/node-pty": {
+      "version": "1.2.0-beta.3",
+      "license": "MIT",
+      "peer": true,
+      "optionalDependencies": {
+        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.3",
+        "@lydell/node-pty-darwin-x64": "1.2.0-beta.3",
+        "@lydell/node-pty-linux-arm64": "1.2.0-beta.3",
+        "@lydell/node-pty-linux-x64": "1.2.0-beta.3",
+        "@lydell/node-pty-win32-arm64": "1.2.0-beta.3",
+        "@lydell/node-pty-win32-x64": "1.2.0-beta.3"
+      }
+    },
+    "node_modules/@lydell/node-pty-linux-x64": {
+      "version": "1.2.0-beta.3",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@mariozechner/clipboard": {
+      "version": "0.3.2",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.2",
+        "@mariozechner/clipboard-darwin-universal": "0.3.2",
+        "@mariozechner/clipboard-darwin-x64": "0.3.2",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.2",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.2",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/jiti": {
+      "version": "2.6.5",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "std-env": "^3.10.0",
+        "yoctocolors": "^2.1.2"
+      },
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@mariozechner/pi-agent-core": {
+      "version": "0.55.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@mariozechner/pi-ai": "^0.55.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mariozechner/pi-ai": {
+      "version": "0.55.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.73.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.983.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "1.10.0",
+        "@sinclair/typebox": "^0.34.41",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "chalk": "^5.6.2",
+        "openai": "6.10.0",
+        "partial-json": "^0.1.7",
+        "proxy-agent": "^6.5.0",
+        "undici": "^7.19.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent": {
+      "version": "0.55.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@mariozechner/jiti": "^2.6.2",
+        "@mariozechner/pi-agent-core": "^0.55.3",
+        "@mariozechner/pi-ai": "^0.55.3",
+        "@mariozechner/pi-tui": "^0.55.3",
+        "@silvia-odwyer/photon-node": "^0.3.4",
+        "chalk": "^5.5.0",
+        "cli-highlight": "^2.1.11",
+        "diff": "^8.0.2",
+        "extract-zip": "^2.0.1",
+        "file-type": "^21.1.1",
+        "glob": "^13.0.1",
+        "hosted-git-info": "^9.0.2",
+        "ignore": "^7.0.5",
+        "marked": "^15.0.12",
+        "minimatch": "^10.2.3",
+        "proper-lockfile": "^4.1.2",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "^0.3.2"
+      }
+    },
+    "node_modules/@mariozechner/pi-tui": {
+      "version": "0.55.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mime-types": "^2.1.4",
+        "chalk": "^5.5.0",
+        "get-east-asian-width": "^1.3.0",
+        "koffi": "^2.9.0",
+        "marked": "^15.0.12",
+        "mime-types": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "1.10.0",
+      "peer": true,
+      "dependencies": {
+        "zod": "^3.20.0",
+        "zod-to-json-schema": "^3.24.1"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@mozilla/readability": {
+      "version": "0.6.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.95",
+      "license": "MIT",
+      "peer": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.95",
+        "@napi-rs/canvas-darwin-arm64": "0.1.95",
+        "@napi-rs/canvas-darwin-x64": "0.1.95",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.95",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.95",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.95",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.95",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.95",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.95",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.95",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.95"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.95",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-arm64": {
+      "version": "3.16.2",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-armv7l": {
+      "version": "3.16.2",
+      "cpu": [
+        "arm",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64": {
+      "version": "3.16.2",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-cuda": {
+      "version": "3.16.2",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-cuda-ext": {
+      "version": "3.16.2",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-vulkan": {
+      "version": "3.16.2",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@octokit/app": {
+      "version": "16.1.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/auth-app": "^8.1.2",
+        "@octokit/auth-unauthenticated": "^7.0.3",
+        "@octokit/core": "^7.0.6",
+        "@octokit/oauth-app": "^8.0.3",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/types": "^16.0.0",
+        "@octokit/webhooks": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-app": {
+      "version": "8.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^9.0.3",
+        "@octokit/auth-oauth-user": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "toad-cache": "^3.7.0",
+        "universal-github-app-jwt": "^2.2.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "9.0.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.3",
+        "@octokit/auth-oauth-user": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "8.0.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/oauth-methods": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "6.0.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.3",
+        "@octokit/oauth-methods": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-unauthenticated": {
+      "version": "7.0.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-app": {
+      "version": "8.0.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^9.0.2",
+        "@octokit/auth-oauth-user": "^6.0.1",
+        "@octokit/auth-unauthenticated": "^7.0.2",
+        "@octokit/core": "^7.0.5",
+        "@octokit/oauth-authorization-url": "^8.0.0",
+        "@octokit/oauth-methods": "^6.0.1",
+        "@types/aws-lambda": "^8.10.83",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "8.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "6.0.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^8.0.0",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@octokit/openapi-webhooks-types": {
+      "version": "12.1.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@octokit/plugin-paginate-graphql": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "8.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=7"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "11.0.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^7.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.8",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "14.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/openapi-webhooks-types": "12.1.0",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/webhooks-methods": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/webhooks-methods": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@reflink/reflink": {
+      "version": "0.1.19",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@reflink/reflink-darwin-arm64": "0.1.19",
+        "@reflink/reflink-darwin-x64": "0.1.19",
+        "@reflink/reflink-linux-arm64-gnu": "0.1.19",
+        "@reflink/reflink-linux-arm64-musl": "0.1.19",
+        "@reflink/reflink-linux-x64-gnu": "0.1.19",
+        "@reflink/reflink-linux-x64-musl": "0.1.19",
+        "@reflink/reflink-win32-arm64-msvc": "0.1.19",
+        "@reflink/reflink-win32-x64-msvc": "0.1.19"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-x64-gnu": {
+      "version": "0.1.19",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.48",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@slack/bolt": {
+      "version": "4.6.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@slack/logger": "^4.0.0",
+        "@slack/oauth": "^3.0.4",
+        "@slack/socket-mode": "^2.0.5",
+        "@slack/types": "^2.18.0",
+        "@slack/web-api": "^7.12.0",
+        "axios": "^1.12.0",
+        "express": "^5.0.0",
+        "path-to-regexp": "^8.1.0",
+        "raw-body": "^3",
+        "tsscmp": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=8.6.0"
+      },
+      "peerDependencies": {
+        "@types/express": "^5.0.0"
+      }
+    },
+    "node_modules/@slack/logger": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": ">=18.0.0"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/oauth": {
+      "version": "3.0.4",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@slack/logger": "^4",
+        "@slack/web-api": "^7.10.0",
+        "@types/jsonwebtoken": "^9",
+        "@types/node": ">=18",
+        "jsonwebtoken": "^9"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=8.6.0"
+      }
+    },
+    "node_modules/@slack/socket-mode": {
+      "version": "2.0.5",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@slack/logger": "^4",
+        "@slack/web-api": "^7.10.0",
+        "@types/node": ">=18",
+        "@types/ws": "^8",
+        "eventemitter3": "^5",
+        "ws": "^8"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.20.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.14.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@slack/logger": "^4.0.0",
+        "@slack/types": "^2.20.0",
+        "@types/node": ">=18.0.0",
+        "@types/retry": "0.12.0",
+        "axios": "^1.13.5",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.4",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.9",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-config-provider": "^4.2.1",
+        "@smithy/util-endpoints": "^3.3.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.7",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-stream": "^4.5.16",
+        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/uuid": "^1.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.12",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/querystring-builder": "^4.2.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-buffer-from": "^4.2.1",
+        "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.21",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.23.7",
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-middleware": "^4.2.10",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.38",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/service-error-classification": "^4.2.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-retry": "^4.2.10",
+        "@smithy/uuid": "^1.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.11",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.4.13",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.10",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/querystring-builder": "^4.2.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.5",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.1",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-uri-escape": "^4.2.1",
+        "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.23.7",
+        "@smithy/middleware-endpoint": "^4.4.21",
+        "@smithy/middleware-stack": "^4.2.10",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.16",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.13.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.1",
+        "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.2",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.37",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.40",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/credential-provider-imds": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.3.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.10",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.10",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.16",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/node-http-handler": "^4.4.13",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-buffer-from": "^4.2.1",
+        "@smithy/util-hex-encoding": "^4.2.1",
+        "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@snazzah/davey": {
+      "version": "0.1.10",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Snazzah"
+      },
+      "optionalDependencies": {
+        "@snazzah/davey-android-arm-eabi": "0.1.10",
+        "@snazzah/davey-android-arm64": "0.1.10",
+        "@snazzah/davey-darwin-arm64": "0.1.10",
+        "@snazzah/davey-darwin-x64": "0.1.10",
+        "@snazzah/davey-freebsd-x64": "0.1.10",
+        "@snazzah/davey-linux-arm-gnueabihf": "0.1.10",
+        "@snazzah/davey-linux-arm64-gnu": "0.1.10",
+        "@snazzah/davey-linux-arm64-musl": "0.1.10",
+        "@snazzah/davey-linux-x64-gnu": "0.1.10",
+        "@snazzah/davey-linux-x64-musl": "0.1.10",
+        "@snazzah/davey-wasm32-wasi": "0.1.10",
+        "@snazzah/davey-win32-arm64-msvc": "0.1.10",
+        "@snazzah/davey-win32-ia32-msvc": "0.1.10",
+        "@snazzah/davey-win32-x64-msvc": "0.1.10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-x64-gnu": {
+      "version": "0.1.10",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tinyhttp/content-disposition": {
+      "version": "2.2.4",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/tinyhttp/tinyhttp?sponsor=1"
+      }
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.161",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.9",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "bun-types": "1.3.9"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mime-types": {
+      "version": "2.1.4",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@whiskeysockets/baileys": {
+      "version": "7.0.0-rc.9",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@cacheable/node-cache": "^1.4.0",
+        "@hapi/boom": "^9.1.3",
+        "async-mutex": "^0.5.0",
+        "libsignal": "git+https://github.com/whiskeysockets/libsignal-node",
+        "lru-cache": "^11.1.0",
+        "music-metadata": "^11.7.0",
+        "p-queue": "^9.0.0",
+        "pino": "^9.6",
+        "protobufjs": "^7.2.4",
+        "ws": "^8.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "audio-decode": "^2.1.3",
+        "jimp": "^1.6.0",
+        "link-preview-js": "^3.0.0",
+        "sharp": "*"
+      },
+      "peerDependenciesMeta": {
+        "audio-decode": {
+          "optional": true
+        },
+        "jimp": {
+          "optional": true
+        },
+        "link-preview-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@whiskeysockets/baileys/node_modules/libsignal": {
+      "version": "6.0.0",
+      "resolved": "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#bcea72df9ec34d9d9140ab30619cf479c7c144c7",
+      "license": "GPL-3.0",
+      "peer": true,
+      "dependencies": {
+        "curve25519-js": "^0.0.4",
+        "protobufjs": "^7.5.5"
+      }
+    },
+    "node_modules/@whiskeysockets/baileys/node_modules/p-queue": {
+      "version": "9.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@whiskeysockets/baileys/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "license": "Python-2.0",
+      "peer": true
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.2.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.9",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.3.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.6.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chmodrp": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/chalk": {
+      "version": "4.1.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/cliui": {
+      "version": "7.0.4",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs": {
+      "version": "16.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cmake-js": {
+      "version": "8.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "fs-extra": "^11.3.3",
+        "node-api-headers": "^1.8.0",
+        "rc": "1.2.8",
+        "semver": "^7.7.3",
+        "tar": "^7.5.6",
+        "url-join": "^4.0.1",
+        "which": "^6.0.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "cmake-js": "bin/cmake-js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/isexe": {
+      "version": "4.0.0",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cmake-js/node_modules/which": {
+      "version": "6.0.1",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/croner": {
+      "version": "10.0.1",
+      "funding": [
+        {
+          "type": "other",
+          "url": "https://paypal.me/hexagonpp"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/hexagon"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/curve25519-js": {
+      "version": "0.0.4",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.3",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.40",
+      "license": "MIT",
+      "peer": true,
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-var": {
+      "version": "7.5.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "license": "MIT"
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gauge/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.3",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/gaxios/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/gaxios/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/gaxios/node_modules/glob": {
+      "version": "10.5.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gaxios/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/gaxios/node_modules/minimatch": {
+      "version": "9.0.9",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gaxios/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gaxios/node_modules/rimraf": {
+      "version": "5.0.10",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.1",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "7.1.3",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/grammy": {
+      "version": "1.41.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@grammyjs/types": "3.25.0",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.4.3",
+        "node-fetch": "^2.7.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/hashery": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hookified": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/hosted-git-info": {
+      "version": "9.0.2",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/ipull": {
+      "version": "3.9.5",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tinyhttp/content-disposition": "^2.2.0",
+        "async-retry": "^1.3.3",
+        "chalk": "^5.3.0",
+        "ci-info": "^4.0.0",
+        "cli-spinners": "^2.9.2",
+        "commander": "^10.0.0",
+        "eventemitter3": "^5.0.1",
+        "filenamify": "^6.0.0",
+        "fs-extra": "^11.1.1",
+        "is-unicode-supported": "^2.0.0",
+        "lifecycle-utils": "^2.0.1",
+        "lodash.debounce": "^4.0.8",
+        "lowdb": "^7.0.1",
+        "pretty-bytes": "^6.1.0",
+        "pretty-ms": "^8.0.0",
+        "sleep-promise": "^9.1.0",
+        "slice-ansi": "^7.1.0",
+        "stdout-update": "^4.0.1",
+        "strip-ansi": "^7.1.0"
+      },
+      "bin": {
+        "ipull": "dist/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/ido-pluto/ipull?sponsor=1"
+      },
+      "optionalDependencies": {
+        "@reflink/reflink": "^0.1.16"
+      }
+    },
+    "node_modules/ipull/node_modules/lifecycle-utils": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ipull/node_modules/parse-ms": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipull/node_modules/pretty-ms": {
+      "version": "8.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "parse-ms": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipull/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.7",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "peer": true,
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "5.6.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "2.15.1",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lifecycle-utils": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.12",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.0.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.identity": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.pickby": {
+      "version": "4.6.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/log-symbols": {
+      "version": "7.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lowdb": {
+      "version": "7.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "steno": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.6",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "license": "MIT"
+    },
+    "node_modules/music-metadata": {
+      "version": "11.12.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Borewit"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/borewit"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "file-type": "^21.3.0",
+        "media-typer": "^1.1.0",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0",
+        "win-guid": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.6",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.6.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-api-headers": {
+      "version": "1.8.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/node-domexception": {
+      "name": "@nolyfill/domexception",
+      "version": "1.0.28",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
+    "node_modules/node-edge-tts": {
+      "version": "1.2.10",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "https-proxy-agent": "^7.0.1",
+        "ws": "^8.13.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "node-edge-tts": "bin.js"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-llama-cpp": {
+      "version": "3.16.2",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.5",
+        "async-retry": "^1.3.3",
+        "bytes": "^3.1.2",
+        "chalk": "^5.6.2",
+        "chmodrp": "^1.0.2",
+        "cmake-js": "^8.0.0",
+        "cross-spawn": "^7.0.6",
+        "env-var": "^7.5.0",
+        "filenamify": "^6.0.0",
+        "fs-extra": "^11.3.0",
+        "ignore": "^7.0.4",
+        "ipull": "^3.9.5",
+        "is-unicode-supported": "^2.1.0",
+        "lifecycle-utils": "^3.1.1",
+        "log-symbols": "^7.0.1",
+        "nanoid": "^5.1.6",
+        "node-addon-api": "^8.5.0",
+        "octokit": "^5.0.5",
+        "ora": "^9.3.0",
+        "pretty-ms": "^9.3.0",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.7.1",
+        "simple-git": "^3.31.1",
+        "slice-ansi": "^8.0.0",
+        "stdout-update": "^4.0.1",
+        "strip-ansi": "^7.1.2",
+        "validate-npm-package-name": "^7.0.2",
+        "which": "^6.0.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "nlc": "dist/cli/cli.js",
+        "node-llama-cpp": "dist/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/giladgd"
+      },
+      "optionalDependencies": {
+        "@node-llama-cpp/linux-arm64": "3.16.2",
+        "@node-llama-cpp/linux-armv7l": "3.16.2",
+        "@node-llama-cpp/linux-x64": "3.16.2",
+        "@node-llama-cpp/linux-x64-cuda": "3.16.2",
+        "@node-llama-cpp/linux-x64-cuda-ext": "3.16.2",
+        "@node-llama-cpp/linux-x64-vulkan": "3.16.2",
+        "@node-llama-cpp/mac-arm64-metal": "3.16.2",
+        "@node-llama-cpp/mac-x64": "3.16.2",
+        "@node-llama-cpp/win-arm64": "3.16.2",
+        "@node-llama-cpp/win-x64": "3.16.2",
+        "@node-llama-cpp/win-x64-cuda": "3.16.2",
+        "@node-llama-cpp/win-x64-cuda-ext": "3.16.2",
+        "@node-llama-cpp/win-x64-vulkan": "3.16.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/isexe": {
+      "version": "4.0.0",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/which": {
+      "version": "6.0.1",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/octokit": {
+      "version": "5.0.5",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/app": "^16.1.2",
+        "@octokit/core": "^7.0.6",
+        "@octokit/oauth-app": "^8.0.3",
+        "@octokit/plugin-paginate-graphql": "^6.0.0",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+        "@octokit/plugin-retry": "^8.0.3",
+        "@octokit/plugin-throttling": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "@octokit/webhooks": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.10.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openclaw": {
+      "version": "2026.3.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@agentclientprotocol/sdk": "0.14.1",
+        "@aws-sdk/client-bedrock": "^3.1000.0",
+        "@buape/carbon": "0.0.0-beta-20260216184201",
+        "@clack/prompts": "^1.0.1",
+        "@discordjs/voice": "^0.19.0",
+        "@grammyjs/runner": "^2.0.3",
+        "@grammyjs/transformer-throttler": "^1.2.1",
+        "@homebridge/ciao": "^1.3.5",
+        "@larksuiteoapi/node-sdk": "^1.59.0",
+        "@line/bot-sdk": "^10.6.0",
+        "@lydell/node-pty": "1.2.0-beta.3",
+        "@mariozechner/pi-agent-core": "0.55.3",
+        "@mariozechner/pi-ai": "0.55.3",
+        "@mariozechner/pi-coding-agent": "0.55.3",
+        "@mariozechner/pi-tui": "0.55.3",
+        "@mozilla/readability": "^0.6.0",
+        "@sinclair/typebox": "0.34.48",
+        "@slack/bolt": "^4.6.0",
+        "@slack/web-api": "^7.14.1",
+        "@snazzah/davey": "^0.1.9",
+        "@whiskeysockets/baileys": "7.0.0-rc.9",
+        "ajv": "^8.18.0",
+        "chalk": "^5.6.2",
+        "chokidar": "^5.0.0",
+        "cli-highlight": "^2.1.11",
+        "commander": "^14.0.3",
+        "croner": "^10.0.1",
+        "discord-api-types": "^0.38.40",
+        "dotenv": "^17.3.1",
+        "express": "^5.2.1",
+        "file-type": "^21.3.0",
+        "gaxios": "7.1.3",
+        "google-auth-library": "10.6.1",
+        "grammy": "^1.41.0",
+        "https-proxy-agent": "^7.0.6",
+        "ipaddr.js": "^2.3.0",
+        "jiti": "^2.6.1",
+        "json5": "^2.2.3",
+        "jszip": "^3.10.1",
+        "linkedom": "^0.18.12",
+        "long": "^5.3.2",
+        "markdown-it": "^14.1.1",
+        "node-domexception": "npm:@nolyfill/domexception@^1.0.28",
+        "node-edge-tts": "^1.2.10",
+        "opusscript": "^0.1.1",
+        "osc-progress": "^0.3.0",
+        "pdfjs-dist": "^5.5.207",
+        "playwright-core": "1.58.2",
+        "qrcode-terminal": "^0.12.0",
+        "sharp": "^0.34.5",
+        "sqlite-vec": "0.1.7-alpha.2",
+        "strip-ansi": "^7.2.0",
+        "tar": "7.5.9",
+        "tslog": "^4.10.2",
+        "undici": "^7.22.0",
+        "ws": "^8.19.0",
+        "yaml": "^2.8.2",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "openclaw": "openclaw.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "@discordjs/opus": "^0.10.0"
+      },
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.89",
+        "node-llama-cpp": "3.16.2"
+      }
+    },
+    "node_modules/openclaw/node_modules/commander": {
+      "version": "14.0.3",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/openclaw/node_modules/zod": {
+      "version": "4.3.6",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/opusscript": {
+      "version": "0.1.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ora": {
+      "version": "9.3.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.1",
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "8.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/osc-progress": {
+      "version": "0.3.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "license": "BlueOak-1.0.0",
+      "peer": true
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "license": "(MIT AND Zlib)",
+      "peer": true
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.5.207",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0 || >=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.95",
+        "node-readable-to-web-readable-stream": "^0.4.2"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "6.1.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qified": {
+      "version": "0.6.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hookified": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "peer": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "peer": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.5",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/simple-git": {
+      "version": "3.32.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/sleep-promise": {
+      "version": "9.1.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/sqlite-vec": {
+      "version": "0.1.7-alpha.2",
+      "license": "MIT OR Apache",
+      "peer": true,
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.7-alpha.2",
+        "sqlite-vec-darwin-x64": "0.1.7-alpha.2",
+        "sqlite-vec-linux-arm64": "0.1.7-alpha.2",
+        "sqlite-vec-linux-x64": "0.1.7-alpha.2",
+        "sqlite-vec-windows-x64": "0.1.7-alpha.2"
+      }
+    },
+    "node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.7-alpha.2",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "license": "MIT"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.3.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stdout-update": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-escapes": "^6.2.0",
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.1.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/stdout-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/stdout-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/steno": {
+      "version": "4.0.2",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.4",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.9",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "license": "0BSD",
+      "peer": true
+    },
+    "node_modules/tslog": {
+      "version": "4.10.2",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/fullstack-build/tslog?sponsor=1"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "2.2.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "7.0.2",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/win-guid": {
+      "version": "0.2.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/scripts/coordinated-npm-release/__tests__/coordinated-npm-release.test.mjs
+++ b/scripts/coordinated-npm-release/__tests__/coordinated-npm-release.test.mjs
@@ -1,0 +1,549 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmod,
+  cp,
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { parseReleaseTag } from "../lib.mjs";
+
+const testDirectory = dirname(fileURLToPath(import.meta.url));
+const sourceDirectory = resolve(testDirectory, "..");
+const repositoryRoot = resolve(sourceDirectory, "../..");
+const releaseTag = "v0.17.0";
+const version = "0.17.0";
+const releaseManifest = JSON.parse(
+  await readFile(resolve(sourceDirectory, "manifest.json"), "utf8"),
+);
+const packageDefinitions = [
+  {
+    label: "Chorus CLI",
+    directory: ".",
+    packageName: "@chorus-aidlc/chorus",
+    requiredFiles: [
+      "package.json",
+      "chorus.mjs",
+      "cli/daemon.mjs",
+      "prisma/schema.prisma",
+      ".next/standalone/server.js",
+    ],
+  },
+  {
+    label: "OpenClaw plugin",
+    directory: "packages/openclaw-plugin",
+    packageName: "@chorus-aidlc/chorus-openclaw-plugin",
+    requiredFiles: [
+      "package.json",
+      "dist/index.js",
+      "src/index.ts",
+      "openclaw.plugin.json",
+      "README.md",
+    ],
+  },
+  {
+    label: "dsh plugin",
+    directory: "packages/chorus-dsh",
+    packageName: "@chorus-aidlc/chorus-dsh",
+    requiredFiles: [
+      "package.json",
+      "bin/chorus-mcp-call.mjs",
+      "dist/chorus-dsh.mjs",
+      "dist/index.d.ts",
+      "dist/persona.mjs",
+      "dist/persona.d.ts",
+      "cordis.patch.yml",
+      "README.md",
+    ],
+  },
+];
+const expectedLifecycleCommands = {
+  "@chorus-aidlc/chorus": {
+    installCommands: ["pnpm install --frozen-lockfile"],
+    checkCommands: [
+      "pnpm exec eslint src cli chorus.mjs scripts/prepack-pglite.mjs scripts/coordinated-npm-release",
+      "pnpm exec tsc --noEmit",
+      "pnpm test",
+    ],
+    buildCommands: ["pnpm build"],
+    packageCommands: ["node scripts/prepack-pglite.mjs"],
+    postPackCheck: "chorus-cli-smoke",
+  },
+  "@chorus-aidlc/chorus-openclaw-plugin": {
+    installCommands: [
+      "npm ci --ignore-scripts --no-audit --no-fund",
+    ],
+    checkCommands: ["npm run clean", "npm run typecheck", "npm run test"],
+    buildCommands: ["npm run build"],
+    packageCommands: [
+      "test -f dist/index.js",
+      "grep -F 'id: \"chorus-openclaw-plugin\"' dist/index.js",
+    ],
+    postPackCheck: "openclaw-plugin",
+  },
+  "@chorus-aidlc/chorus-dsh": {
+    installCommands: ["pnpm install --frozen-lockfile"],
+    checkCommands: [
+      "pnpm lint",
+      "pnpm typecheck",
+      "pnpm test",
+      "pnpm run check:dsh-contract",
+    ],
+    buildCommands: ["pnpm build"],
+    packageCommands: ["pnpm run check:package", "pnpm run check:pack"],
+    postPackCheck: "none",
+  },
+};
+
+async function writeJson(path, value) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function createFixture(t, { failPrepareFor } = {}) {
+  const root = await mkdtemp(resolve(tmpdir(), "chorus-coordinated-release-test-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const scripts = resolve(root, "scripts/coordinated-npm-release");
+  await mkdir(scripts, { recursive: true });
+  for (const file of ["lib.mjs", "prepare.mjs", "publish.mjs"]) {
+    await cp(resolve(sourceDirectory, file), resolve(scripts, file));
+  }
+
+  const manifest = {
+    packages: releaseManifest.packages.map((entry) => ({
+      ...entry,
+      requiredFiles: packageDefinitions.find(
+        ({ packageName }) => packageName === entry.packageName,
+      ).requiredFiles,
+      ...Object.fromEntries(
+        ["installCommands", "checkCommands", "buildCommands", "packageCommands"].map(
+          (phase) => [
+            phase,
+            entry[phase].map(
+              (_, index) => `node fixture-command.mjs ${phase} ${index}`,
+            ),
+          ],
+        ),
+      ),
+      forbiddenPatterns: ["(^|/)forbidden-secret[.]txt$"],
+      postPackCheck:
+        entry.packageName === "@chorus-aidlc/chorus-openclaw-plugin"
+          ? "openclaw-plugin"
+          : "none",
+    })),
+  };
+  await writeJson(resolve(scripts, "manifest.json"), manifest);
+
+  for (const definition of packageDefinitions) {
+    const packageRoot = resolve(root, definition.directory);
+    const files = definition.requiredFiles.filter((file) => file !== "package.json");
+    await writeJson(resolve(packageRoot, "package.json"), {
+      name: definition.packageName,
+      version,
+      files,
+    });
+    for (const file of files) {
+      const path = resolve(packageRoot, file);
+      await mkdir(dirname(path), { recursive: true });
+      const content =
+        file === "dist/index.js"
+          ? 'export default { id: "chorus-openclaw-plugin" };\n'
+          : `${definition.packageName}: ${file}\n`;
+      await writeFile(path, content);
+    }
+    await writeFile(
+      resolve(packageRoot, "fixture-command.mjs"),
+      [
+        'import { appendFileSync } from "node:fs";',
+        "const [phase, index] = process.argv.slice(2);",
+        `appendFileSync(${JSON.stringify(resolve(root, "prepare.log"))}, JSON.stringify({ packageName: ${JSON.stringify(definition.packageName)}, phase, index: Number(index) }) + "\\n");`,
+        failPrepareFor === definition.packageName
+          ? 'if (phase === "checkCommands" && index === "0") throw new Error("intentional prepare failure");'
+          : "",
+        "",
+      ].join("\n"),
+    );
+  }
+  return root;
+}
+
+function runScript(root, script, args = [], env = {}) {
+  return spawnSync(process.execPath, [
+    resolve(root, "scripts/coordinated-npm-release", script),
+    ...args,
+  ], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+async function readMaybe(path) {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") return "";
+    throw error;
+  }
+}
+
+async function prepareFixture(t) {
+  const root = await createFixture(t);
+  const result = runScript(root, "prepare.mjs", [releaseTag]);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return root;
+}
+
+async function installMockNpm(root) {
+  const path = resolve(root, "mock-npm.mjs");
+  await writeFile(
+    path,
+    `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+appendFileSync(process.env.MOCK_NPM_LOG, JSON.stringify({ args, cwd: process.cwd() }) + "\\n");
+const scenario = process.env.MOCK_NPM_SCENARIO;
+const spec = args[1] ?? "";
+const packageName = spec.slice(0, spec.lastIndexOf("@"));
+const index = [
+  "@chorus-aidlc/chorus",
+  "@chorus-aidlc/chorus-openclaw-plugin",
+  "@chorus-aidlc/chorus-dsh",
+].indexOf(packageName);
+
+if (args.join(" ") === "config get registry") {
+  console.log("https://registry.npmjs.org/");
+} else if (args[0] === "config" && args[1] === "get" && args[2].endsWith(":registry")) {
+  console.log(scenario === "scope-registry-hijack" ? "https://malicious.example.com/" : "undefined");
+} else if (args[0] === "view" && args[2] === "version") {
+  if (scenario.startsWith("first-published") && index === 0) {
+    console.log(JSON.stringify("0.17.0"));
+  } else if (scenario === "lookup-error-second" && index === 1) {
+    console.error("E401 registry authorization failure");
+    process.exitCode = 1;
+  } else {
+    console.error("npm error code E404");
+    console.error("npm error 404 Not Found - GET " + spec);
+    process.exitCode = 1;
+  }
+} else if (args[0] === "publish") {
+  if (scenario === "publish-fail-second" && args[1].includes("chorus-openclaw-plugin")) {
+    console.error("mock publish rejected");
+    process.exitCode = 1;
+  }
+} else if (args[0] === "view" && args[2] === "dist.attestations") {
+  if (scenario === "first-published-provenance-missing" && index === 0) {
+    console.log(JSON.stringify({}));
+  } else if (scenario === "first-published-provenance-error" && index === 0) {
+    console.error("E503 attestation metadata unavailable");
+    process.exitCode = 1;
+  } else {
+    console.log(JSON.stringify({
+      url: "https://registry.npmjs.org/-/npm/v1/attestations/example",
+      provenance: { predicateType: "https://slsa.dev/provenance/v1" },
+    }));
+  }
+} else {
+  console.error("unexpected mock npm invocation: " + args.join(" "));
+  process.exitCode = 2;
+}
+`,
+  );
+  await chmod(path, 0o755);
+  return path;
+}
+
+async function runPublish(root, scenario) {
+  const npmLog = resolve(root, `npm-${scenario}.jsonl`);
+  const summary = resolve(root, `summary-${scenario}.md`);
+  const npmCommand = await installMockNpm(root);
+  const result = runScript(root, "publish.mjs", [releaseTag], {
+    CHORUS_RELEASE_NPM_CLI: npmCommand,
+    CHORUS_RELEASE_PROVENANCE_RETRY_DELAY_MS: "0",
+    CHORUS_RELEASE_PROVENANCE_RETRY_ATTEMPTS: "5",
+    GITHUB_STEP_SUMMARY: summary,
+    MOCK_NPM_LOG: npmLog,
+    MOCK_NPM_SCENARIO: scenario,
+  });
+  const calls = (await readMaybe(npmLog))
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  return { result, calls, summary: await readMaybe(summary) };
+}
+
+test("release tags must be exact stable vX.Y.Z versions", () => {
+  assert.equal(parseReleaseTag("v12.34.56"), "12.34.56");
+  for (const invalid of [
+    "1.2.3",
+    "v1.2",
+    "v01.2.3",
+    "v1.2.3-beta.1",
+    "refs/tags/v1.2.3",
+    "",
+  ]) {
+    assert.throws(() => parseReleaseTag(invalid), /exact vX[.]Y[.]Z/);
+  }
+});
+
+test("real release manifest preserves every package lifecycle and pack gate", () => {
+  assert.deepEqual(
+    releaseManifest.packages.map(({ directory, packageName }) => ({
+      directory,
+      packageName,
+    })),
+    packageDefinitions.map(({ directory, packageName }) => ({
+      directory,
+      packageName,
+    })),
+  );
+  for (const entry of releaseManifest.packages) {
+    const expected = expectedLifecycleCommands[entry.packageName];
+    assert.ok(expected, `unexpected release package ${entry.packageName}`);
+    for (const phase of [
+      "installCommands",
+      "checkCommands",
+      "buildCommands",
+      "packageCommands",
+    ]) {
+      assert.deepEqual(
+        entry[phase],
+        expected[phase],
+        `${entry.packageName} ${phase} must retain all required gates`,
+      );
+    }
+    assert.equal(entry.postPackCheck, expected.postPackCheck);
+  }
+});
+
+test("standard CI runs the coordinated package-contract suite", async () => {
+  const workflow = await readFile(
+    resolve(repositoryRoot, ".github/workflows/test.yml"),
+    "utf8",
+  );
+  assert.match(workflow, /pnpm test:release-contract/);
+});
+
+test("name and version drift fail before any package command or artifact", async (t) => {
+  for (const drift of [
+    { directory: "packages/openclaw-plugin", field: "name", value: "@example/wrong" },
+    { directory: "packages/chorus-dsh", field: "version", value: "0.17.1" },
+  ]) {
+    await t.test(`${drift.field} drift`, async (t) => {
+      const root = await createFixture(t);
+      const path = resolve(root, drift.directory, "package.json");
+      const packageJson = JSON.parse(await readFile(path, "utf8"));
+      packageJson[drift.field] = drift.value;
+      await writeJson(path, packageJson);
+
+      const result = runScript(root, "prepare.mjs", [releaseTag]);
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /name must be|version must match/);
+      assert.equal(await readMaybe(resolve(root, "prepare.log")), "");
+      assert.equal(
+        await readMaybe(resolve(root, ".release-artifacts/npm/prepare-result.json")),
+        "",
+      );
+    });
+  }
+});
+
+test("a late prepare failure leaves no publish handoff and audits unattempted state", async (t) => {
+  const root = await createFixture(t, {
+    failPrepareFor: "@chorus-aidlc/chorus-dsh",
+  });
+  const summary = resolve(root, "summary.md");
+  const result = runScript(root, "prepare.mjs", [releaseTag], {
+    GITHUB_STEP_SUMMARY: summary,
+  });
+  assert.equal(result.status, 1);
+  assert.equal(
+    await readMaybe(resolve(root, ".release-artifacts/npm/prepare-result.json")),
+    "",
+  );
+  const attemptedPackages = [
+    ...new Set(
+      (await readFile(resolve(root, "prepare.log"), "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line).packageName),
+    ),
+  ];
+  assert.deepEqual(attemptedPackages, packageDefinitions.map(({ packageName }) => packageName));
+  assert.match(await readFile(summary, "utf8"), /chorus-dsh` \| prepare-failed/);
+
+  const publish = runScript(root, "publish.mjs", [releaseTag]);
+  assert.equal(publish.status, 1);
+  assert.doesNotMatch(`${publish.stdout}\n${publish.stderr}`, /\$ npm publish/);
+});
+
+test("real npm pack prepares all three contract-shaped tarballs in fixed order", async (t) => {
+  const root = await prepareFixture(t);
+  const lifecycleLog = (await readFile(resolve(root, "prepare.log"), "utf8"))
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  assert.deepEqual(
+    lifecycleLog,
+    releaseManifest.packages.flatMap((entry) =>
+      ["installCommands", "checkCommands", "buildCommands", "packageCommands"].flatMap(
+        (phase) =>
+          entry[phase].map((_, index) => ({
+            packageName: entry.packageName,
+            phase,
+            index,
+          })),
+      ),
+    ),
+  );
+  const prepared = JSON.parse(
+    await readFile(resolve(root, ".release-artifacts/npm/prepare-result.json"), "utf8"),
+  );
+  assert.deepEqual(
+    prepared.packages.map(({ packageName }) => packageName),
+    packageDefinitions.map(({ packageName }) => packageName),
+  );
+  for (const [index, entry] of prepared.packages.entries()) {
+    assert.equal(entry.version, version);
+    assert.match(entry.sha256, /^[a-f0-9]{64}$/);
+    const files = execFileSync("tar", ["-tzf", entry.tarball], {
+      encoding: "utf8",
+    });
+    for (const required of packageDefinitions[index].requiredFiles) {
+      assert.match(files, new RegExp(`^package/${required.replaceAll(".", "[.]")}$`, "m"));
+    }
+  }
+});
+
+test("fresh publication uses fixed order and verifies automatic provenance", async (t) => {
+  const root = await prepareFixture(t);
+  const { result, calls, summary } = await runPublish(root, "all-missing");
+  assert.equal(result.status, 0, result.stderr);
+
+  const publishes = calls.filter(({ args }) => args[0] === "publish");
+  assert.deepEqual(
+    publishes.map(({ cwd }) => cwd),
+    packageDefinitions.map(({ directory }) => resolve(root, directory)),
+  );
+  assert.ok(publishes.every(({ args }) => args.at(-2) === "--access" && args.at(-1) === "public"));
+  assert.ok(publishes.every(({ args }) => !args.some((arg) => /provenance/i.test(arg))));
+  assert.equal(
+    calls.filter(({ args }) => args[2] === "dist.attestations").length,
+    3,
+  );
+  for (const { packageName } of packageDefinitions) {
+    assert.match(summary, new RegExp(`${packageName.replaceAll("/", "\\/")}\\\` \\| published`));
+  }
+});
+
+test("an already-published version is skipped and remaining packages continue", async (t) => {
+  const root = await prepareFixture(t);
+  const { result, calls, summary } = await runPublish(root, "first-published");
+  assert.equal(result.status, 0, result.stderr);
+  const publishes = calls.filter(({ args }) => args[0] === "publish");
+  assert.equal(publishes.length, 2);
+  assert.ok(publishes[0].args[1].includes("chorus-openclaw-plugin"));
+  assert.equal(
+    calls.filter(
+      ({ args }) =>
+        args[1] === "@chorus-aidlc/chorus@0.17.0" &&
+        args[2] === "dist.attestations",
+    ).length,
+    1,
+  );
+  assert.match(summary, /@chorus-aidlc\/chorus` \| skipped-already-published/);
+});
+
+test("missing provenance on an already-published version fails the rerun", async (t) => {
+  const root = await prepareFixture(t);
+  const { result, calls, summary } = await runPublish(
+    root,
+    "first-published-provenance-missing",
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /does not contain an SLSA provenance attestation/);
+  assert.equal(calls.filter(({ args }) => args[0] === "publish").length, 0);
+  assert.equal(
+    calls.filter(({ args }) => args[2] === "dist.attestations").length,
+    5,
+  );
+  assert.match(summary, /@chorus-aidlc\/chorus` \| failed/);
+  assert.match(summary, /chorus-openclaw-plugin` \| not-attempted/);
+});
+
+test("provenance query failure on an already-published version fails the rerun", async (t) => {
+  const root = await prepareFixture(t);
+  const { result, calls, summary } = await runPublish(
+    root,
+    "first-published-provenance-error",
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /E503 attestation metadata unavailable/);
+  assert.equal(calls.filter(({ args }) => args[0] === "publish").length, 0);
+  assert.equal(
+    calls.filter(({ args }) => args[2] === "dist.attestations").length,
+    5,
+  );
+  assert.match(summary, /@chorus-aidlc\/chorus` \| failed/);
+  assert.match(summary, /chorus-openclaw-plugin` \| not-attempted/);
+});
+
+test("registry lookup errors stop later uploads and mark failed/not-attempted", async (t) => {
+  const root = await prepareFixture(t);
+  const { result, calls, summary } = await runPublish(root, "lookup-error-second");
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unable to determine/);
+  assert.equal(calls.filter(({ args }) => args[0] === "publish").length, 1);
+  assert.match(summary, /chorus-openclaw-plugin` \| failed/);
+  assert.match(summary, /chorus-dsh` \| not-attempted/);
+});
+
+test("publish failures stop later uploads and mark failed/not-attempted", async (t) => {
+  const root = await prepareFixture(t);
+  const { result, calls, summary } = await runPublish(root, "publish-fail-second");
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /publish failed/);
+  assert.equal(calls.filter(({ args }) => args[0] === "publish").length, 2);
+  assert.match(summary, /chorus-openclaw-plugin` \| failed/);
+  assert.match(summary, /chorus-dsh` \| not-attempted/);
+});
+
+test("a scope registry redirected off npmjs fails before any upload", async (t) => {
+  const root = await prepareFixture(t);
+  const { result, calls, summary } = await runPublish(root, "scope-registry-hijack");
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /npm publish registry \(@chorus-aidlc:registry\) must be https:\/\/registry\.npmjs\.org\//,
+  );
+  assert.equal(calls.filter(({ args }) => args[0] === "publish").length, 0);
+  assert.equal(calls.filter(({ args }) => args[2] === "version").length, 0);
+  assert.match(summary, /@chorus-aidlc\/chorus` \| failed/);
+  assert.match(summary, /chorus-openclaw-plugin` \| not-attempted/);
+  assert.match(summary, /chorus-dsh` \| not-attempted/);
+});
+
+test("workflow is release-only, tokenless, minimally privileged, and provenance-aware", async () => {
+  const workflow = await readFile(
+    resolve(repositoryRoot, ".github/workflows/publish-npm.yml"),
+    "utf8",
+  );
+  assert.match(workflow, /release:\s*\n\s+types: \[published\]/);
+  assert.doesNotMatch(workflow, /^\s+(push|pull_request):/m);
+  assert.match(workflow, /permissions:\s*\n\s+contents: read\s*\n\s+id-token: write/);
+  assert.doesNotMatch(workflow, /registry-url|NPM_TOKEN|NODE_AUTH_TOKEN|_authToken/);
+  assert.match(workflow, /runs-on: ubuntu-latest/);
+  assert.match(workflow, /node-version: ['"]24['"]/);
+  assert.match(workflow, /CHORUS_RELEASE_EXPECT_PROVENANCE:.*repository[.]private/);
+  assert.match(workflow, /prepare[.]mjs[\s\S]*publish[.]mjs/);
+});

--- a/scripts/coordinated-npm-release/lib.mjs
+++ b/scripts/coordinated-npm-release/lib.mjs
@@ -1,0 +1,110 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+export const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+export const repositoryRoot = resolve(scriptDirectory, "../..");
+export const artifactDirectory = resolve(repositoryRoot, ".release-artifacts/npm");
+export const prepareResultPath = resolve(artifactDirectory, "prepare-result.json");
+
+const expectedPackages = [
+  [".", "@chorus-aidlc/chorus"],
+  ["packages/openclaw-plugin", "@chorus-aidlc/chorus-openclaw-plugin"],
+  ["packages/chorus-dsh", "@chorus-aidlc/chorus-dsh"],
+];
+
+export async function loadManifest() {
+  const manifest = JSON.parse(
+    await readFile(resolve(scriptDirectory, "manifest.json"), "utf8"),
+  );
+  const identities = manifest.packages?.map(({ directory, packageName }) => [
+    directory,
+    packageName,
+  ]);
+  if (JSON.stringify(identities) !== JSON.stringify(expectedPackages)) {
+    throw new Error(
+      "Release manifest must contain exactly Chorus CLI, OpenClaw, and dsh in publish order",
+    );
+  }
+  return manifest;
+}
+
+export function parseReleaseTag(tag) {
+  const match = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(tag);
+  if (!match) {
+    throw new Error(`Release tag must be an exact vX.Y.Z version; received ${JSON.stringify(tag)}`);
+  }
+  return tag.slice(1);
+}
+
+export function run(
+  command,
+  { cwd = repositoryRoot, capture = false, env = process.env } = {},
+) {
+  console.log(`$ ${command}`);
+  const result = spawnSync(command, {
+    cwd,
+    env,
+    encoding: "utf8",
+    shell: true,
+    stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail = capture
+      ? `\n${[result.stdout, result.stderr].filter(Boolean).join("\n").trim()}`
+      : "";
+    throw new Error(`Command failed with exit code ${result.status}: ${command}${detail}`);
+  }
+  return capture ? result.stdout.trim() : "";
+}
+
+export function runFile(command, args, { cwd = repositoryRoot, capture = false } = {}) {
+  console.log(`$ ${command} ${args.join(" ")}`);
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
+  });
+  if (result.error) throw result.error;
+  return result;
+}
+
+export async function packageIdentity(packageDirectory) {
+  const packageJsonPath = resolve(repositoryRoot, packageDirectory, "package.json");
+  return JSON.parse(await readFile(packageJsonPath, "utf8"));
+}
+
+export async function sha256(file) {
+  return createHash("sha256").update(await readFile(file)).digest("hex");
+}
+
+export function assertSuccessful(result, description) {
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    throw new Error(`${description} failed with exit code ${result.status}${detail ? `\n${detail}` : ""}`);
+  }
+}
+
+export async function appendJobSummary(markdown) {
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const { appendFile } = await import("node:fs/promises");
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`);
+  } else {
+    console.log(markdown);
+  }
+}
+
+export function summaryTable(version, rows, heading = "Coordinated npm release") {
+  return [
+    `## ${heading}`,
+    "",
+    `Release version: \`${version}\``,
+    "",
+    "| Package | Status |",
+    "| --- | --- |",
+    ...rows.map(({ packageName, status }) => `| \`${packageName}\` | ${status} |`),
+  ].join("\n");
+}

--- a/scripts/coordinated-npm-release/manifest.json
+++ b/scripts/coordinated-npm-release/manifest.json
@@ -1,0 +1,109 @@
+{
+  "packages": [
+    {
+      "label": "Chorus CLI",
+      "directory": ".",
+      "packageName": "@chorus-aidlc/chorus",
+      "installCommands": [
+        "pnpm install --frozen-lockfile"
+      ],
+      "checkCommands": [
+        "pnpm exec eslint src cli chorus.mjs scripts/prepack-pglite.mjs scripts/coordinated-npm-release",
+        "pnpm exec tsc --noEmit",
+        "pnpm test"
+      ],
+      "buildCommands": [
+        "pnpm build"
+      ],
+      "packageCommands": [
+        "node scripts/prepack-pglite.mjs"
+      ],
+      "requiredFiles": [
+        "package.json",
+        "chorus.mjs",
+        "cli/daemon.mjs",
+        "prisma/schema.prisma",
+        ".next/standalone/server.js"
+      ],
+      "forbiddenPatterns": [
+        "^node_modules/",
+        "(^|/)__tests__/",
+        "(^|/)\\.env($|\\.)"
+      ],
+      "postPackCheck": "chorus-cli-smoke"
+    },
+    {
+      "label": "OpenClaw plugin",
+      "directory": "packages/openclaw-plugin",
+      "packageName": "@chorus-aidlc/chorus-openclaw-plugin",
+      "installCommands": [
+        "npm ci --ignore-scripts --no-audit --no-fund"
+      ],
+      "checkCommands": [
+        "npm run clean",
+        "npm run typecheck",
+        "npm run test"
+      ],
+      "buildCommands": [
+        "npm run build"
+      ],
+      "packageCommands": [
+        "test -f dist/index.js",
+        "grep -F 'id: \"chorus-openclaw-plugin\"' dist/index.js"
+      ],
+      "requiredFiles": [
+        "package.json",
+        "dist/index.js",
+        "src/index.ts",
+        "openclaw.plugin.json",
+        "README.md"
+      ],
+      "forbiddenPatterns": [
+        "(^|/)node_modules/",
+        "(^|/)__tests__/",
+        "(^|/)bin/publish\\.sh$",
+        "(^|/)\\.env($|\\.)"
+      ],
+      "postPackCheck": "openclaw-plugin"
+    },
+    {
+      "label": "dsh plugin",
+      "directory": "packages/chorus-dsh",
+      "packageName": "@chorus-aidlc/chorus-dsh",
+      "installCommands": [
+        "pnpm install --frozen-lockfile"
+      ],
+      "checkCommands": [
+        "pnpm lint",
+        "pnpm typecheck",
+        "pnpm test",
+        "pnpm run check:dsh-contract"
+      ],
+      "buildCommands": [
+        "pnpm build"
+      ],
+      "packageCommands": [
+        "pnpm run check:package",
+        "pnpm run check:pack"
+      ],
+      "requiredFiles": [
+        "package.json",
+        "bin/chorus-mcp-call.mjs",
+        "dist/chorus-dsh.mjs",
+        "dist/index.d.ts",
+        "dist/persona.mjs",
+        "dist/persona.d.ts",
+        "cordis.patch.yml",
+        "README.md"
+      ],
+      "forbiddenPatterns": [
+        "(^|/)node_modules/",
+        "(^|/)tests/",
+        "(^|/)install-dsh",
+        "(^|/)agent-presets/",
+        "(^|/)\\.env($|\\.)"
+      ],
+      "postPackCheck": "none"
+    }
+  ]
+}

--- a/scripts/coordinated-npm-release/prepare.mjs
+++ b/scripts/coordinated-npm-release/prepare.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, resolve } from "node:path";
+import {
+  appendJobSummary,
+  artifactDirectory,
+  assertSuccessful,
+  loadManifest,
+  packageIdentity,
+  parseReleaseTag,
+  prepareResultPath,
+  repositoryRoot,
+  run,
+  runFile,
+  sha256,
+  summaryTable,
+} from "./lib.mjs";
+
+const releaseTag = process.argv[2];
+const manifest = await loadManifest();
+let version = "invalid";
+let currentPackage = null;
+let validationDirectory = null;
+const statuses = manifest.packages.map(({ packageName }) => ({
+  packageName,
+  status: "not-attempted",
+}));
+
+function setStatus(packageName, status) {
+  statuses.find((row) => row.packageName === packageName).status = status;
+}
+
+async function validateTarball(entry, packed, tarballPath, expectedVersion) {
+  if (packed.name !== entry.packageName || packed.version !== expectedVersion) {
+    throw new Error(
+      `${entry.packageName} tarball identity mismatch: ${packed.name}@${packed.version}`,
+    );
+  }
+
+  const files = new Set((packed.files ?? []).map(({ path }) => path));
+  for (const required of entry.requiredFiles) {
+    if (!files.has(required)) {
+      throw new Error(`${entry.packageName} tarball is missing required file ${required}`);
+    }
+  }
+  for (const pattern of entry.forbiddenPatterns) {
+    const matcher = new RegExp(pattern);
+    const forbidden = [...files].find((file) => matcher.test(file));
+    if (forbidden) {
+      throw new Error(`${entry.packageName} tarball contains forbidden file ${forbidden}`);
+    }
+  }
+
+  const packedManifest = runFile(
+    "tar",
+    ["-xOzf", tarballPath, "package/package.json"],
+    { capture: true },
+  );
+  assertSuccessful(packedManifest, `${entry.packageName} packed manifest extraction`);
+  const identity = JSON.parse(packedManifest.stdout);
+  if (identity.name !== entry.packageName || identity.version !== expectedVersion) {
+    throw new Error(`${entry.packageName} packed package.json does not match the release`);
+  }
+
+  if (entry.postPackCheck === "openclaw-plugin") {
+    const packedEntry = runFile(
+      "tar",
+      ["-xOzf", tarballPath, "package/dist/index.js"],
+      { capture: true },
+    );
+    assertSuccessful(packedEntry, "OpenClaw packed entry extraction");
+    if (!packedEntry.stdout.includes('id: "chorus-openclaw-plugin"')) {
+      throw new Error("OpenClaw packed entry does not contain the expected plugin id");
+    }
+  }
+
+  if (entry.postPackCheck === "chorus-cli-smoke") {
+    const installDirectory = await mkdtemp(resolve(tmpdir(), "chorus-release-smoke-"));
+    try {
+      runFile(
+        "npm",
+        [
+          "install",
+          "--ignore-scripts",
+          "--no-audit",
+          "--no-fund",
+          "--no-save",
+          "--prefix",
+          installDirectory,
+          tarballPath,
+        ],
+      );
+      const chorus = resolve(installDirectory, "node_modules/.bin/chorus");
+      const smoke = runFile(chorus, ["--version"], { capture: true });
+      assertSuccessful(smoke, "Installed Chorus CLI smoke test");
+      if (smoke.stdout.trim() !== expectedVersion) {
+        throw new Error(
+          `Installed Chorus CLI version mismatch: expected ${expectedVersion}, got ${smoke.stdout.trim()}`,
+        );
+      }
+    } finally {
+      await rm(installDirectory, { recursive: true, force: true });
+    }
+  }
+}
+
+try {
+  version = parseReleaseTag(releaseTag);
+
+  // Identity checks are intentionally completed for all packages before any
+  // install, build, registry lookup, or publish operation.
+  for (const entry of manifest.packages) {
+    const identity = await packageIdentity(entry.directory);
+    if (identity.name !== entry.packageName) {
+      throw new Error(
+        `${entry.directory}/package.json name must be ${entry.packageName}; received ${identity.name}`,
+      );
+    }
+    if (identity.version !== version) {
+      throw new Error(
+        `${entry.packageName} version must match ${releaseTag}; received ${identity.version}`,
+      );
+    }
+    if (identity.publishConfig?.registry !== undefined) {
+      throw new Error(
+        `${entry.packageName} must use npm's verified default registry, not publishConfig.registry`,
+      );
+    }
+  }
+
+  await rm(artifactDirectory, { recursive: true, force: true });
+  await mkdir(artifactDirectory, { recursive: true });
+  validationDirectory = await mkdtemp(resolve(tmpdir(), "chorus-release-validation-"));
+  const checkEnvironment = {
+    ...process.env,
+    CHORUS_DAEMON_CONFIG_PATH: resolve(
+      validationDirectory,
+      ".chorus",
+      "daemon.json",
+    ),
+    CHORUS_CLAUDE_SETTINGS_PATH: resolve(
+      validationDirectory,
+      ".claude",
+      "settings.json",
+    ),
+  };
+  delete checkEnvironment.CHORUS_AGENT_PROFILE;
+  delete checkEnvironment.CHORUS_URL;
+  delete checkEnvironment.CHORUS_API_KEY;
+  const prepared = [];
+
+  for (const entry of manifest.packages) {
+    currentPackage = entry.packageName;
+    setStatus(entry.packageName, "preparing");
+    const cwd = resolve(repositoryRoot, entry.directory);
+    console.log(`\n=== Prepare ${entry.label}: ${entry.packageName}@${version} ===`);
+
+    for (const command of entry.installCommands) run(command, { cwd });
+    for (const command of entry.checkCommands) {
+      run(command, { cwd, env: checkEnvironment });
+    }
+    for (const command of entry.buildCommands) run(command, { cwd });
+    for (const command of entry.packageCommands) run(command, { cwd });
+
+    const pack = runFile(
+      "npm",
+      ["pack", "--ignore-scripts", "--json", "--pack-destination", artifactDirectory],
+      { cwd, capture: true },
+    );
+    assertSuccessful(pack, `${entry.packageName} npm pack`);
+    const packOutput = JSON.parse(pack.stdout);
+    if (!Array.isArray(packOutput) || packOutput.length !== 1) {
+      throw new Error(`${entry.packageName} npm pack returned an unexpected result`);
+    }
+    const packed = packOutput[0];
+    const tarballPath = resolve(artifactDirectory, packed.filename);
+    await validateTarball(entry, packed, tarballPath, version);
+
+    prepared.push({
+      label: entry.label,
+      directory: entry.directory,
+      packageName: entry.packageName,
+      version,
+      tarball: tarballPath,
+      filename: basename(tarballPath),
+      sha256: await sha256(tarballPath),
+    });
+    setStatus(entry.packageName, "prepared");
+  }
+
+  await writeFile(
+    prepareResultPath,
+    `${JSON.stringify({ releaseTag, version, packages: prepared }, null, 2)}\n`,
+  );
+  console.log(`\nPrepared all three packages: ${prepareResultPath}`);
+} catch (error) {
+  if (currentPackage) setStatus(currentPackage, "prepare-failed");
+  await appendJobSummary(summaryTable(version, statuses, "Coordinated npm release preparation failed"));
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+} finally {
+  if (validationDirectory) {
+    await rm(validationDirectory, { recursive: true, force: true });
+  }
+}

--- a/scripts/coordinated-npm-release/publish.mjs
+++ b/scripts/coordinated-npm-release/publish.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+import { access, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+  appendJobSummary,
+  assertSuccessful,
+  loadManifest,
+  parseReleaseTag,
+  prepareResultPath,
+  repositoryRoot,
+  runFile,
+  sha256,
+  summaryTable,
+} from "./lib.mjs";
+
+const releaseTag = process.argv[2];
+const npmCommand = process.env.CHORUS_RELEASE_NPM_CLI || "npm";
+const expectProvenance = process.env.CHORUS_RELEASE_EXPECT_PROVENANCE !== "false";
+const provenanceRetryDelayMs = Number(
+  process.env.CHORUS_RELEASE_PROVENANCE_RETRY_DELAY_MS ?? "3000",
+);
+// Fresh publishes need time for the registry/CDN to expose the attestation.
+// Default budget ~= (attempts - 1) * delay ≈ 57s; both are env-overridable.
+const provenanceRetryAttempts = Number(
+  process.env.CHORUS_RELEASE_PROVENANCE_RETRY_ATTEMPTS ?? "20",
+);
+const npmPublicRegistry = "https://registry.npmjs.org/";
+const manifest = await loadManifest();
+const version = parseReleaseTag(releaseTag);
+const statuses = manifest.packages.map(({ packageName }) => ({
+  packageName,
+  status: "not-attempted",
+}));
+let currentPackage = null;
+
+function setStatus(packageName, status) {
+  statuses.find((row) => row.packageName === packageName).status = status;
+}
+
+async function validatePreparedResult() {
+  const result = JSON.parse(await readFile(prepareResultPath, "utf8"));
+  if (result.releaseTag !== releaseTag || result.version !== version) {
+    throw new Error("Prepared release identity does not match the requested release tag");
+  }
+  const identities = result.packages?.map(({ directory, packageName, version: packageVersion }) => [
+    directory,
+    packageName,
+    packageVersion,
+  ]);
+  const expected = manifest.packages.map(({ directory, packageName }) => [
+    directory,
+    packageName,
+    version,
+  ]);
+  if (JSON.stringify(identities) !== JSON.stringify(expected)) {
+    throw new Error("Prepared package set or order does not match the release manifest");
+  }
+  for (const entry of result.packages) {
+    await access(entry.tarball);
+    if (await sha256(entry.tarball) !== entry.sha256) {
+      throw new Error(`${entry.packageName} tarball changed after preparation`);
+    }
+  }
+  return result;
+}
+
+function npmConfigGet(key, packageName, cwd) {
+  const lookup = runFile(npmCommand, ["config", "get", key], { cwd, capture: true });
+  assertSuccessful(lookup, `${packageName} npm config get ${key}`);
+  return lookup.stdout.trim();
+}
+
+function isRegistryUnset(value) {
+  return value === "" || value === "undefined" || value === "null";
+}
+
+// npm resolves the publish target for a scoped package from `<scope>:registry`
+// first, falling back to the default `registry`. Verify the *effective* target,
+// not just the default — otherwise a scope-specific .npmrc could redirect the
+// upload while this guard still reports npmjs.org.
+function verifyPublishRegistry(packageName, cwd) {
+  let source = "registry";
+  let effective = npmConfigGet("registry", packageName, cwd);
+  if (packageName.startsWith("@") && packageName.includes("/")) {
+    const scope = packageName.slice(0, packageName.indexOf("/"));
+    const scoped = npmConfigGet(`${scope}:registry`, packageName, cwd);
+    if (!isRegistryUnset(scoped)) {
+      source = `${scope}:registry`;
+      effective = scoped;
+    }
+  }
+  if (effective !== npmPublicRegistry) {
+    throw new Error(
+      `${packageName} npm publish registry (${source}) must be ${npmPublicRegistry}; received ${effective || "(empty)"}`,
+    );
+  }
+  console.log(`${packageName} npm publish registry verified via ${source}: ${npmPublicRegistry}`);
+}
+
+function registryState(packageName, cwd) {
+  const spec = `${packageName}@${version}`;
+  const lookup = runFile(
+    npmCommand,
+    ["view", spec, "version", "--json"],
+    { cwd, capture: true },
+  );
+  if (lookup.status === 0) {
+    let publishedVersion;
+    try {
+      publishedVersion = JSON.parse(lookup.stdout);
+    } catch {
+      throw new Error(`npm registry returned invalid JSON while checking ${spec}`);
+    }
+    if (publishedVersion !== version) {
+      throw new Error(`npm registry returned an unexpected version while checking ${spec}`);
+    }
+    return "published";
+  }
+
+  const output = `${lookup.stdout}\n${lookup.stderr}`;
+  if (/\bE404\b/.test(output) && output.includes(spec)) return "missing";
+  throw new Error(
+    `Unable to determine whether ${spec} exists (exit ${lookup.status})\n${output.trim()}`,
+  );
+}
+
+async function verifyProvenance(packageName, cwd) {
+  const spec = `${packageName}@${version}`;
+  let lastDetail = "no registry response";
+  for (let attempt = 1; attempt <= provenanceRetryAttempts; attempt++) {
+    const lookup = runFile(
+      npmCommand,
+      ["view", spec, "dist.attestations", "--json"],
+      { cwd, capture: true },
+    );
+    if (lookup.status === 0) {
+      try {
+        const attestations = JSON.parse(lookup.stdout);
+        if (
+          typeof attestations?.url === "string" &&
+          attestations.provenance?.predicateType === "https://slsa.dev/provenance/v1"
+        ) {
+          console.log(`${spec} provenance attestation verified`);
+          return;
+        }
+        lastDetail = "registry metadata does not contain an SLSA provenance attestation";
+      } catch {
+        lastDetail = "registry returned invalid attestation JSON";
+      }
+    } else {
+      lastDetail = [lookup.stdout, lookup.stderr].filter(Boolean).join("\n").trim();
+    }
+    if (attempt < provenanceRetryAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, provenanceRetryDelayMs));
+    }
+  }
+  throw new Error(`Unable to verify automatic provenance for ${spec}: ${lastDetail}`);
+}
+
+try {
+  const prepared = await validatePreparedResult();
+
+  for (const entry of prepared.packages) {
+    currentPackage = entry.packageName;
+    const packageDirectory = resolve(repositoryRoot, entry.directory);
+    console.log(`\n=== Publish ${entry.packageName}@${version} ===`);
+    verifyPublishRegistry(entry.packageName, packageDirectory);
+    const alreadyPublished =
+      registryState(entry.packageName, packageDirectory) === "published";
+    if (alreadyPublished) {
+      console.log(`${entry.packageName}@${version} is already published; skipping`);
+    } else {
+      const publish = runFile(
+        npmCommand,
+        ["publish", entry.tarball, "--access", "public"],
+        { cwd: packageDirectory },
+      );
+      assertSuccessful(publish, `${entry.packageName} publish`);
+    }
+    if (expectProvenance) {
+      await verifyProvenance(entry.packageName, packageDirectory);
+    } else {
+      console.log(`${entry.packageName}@${version} provenance check skipped for a private source repository`);
+    }
+    setStatus(
+      entry.packageName,
+      alreadyPublished ? "skipped-already-published" : "published",
+    );
+  }
+} catch (error) {
+  if (currentPackage) setStatus(currentPackage, "failed");
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+} finally {
+  await appendJobSummary(summaryTable(version, statuses));
+}

--- a/scripts/prepack-pglite.mjs
+++ b/scripts/prepack-pglite.mjs
@@ -91,12 +91,20 @@ try {
   // ignore
 }
 
-// --- 3. Copy static assets and public/ into standalone directory ---
+// --- 3. Remove build-time environment files from the publishable output ---
+
+const standaloneDir = join(process.cwd(), ".next", "standalone");
+for (const entry of readdirSync(standaloneDir)) {
+  if (entry === ".env" || entry.startsWith(".env.")) {
+    rmSync(join(standaloneDir, entry), { force: true });
+    console.log(`  removed standalone/${entry}`);
+  }
+}
+
+// --- 4. Copy static assets and public/ into standalone directory ---
 // Next.js standalone server.js expects .next/static/ and public/ relative
 // to its own directory (.next/standalone/), but `next build` outputs them
 // at the project root. Docker does this via COPY; we do it here for npm.
-
-const standaloneDir = join(process.cwd(), ".next", "standalone");
 
 console.log("Copying static assets into standalone directory...");
 const staticSrc = join(process.cwd(), ".next", "static");
@@ -109,7 +117,7 @@ const publicDst = join(standaloneDir, "public");
 cpSync(publicSrc, publicDst, { recursive: true });
 console.log("  copied public/");
 
-// --- 4. Rewrite Prisma's hardcoded build-host __dirname in server chunks ---
+// --- 5. Rewrite Prisma's hardcoded build-host __dirname in server chunks ---
 // Prisma 7's generated client.ts contains:
 //   globalThis['__dirname'] = path.dirname(fileURLToPath(import.meta.url))
 // webpack inlines `import.meta.url` at build time as the absolute file:// URL
@@ -138,10 +146,15 @@ try {
 }
 
 let patchedCount = 0;
+let portableCount = 0;
 for (const name of chunkFiles) {
   if (!name.endsWith(".js")) continue;
   const fullPath = join(chunksDir, name);
   const original = readFileSync(fullPath, "utf8");
+  if (original.includes(prismaDirnameRep)) {
+    portableCount++;
+    continue;
+  }
   if (!prismaDirnameRe.test(original)) continue;
   prismaDirnameRe.lastIndex = 0;
   const patched = original.replace(prismaDirnameRe, prismaDirnameRep);
@@ -150,7 +163,7 @@ for (const name of chunkFiles) {
   console.log(`  patched chunks/${name}`);
 }
 
-if (patchedCount === 0) {
+if (patchedCount + portableCount === 0) {
   // If we ship a tarball without this patch on Windows it breaks at runtime.
   // Fail loudly so a Prisma upgrade that changes the generated shape can't
   // silently slip through.
@@ -167,5 +180,8 @@ if (patchedCount === 0) {
   process.exit(1);
 }
 console.log(`  patched ${patchedCount} chunk(s)`);
+if (portableCount > 0) {
+  console.log(`  verified ${portableCount} previously patched chunk(s)`);
+}
 
 console.log("Prepack complete.");


### PR DESCRIPTION
## Summary
- publish the Chorus CLI, OpenClaw plugin, and dsh plugin from one release-triggered GitHub Actions workflow
- use npm Trusted Publishing/OIDC without storing npm tokens, with fixed-order fail-stop and idempotent reruns
- preserve every package build/pack contract, verify tarball hashes and provenance, and document the release process
- make OpenClaw installs reproducible with a tracked npm lockfile

## Test plan
- [x] `pnpm test:release-contract` (16/16)
- [x] `pnpm exec vitest run cli/__tests__/credentials.test.mjs` (14/14)
- [x] `node scripts/coordinated-npm-release/prepare.mjs v0.17.0` (all three package gates, builds, packs, and smoke checks)
- [x] `git diff --check`

## Chorus
Idea: `480db634-cc2f-4082-bf69-960cd05bc5b5`
Proposal: `b077611f-2155-44b3-b620-615151961e4a`