### PR TITLE
fix: make dsh release contract runner-safe

### DIFF
--- a/packages/chorus-dsh/scripts/check-dsh-contract.sh
+++ b/packages/chorus-dsh/scripts/check-dsh-contract.sh
@@ -2,7 +2,17 @@
 set -euo pipefail
 
 expected="99f6f02fecdb7dff40c3fbc9470f5907c29f74ca"
-checkout="${DSH_CHECKOUT:-/home/ubuntu/dev/deepseek-harness}"
+tag="dsh-v0.1.0-rc.7"
+checkout="${DSH_CHECKOUT:-}"
+temporary_checkout=""
+
+if [[ -z "$checkout" ]]; then
+  temporary_checkout="$(mktemp -d)"
+  trap 'rm -rf "$temporary_checkout"' EXIT
+  checkout="$temporary_checkout/deepseek-harness"
+  git clone --quiet --depth 1 --branch "$tag" \
+    https://github.com/deepseek-ai/deepseek-harness.git "$checkout"
+fi
 
 if [[ ! -d "$checkout/.git" ]]; then
   echo "missing pinned deepseek-harness checkout: $checkout" >&2
@@ -11,7 +21,7 @@ fi
 
 actual="$(git -C "$checkout" rev-parse HEAD)"
 if [[ "$actual" != "$expected" ]]; then
-  echo "unsupported deepseek-harness revision: expected dsh-v0.1.0-rc.7 ($expected), got $actual" >&2
+  echo "unsupported deepseek-harness revision: expected $tag ($expected), got $actual" >&2
   exit 1
 fi
 

--- a/scripts/coordinated-npm-release/__tests__/coordinated-npm-release.test.mjs
+++ b/scripts/coordinated-npm-release/__tests__/coordinated-npm-release.test.mjs
@@ -327,6 +327,18 @@ test("real release manifest preserves every package lifecycle and pack gate", ()
   }
 });
 
+test("dsh contract check bootstraps its pinned upstream on clean runners", async () => {
+  const script = await readFile(
+    resolve(repositoryRoot, "packages/chorus-dsh/scripts/check-dsh-contract.sh"),
+    "utf8",
+  );
+
+  assert.match(script, /checkout="\$\{DSH_CHECKOUT:-\}"/);
+  assert.match(script, /git clone .*--branch "\$tag"/s);
+  assert.match(script, /99f6f02fecdb7dff40c3fbc9470f5907c29f74ca/);
+  assert.doesNotMatch(script, /\/home\/ubuntu\/dev\/deepseek-harness/);
+});
+
 test("standard CI runs the coordinated package-contract suite", async () => {
   const workflow = await readFile(
     resolve(repositoryRoot, ".github/workflows/test.yml"),


### PR DESCRIPTION
## Summary
- bootstrap the pinned deepseek-harness checkout when DSH_CHECKOUT is unset
- keep exact tag and commit validation
- add release-contract regression coverage for clean runners

## Verification
- env -u DSH_CHECKOUT pnpm --dir packages/chorus-dsh run check:dsh-contract
- env -u CHORUS_AGENT_PROFILE pnpm --dir packages/chorus-dsh test
- npm run test:release-contract