### PR TITLE
fix: generate Prisma client before npm release checks

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,19 +16,19 @@ jobs:
 
     steps:
       - name: Checkout immutable release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name }}
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: ''
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: '9.15.0'
           run_install: false

--- a/scripts/coordinated-npm-release/__tests__/coordinated-npm-release.test.mjs
+++ b/scripts/coordinated-npm-release/__tests__/coordinated-npm-release.test.mjs
@@ -69,6 +69,7 @@ const expectedLifecycleCommands = {
   "@chorus-aidlc/chorus": {
     installCommands: ["pnpm install --frozen-lockfile"],
     checkCommands: [
+      "pnpm exec prisma generate",
       "pnpm exec eslint src cli chorus.mjs scripts/prepack-pglite.mjs scripts/coordinated-npm-release",
       "pnpm exec tsc --noEmit",
       "pnpm test",

--- a/scripts/coordinated-npm-release/manifest.json
+++ b/scripts/coordinated-npm-release/manifest.json
@@ -8,6 +8,7 @@
         "pnpm install --frozen-lockfile"
       ],
       "checkCommands": [
+        "pnpm exec prisma generate",
         "pnpm exec eslint src cli chorus.mjs scripts/prepack-pglite.mjs scripts/coordinated-npm-release",
         "pnpm exec tsc --noEmit",
         "pnpm test"


### PR DESCRIPTION
Fix the v0.17.1 release preflight failure by generating Prisma Client before TypeScript checks. Also update JavaScript actions to Node 24-native major versions. Verified with the full three-package prepare flow in a clean detached worktree.