### PR TITLE
fix: stop active-session indicator popover flickering on hover

### DIFF
--- a/src/components/active-session-indicator.tsx
+++ b/src/components/active-session-indicator.tsx
@@ -123,6 +123,12 @@ export function ActiveSessionIndicator({
       <PopoverContent
         align="start"
         sideOffset={6}
+        // Hover-out closes the popover, and Radix by default returns focus to the
+        // trigger on close — which re-fires the trigger's `onFocus` and reopens
+        // the popover, a close→reopen bounce that reads as a hover flicker. The
+        // popover is a hover/keyboard-open affordance, not a focus trap, so we
+        // suppress the focus return; keyboard open via `onFocus` still works.
+        onCloseAutoFocus={(event) => event.preventDefault()}
         onPointerDown={(event) => event.stopPropagation()}
         onPointerEnter={cancelClose}
         onPointerLeave={scheduleClose}


### PR DESCRIPTION
## Summary
- The idea-tracker live-session indicator (added in #517) opens its chooser popover on hover. On hover-out the popover closed, then immediately reopened — a visible flicker that also left it stuck open.

## Root cause
Radix returns focus to the trigger when a Popover closes (default `onCloseAutoFocus`). That programmatic refocus re-fired the trigger's `onFocus={() => setOpen(true)}`, reopening the popover — a close→reopen bounce. Confirmed in-browser: hover-out produced `aria-expanded: true → false → true` (~170ms), ending focused on the trigger.

## Fix
Add `onCloseAutoFocus={(event) => event.preventDefault()}` to the `PopoverContent` so closing no longer yanks focus back to the trigger. The popover is a hover/keyboard-open affordance, not a focus trap; keyboard open via `onFocus` still works.

## Changed files
| File | Change |
|------|--------|
| `src/components/active-session-indicator.tsx` | Suppress focus-return on popover close (+comment) |

## Test plan
- [x] Reproduced pre-fix in a real browser (throwaway harness): `true → false → true` reopen bounce.
- [x] Verified post-fix: hover-out closes cleanly once (`true → false`, focus to body, no reopen).
- [x] Existing 10 `active-session-indicator` tests pass; `tsc` + eslint clean.
- Note: jsdom can't exercise Radix's focus-return, so no unit test was added (one would pass regardless of the bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)