### PR TITLE
fix: consolidate dashboard SSE connections

### DIFF
--- a/openspec/changes/archive/2026-09-01-fix-sse-connection-exhaustion/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-01-fix-sse-connection-exhaustion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/archive/2026-09-01-fix-sse-connection-exhaustion/README.md
+++ b/openspec/changes/archive/2026-09-01-fix-sse-connection-exhaustion/README.md
@@ -1,0 +1,3 @@
+# fix-sse-connection-exhaustion
+
+Fix Issue #521 by consolidating browser realtime, presence, and notification delivery onto one stable company-wide SSE stream per tab.

--- a/openspec/changes/archive/2026-09-01-fix-sse-connection-exhaustion/design.md
+++ b/openspec/changes/archive/2026-09-01-fix-sse-connection-exhaustion/design.md
@@ -1,0 +1,105 @@
+## Context
+
+The authenticated dashboard currently mounts three independent browser EventSources:
+
+- `RealtimeProvider` opens `/api/events?projectUuid=...` (or `/api/events`) for page change, presence, and execution subscribers.
+- `AgentPresenceProvider` opens a stable company-wide `/api/events`, optionally adding `sessionUuid`, for execution, session activity, and transcript events.
+- `NotificationProvider` opens `/api/events/notifications` for unread counts and notification toasts.
+
+The shell-level `/api/events` route already multiplexes change, presence, execution, session activity, and transcript events. The company stream therefore sends change/presence events that AgentPresence currently parses and ignores, while Realtime opens another stream to receive part of the same traffic. Browser notification events use a separate user channel on the notification route. Direct HTTP/1.1 deployments expose the browser connection-limit failure described in Issue #521.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Use exactly one long-lived EventSource for the authenticated dashboard tab.
+- Keep that physical stream company-wide and stable across page navigation.
+- Preserve current page project isolation, execution/session visibility, notification UX, and reconnect recovery.
+- Keep daemon registration, reverse control, and notification transport on `/api/events/notifications`.
+- Keep `RealtimeProvider` usable outside the dashboard shell.
+
+**Non-Goals:**
+
+- Sharing a connection across tabs through SharedWorker, BroadcastChannel leader election, or a service worker.
+- Removing `/api/events/notifications` or changing daemon transport.
+- Dynamically reconnecting the shell stream when page project scope changes.
+- Guaranteeing unlimited tabs on HTTP/1.1; HTTP/2 remains recommended.
+- Changing database schemas or notification persistence.
+
+## Decisions
+
+### Introduce a dedicated shell event-spine provider
+
+A new `DashboardEventProvider` will own the sole dashboard `EventSource("/api/events")`, raw parsed-event subscriber registries, the selected transcript `sessionUuid`, and a monotonically increasing open generation. It wraps `AgentPresenceProvider`, `NotificationProvider`, and page `RealtimeProvider` instances.
+
+This separates transport ownership from AgentPresence's domain state and avoids making Notification depend on a provider currently nested inside it. It also removes the runtime/type dependency cycle that would result if Realtime imported AgentPresence while AgentPresence imported Realtime event types.
+
+The provider reconnects only for the existing low-frequency reasons: selected transcript session changes, a non-open stream is detected on visibility resume, or native EventSource reconnect completes. Page navigation does not alter its URL or lifecycle.
+
+### Route domain events through stable subscriptions
+
+The provider parses each SSE data message once and fans the typed payload to ref-backed subscribers. Subscription registration and removal do not reconnect the stream.
+
+- `AgentPresenceProvider` subscribes to execution, session activity, transcript, and open-generation events. Its polling, merge generation guard, activity reset, and execution catch-up behavior remain intact.
+- `RealtimeProvider` subscribes to change, presence, execution, and open-generation events when the shell spine is available.
+- `NotificationProvider` subscribes to notification events and retains its REST unread reconciliation.
+
+When `RealtimeProvider` is mounted without `DashboardEventProvider`, it retains its direct EventSource implementation as a standalone fallback.
+
+### Filter page-scoped events before any page work
+
+The shell stream stays company-wide to avoid navigation reconnect churn. A project-scoped `RealtimeProvider` rejects change and presence events with a different `projectUuid` before touching throttle timers, debounce timers, or subscribers. Unscoped company pages retain company-wide change/presence delivery.
+
+Execution events remain company/visibility scoped. This preserves existing server behavior: the `projectUuid` query parameter filters change and presence handlers but does not filter execution channels.
+
+Client filtering was chosen over dynamic server scope because changing scope requires replacing the EventSource. That would clear/replay session activity and re-fetch execution state on every project navigation, creating more churn and recovery risk than the lightweight early guard.
+
+### Add browser notifications to the main route without moving daemon lifecycle
+
+For authenticated browser-user streams, `/api/events` will subscribe to the existing `notification:<type>:<actorUuid>` event-bus channel and clean it up on abort. The event payload remains unchanged, including `new_notification`, `count_update`, and `unreadCount`.
+
+Daemon clients continue to use `/api/events/notifications`, including registration outcome, control subscription, liveness touch, disconnect reconciliation, and daemon-targeted notifications. The consolidation does not remove or repurpose that route.
+
+The server must not create duplicate browser notification subscriptions across both routes after the client migration; dashboard `NotificationProvider` no longer opens its own EventSource.
+
+### Preserve notification visibility semantics at consumption time
+
+The old notification stream disconnects while the document is hidden. The unified spine remains connected, so notification consumption must explicitly preserve toast behavior:
+
+- On every `new_notification`, read `document.visibilityState` at receive time.
+- Call `showToast` only when the value is exactly `"visible"`; do not capture visibility in a stale closure.
+- Continue applying `unreadCount` updates while hidden.
+- On visibility transition to visible, fetch unread state through REST to reconcile any disconnect or delivery gap.
+- Visibility changes affect only notification consumption and never close the shared stream.
+
+### Use open generations for gap recovery
+
+`DashboardEventProvider` increments an open generation whenever the physical EventSource opens. Consumers distinguish initial open from subsequent opens:
+
+- Realtime emits its existing general and entity catch-up notifications after a reopen.
+- AgentPresence clears stale activity replay state and re-fetches the execution aggregate after a reopen.
+- Notification relies on pushed unread counts plus its visibility REST reconciliation.
+
+Callbacks read current subscriber refs, and all listeners, timers, and subscriptions are removed on unmount.
+
+## Risks / Trade-offs
+
+- **[Risk] Unrelated company events trigger page refresh work.** → Apply `projectUuid` rejection before throttle, debounce, and every page subscriber; regression-test zero callbacks for unrelated projects.
+- **[Risk] The unified provider becomes a broad coupling point.** → Keep it transport-only with typed subscription contracts; domain state remains in the three existing providers.
+- **[Risk] Hidden tabs start showing notification toasts.** → Gate `showToast` using receive-time `document.visibilityState` and test stale-closure-sensitive visibility changes.
+- **[Risk] A reconnect loses events or causes stale views.** → Emit open generations and retain REST/poll catch-up paths; test native and explicit reconnects.
+- **[Risk] Browser notifications are delivered twice during migration.** → Remove the dashboard notification EventSource in the same change and test one physical EventSource plus one toast per event.
+- **[Trade-off] Company change/presence fan-out remains.** → This traffic already exists on the shell stream, and removing the duplicate project stream lowers total wire events. Revisit server scoping only with measured fan-out evidence.
+- **[Trade-off] Six HTTP/1.1 tabs can still occupy six connections.** → One stream per tab materially raises the limit; HTTP/2 or a future cross-tab shared connection is the complete transport-level mitigation.
+
+## Migration Plan
+
+1. Add browser notification forwarding to `/api/events` while retaining the daemon route.
+2. Introduce `DashboardEventProvider` and migrate AgentPresence to it.
+3. Migrate Realtime and Notification consumers, then reorder dashboard providers so all share the spine.
+4. Add route, context, composition, visibility, reconnect, and cleanup tests.
+5. Deploy as one atomic application change. Rollback restores the three existing client EventSources; no data migration is involved.
+
+## Open Questions
+
+None required for implementation.

--- a/openspec/changes/archive/2026-09-01-fix-sse-connection-exhaustion/proposal.md
+++ b/openspec/changes/archive/2026-09-01-fix-sse-connection-exhaustion/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Each authenticated dashboard tab currently opens three long-lived SSE connections. In direct HTTP/1.1 Docker deployments, two tabs can consume the browser's six same-origin connections and indefinitely queue navigation, RSC, and API requests, as reproduced in GitHub Issue #521.
+
+## What Changes
+
+- Consolidate browser realtime change/presence, agent execution/session/transcript, and notification delivery onto one stable company-wide `/api/events` EventSource per dashboard tab.
+- Keep the shell-level event spine stable across page navigation; page realtime consumers filter change and presence events by `projectUuid` before throttle, debounce, or subscriber work.
+- Preserve the existing company/visibility scope for execution and session events.
+- Add browser notification delivery to `/api/events` while retaining `/api/events/notifications` for daemon registration, control, and notification transport.
+- Preserve notification UX after consolidation: hidden tabs update unread state but do not show toasts; visible transitions reconcile unread state through REST.
+- Preserve a standalone EventSource fallback for `RealtimeProvider` when it is mounted outside the authenticated dashboard shell.
+- Add regression coverage for one EventSource per tab, event routing, reconnect catch-up, visibility behavior, and cleanup.
+
+## Capabilities
+
+### New Capabilities
+
+- `unified-browser-sse`: Defines the single-stream browser transport, routing scopes, notification visibility semantics, reconnect recovery, and standalone fallback.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affects the main and notification SSE routes, `AgentPresenceProvider`, `RealtimeProvider`, `NotificationProvider`, dashboard provider composition, and their tests.
+- Browser clients move from three SSE connections to one; daemon clients continue using `/api/events/notifications`.
+- No database migration or new runtime dependency is required.
+- HTTP/2 remains a recommended deployment improvement, but direct HTTP/1.1 deployments no longer depend on it for ordinary multi-tab use.
+- Implementation and tests are in scope after proposal approval; creating or merging a pull request still requires separate explicit authorization.

--- a/openspec/changes/archive/2026-09-01-fix-sse-connection-exhaustion/specs/unified-browser-sse/spec.md
+++ b/openspec/changes/archive/2026-09-01-fix-sse-connection-exhaustion/specs/unified-browser-sse/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: One dashboard EventSource per tab
+The authenticated dashboard SHALL use exactly one physical EventSource for browser change, presence, execution, session activity, transcript, and notification delivery. The EventSource SHALL remain stable across page navigation and SHALL reconnect only for transcript-session selection or connection recovery.
+
+#### Scenario: Project dashboard mounts
+- **WHEN** the authenticated dashboard mounts its shell and a project-scoped realtime page
+- **THEN** the browser opens exactly one EventSource and its URL targets `/api/events`
+
+#### Scenario: Navigation changes project
+- **WHEN** the user navigates between dashboard projects without changing the selected transcript session
+- **THEN** the physical EventSource remains open and is not replaced because of the project change
+
+#### Scenario: Transcript session changes
+- **WHEN** the selected transcript session changes
+- **THEN** the shared EventSource reconnects with the new encoded `sessionUuid` and all domain subscribers remain registered
+
+### Requirement: Shared realtime preserves event scopes
+The unified browser stream SHALL deliver company-visible execution and session events without page-project filtering. A project-scoped realtime consumer MUST reject change and presence events for other projects before invoking throttle, debounce, general refresh, entity, or presence subscribers.
+
+#### Scenario: Matching project change
+- **WHEN** a change or presence event has the mounted realtime provider's `projectUuid`
+- **THEN** the provider routes it through the existing page subscription behavior
+
+#### Scenario: Unrelated project event
+- **WHEN** a change or presence event has a different `projectUuid`
+- **THEN** the provider invokes no page subscriber and schedules no throttle or debounce work
+
+#### Scenario: Company-visible execution on any project page
+- **WHEN** the stream emits an execution event visible to the authenticated caller
+- **THEN** execution consumers receive it regardless of the mounted page project
+
+### Requirement: Browser notifications share the main stream
+The main `/api/events` route SHALL forward the authenticated browser user's existing notification-channel payloads on the unified stream. Daemon registration, control, liveness, disconnect, and notification transport MUST remain available on `/api/events/notifications`.
+
+#### Scenario: Browser notification arrives
+- **WHEN** the notification event bus publishes an event for the authenticated dashboard user
+- **THEN** `/api/events` forwards the unchanged notification payload and the browser does not open `/api/events/notifications`
+
+#### Scenario: Daemon connects to notification transport
+- **WHEN** a daemon connects to `/api/events/notifications` with self-report parameters
+- **THEN** its registration, control, liveness, disconnect, and notification behavior remains unchanged
+
+#### Scenario: Unified stream aborts
+- **WHEN** a browser `/api/events` request is aborted
+- **THEN** its notification-channel listener and all other event listeners and timers are removed
+
+### Requirement: Notification visibility behavior is preserved
+Notification consumers SHALL read `document.visibilityState` when each notification is received. They MUST show a notification toast only while the document is visible, MUST allow unread counts to update while hidden, and MUST reconcile unread state through REST when the document becomes visible.
+
+#### Scenario: Notification received while visible
+- **WHEN** a `new_notification` event arrives and `document.visibilityState` is `"visible"`
+- **THEN** the unread count updates and one toast is shown
+
+#### Scenario: Notification received while hidden
+- **WHEN** a `new_notification` event arrives and `document.visibilityState` is `"hidden"`
+- **THEN** the unread count updates and no toast is shown
+
+#### Scenario: Visibility changes after subscriber creation
+- **WHEN** visibility changes between subscription time and notification receive time
+- **THEN** toast behavior uses the visibility value at receive time rather than a captured earlier value
+
+#### Scenario: Hidden tab becomes visible
+- **WHEN** the document transitions from hidden to visible
+- **THEN** the notification consumer fetches the unread aggregate through REST without reconnecting the shared EventSource
+
+### Requirement: Reconnects trigger domain catch-up
+The shared event provider SHALL expose a monotonically increasing open generation and distinguish initial connection from subsequent opens. Realtime and agent-presence consumers MUST run their existing catch-up behavior after a subsequent open where events may have been missed.
+
+#### Scenario: Stream reopens after interruption
+- **WHEN** the EventSource opens after an earlier successful open
+- **THEN** realtime triggers general and entity catch-up and agent presence refreshes the execution aggregate
+
+#### Scenario: Initial stream open
+- **WHEN** the EventSource opens for the first time
+- **THEN** consumers use their existing initial fetch paths without duplicate reconnect catch-up work
+
+### Requirement: Standalone realtime fallback remains supported
+A `RealtimeProvider` mounted outside the dashboard shared-event provider SHALL manage its own `/api/events` EventSource with optional project scoping and SHALL close it and clear all timers on unmount.
+
+#### Scenario: Standalone project provider
+- **WHEN** a project-scoped `RealtimeProvider` mounts without the shared dashboard provider
+- **THEN** it opens `/api/events?projectUuid=<encoded-project-uuid>` and preserves its existing event routing
+
+#### Scenario: Standalone provider unmounts
+- **WHEN** the standalone provider unmounts
+- **THEN** it closes its EventSource, removes visibility listeners, and clears pending throttle and debounce timers

--- a/openspec/changes/archive/2026-09-01-fix-sse-connection-exhaustion/tasks.md
+++ b/openspec/changes/archive/2026-09-01-fix-sse-connection-exhaustion/tasks.md
@@ -1,0 +1,24 @@
+## 1. Unified server transport
+
+- [x] 1.1 Add authenticated browser-user notification-channel forwarding and abort cleanup to `/api/events`.
+- [x] 1.2 Preserve `/api/events/notifications` daemon registration, control, liveness, disconnect, and notification behavior.
+- [x] 1.3 Extend route tests for browser notification forwarding, tenant/user isolation, unchanged payloads, and listener cleanup.
+
+## 2. Shared dashboard event spine
+
+- [x] 2.1 Introduce a transport-only `DashboardEventProvider` with one EventSource, typed subscriptions, transcript-session selection, open generations, visibility recovery, and cleanup.
+- [x] 2.2 Migrate AgentPresence execution, session activity, transcript, reconnect reset, and execution catch-up behavior to the shared provider.
+- [x] 2.3 Reorder the authenticated dashboard provider composition so AgentPresence, Notification, and Realtime consume the shared spine.
+
+## 3. Realtime and notification consumers
+
+- [x] 3.1 Migrate `RealtimeProvider` to shared change, presence, execution, and open-generation subscriptions while retaining its standalone EventSource fallback.
+- [x] 3.2 Apply project filtering before all realtime throttle, debounce, and subscriber work, while preserving company-visible execution delivery.
+- [x] 3.3 Remove the dashboard notification EventSource, consume shared notification events, gate toasts on receive-time visibility, retain hidden unread updates, and reconcile unread state on visible transitions.
+
+## 4. Regression verification
+
+- [x] 4.1 Add provider integration tests proving one dashboard EventSource, stable navigation, session-driven reconnect, and complete unmount cleanup.
+- [x] 4.2 Add tests for matching/unrelated project routing, company-visible execution, initial versus reopen catch-up, and standalone realtime fallback.
+- [x] 4.3 Add notification tests for visible and hidden delivery, stale-closure-resistant toast gating, hidden unread updates, visible REST reconciliation, and no duplicate event handling.
+- [x] 4.4 Run focused route/context suites plus applicable type-check and lint validation.

--- a/openspec/specs/unified-browser-sse/spec.md
+++ b/openspec/specs/unified-browser-sse/spec.md
@@ -1,0 +1,91 @@
+# unified-browser-sse Specification
+
+## Purpose
+Define the authenticated dashboard's single-stream browser SSE transport, event-scope preservation, notification behavior, reconnect recovery, and standalone realtime fallback.
+
+## Requirements
+### Requirement: One dashboard EventSource per tab
+The authenticated dashboard SHALL use exactly one physical EventSource for browser change, presence, execution, session activity, transcript, and notification delivery. The EventSource SHALL remain stable across page navigation and SHALL reconnect only for transcript-session selection or connection recovery.
+
+#### Scenario: Project dashboard mounts
+- **WHEN** the authenticated dashboard mounts its shell and a project-scoped realtime page
+- **THEN** the browser opens exactly one EventSource and its URL targets `/api/events`
+
+#### Scenario: Navigation changes project
+- **WHEN** the user navigates between dashboard projects without changing the selected transcript session
+- **THEN** the physical EventSource remains open and is not replaced because of the project change
+
+#### Scenario: Transcript session changes
+- **WHEN** the selected transcript session changes
+- **THEN** the shared EventSource reconnects with the new encoded `sessionUuid` and all domain subscribers remain registered
+
+### Requirement: Shared realtime preserves event scopes
+The unified browser stream SHALL deliver company-visible execution and session events without page-project filtering. A project-scoped realtime consumer MUST reject change and presence events for other projects before invoking throttle, debounce, general refresh, entity, or presence subscribers.
+
+#### Scenario: Matching project change
+- **WHEN** a change or presence event has the mounted realtime provider's `projectUuid`
+- **THEN** the provider routes it through the existing page subscription behavior
+
+#### Scenario: Unrelated project event
+- **WHEN** a change or presence event has a different `projectUuid`
+- **THEN** the provider invokes no page subscriber and schedules no throttle or debounce work
+
+#### Scenario: Company-visible execution on any project page
+- **WHEN** the stream emits an execution event visible to the authenticated caller
+- **THEN** execution consumers receive it regardless of the mounted page project
+
+### Requirement: Browser notifications share the main stream
+The main `/api/events` route SHALL forward the authenticated browser user's existing notification-channel payloads on the unified stream. Daemon registration, control, liveness, disconnect, and notification transport MUST remain available on `/api/events/notifications`.
+
+#### Scenario: Browser notification arrives
+- **WHEN** the notification event bus publishes an event for the authenticated dashboard user
+- **THEN** `/api/events` forwards the unchanged notification payload and the browser does not open `/api/events/notifications`
+
+#### Scenario: Daemon connects to notification transport
+- **WHEN** a daemon connects to `/api/events/notifications` with self-report parameters
+- **THEN** its registration, control, liveness, disconnect, and notification behavior remains unchanged
+
+#### Scenario: Unified stream aborts
+- **WHEN** a browser `/api/events` request is aborted
+- **THEN** its notification-channel listener and all other event listeners and timers are removed
+
+### Requirement: Notification visibility behavior is preserved
+Notification consumers SHALL read `document.visibilityState` when each notification is received. They MUST show a notification toast only while the document is visible, MUST allow unread counts to update while hidden, and MUST reconcile unread state through REST when the document becomes visible.
+
+#### Scenario: Notification received while visible
+- **WHEN** a `new_notification` event arrives and `document.visibilityState` is `"visible"`
+- **THEN** the unread count updates and one toast is shown
+
+#### Scenario: Notification received while hidden
+- **WHEN** a `new_notification` event arrives and `document.visibilityState` is `"hidden"`
+- **THEN** the unread count updates and no toast is shown
+
+#### Scenario: Visibility changes after subscriber creation
+- **WHEN** visibility changes between subscription time and notification receive time
+- **THEN** toast behavior uses the visibility value at receive time rather than a captured earlier value
+
+#### Scenario: Hidden tab becomes visible
+- **WHEN** the document transitions from hidden to visible
+- **THEN** the notification consumer fetches the unread aggregate through REST without reconnecting the shared EventSource
+
+### Requirement: Reconnects trigger domain catch-up
+The shared event provider SHALL expose a monotonically increasing open generation and distinguish initial connection from subsequent opens. Realtime and agent-presence consumers MUST run their existing catch-up behavior after a subsequent open where events may have been missed.
+
+#### Scenario: Stream reopens after interruption
+- **WHEN** the EventSource opens after an earlier successful open
+- **THEN** realtime triggers general and entity catch-up and agent presence refreshes the execution aggregate
+
+#### Scenario: Initial stream open
+- **WHEN** the EventSource opens for the first time
+- **THEN** consumers use their existing initial fetch paths without duplicate reconnect catch-up work
+
+### Requirement: Standalone realtime fallback remains supported
+A `RealtimeProvider` mounted outside the dashboard shared-event provider SHALL manage its own `/api/events` EventSource with optional project scoping and SHALL close it and clear all timers on unmount.
+
+#### Scenario: Standalone project provider
+- **WHEN** a project-scoped `RealtimeProvider` mounts without the shared dashboard provider
+- **THEN** it opens `/api/events?projectUuid=<encoded-project-uuid>` and preserves its existing event routing
+
+#### Scenario: Standalone provider unmounts
+- **WHEN** the standalone provider unmounts
+- **THEN** it closes its EventSource, removes visibility listeners, and clears pending throttle and debounce timers

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -30,6 +30,7 @@ import { DaemonPresenceEntry } from "@/components/daemon-presence-entry";
 import { SidebarPreferences } from "@/components/sidebar-preferences";
 import { AgentConnectionsModal } from "@/components/agent-presence";
 import { NotificationProvider } from "@/contexts/notification-context";
+import { DashboardEventProvider } from "@/contexts/dashboard-event-context";
 import {
   ProjectQuickAccessProvider,
   useProjectQuickAccess,
@@ -567,6 +568,7 @@ export default function DashboardLayout({
   };
 
   return (
+    <DashboardEventProvider>
     <NotificationProvider>
     {/* AuthProvider exposes the current user via useAuth() to the whole shell.
         It is mounted here (not the root layout) because only the authenticated
@@ -589,12 +591,11 @@ export default function DashboardLayout({
         of the sidebar recent list (best-effort, ref-guarded). Under the provider
         so it can consume the shared aggregate. */}
     <ProjectVisitRecorder currentProjectUuid={currentProjectUuid} />
-    {/* AgentPresenceProvider is the single shell-level data spine for the
+    {/* AgentPresenceProvider is the shell-level domain state for the
         bottom-right daemon-presence entry + its roster popover + the chat modal.
         Mounted ONCE here, wrapping the whole shell (sidebar + main), so it
-        survives route changes (does not remount per navigation) and is
-        independent of the per-route, project-scoped RealtimeProvider branches
-        below. */}
+        survives route changes and consumes the DashboardEventProvider transport
+        alongside the per-route RealtimeProvider branches below. */}
     <AgentPresenceProvider>
     {/* PixelActivityProvider — the shell↔project bridge that lets the shell-level
         DaemonPresenceEntry open the project-scoped pixel-canvas activity view.
@@ -671,5 +672,6 @@ export default function DashboardLayout({
     </AuthProvider>
     <Toaster position={isMobile ? "top-center" : "top-right"} closeButton={!isMobile} />
     </NotificationProvider>
+    </DashboardEventProvider>
   );
 }

--- a/src/app/api/events/__tests__/route.test.ts
+++ b/src/app/api/events/__tests__/route.test.ts
@@ -642,3 +642,69 @@ describe("GET /api/events (transcript SSE — open-session subscription)", () =>
     expect(offChannels).toContain(`transcript:${sessionUuid}`);
   });
 });
+
+describe("GET /api/events (browser notification forwarding)", () => {
+  beforeEach(() => {
+    mockGetAuthContext.mockResolvedValue(userAuth);
+    mockParseSelfReport.mockReturnValue(null);
+    mockRegisterConnection.mockResolvedValue(null);
+  });
+
+  it("subscribes only the authenticated browser user's channel and forwards payloads unchanged", async () => {
+    const res = await GET(makeRequest());
+    const { chunks } = await startStream(res);
+    const channel = `notification:user:${userUuid}`;
+    const notificationCall = mockEventBus.on.mock.calls.find(
+      ([candidate]) => candidate === channel,
+    );
+
+    expect(notificationCall).toBeDefined();
+    expect(
+      mockEventBus.on.mock.calls.some(
+        ([candidate]) => candidate === "notification:user:another-user",
+      ),
+    ).toBe(false);
+
+    const payload = {
+      type: "new_notification",
+      notificationUuid: "notification-1",
+      unreadCount: 4,
+      action: "mentioned",
+    };
+    const before = chunks.length;
+    notificationCall![1](payload);
+    await flush();
+
+    expect(chunks).toHaveLength(before + 1);
+    expect(chunks.at(-1)).toBe(`data: ${JSON.stringify(payload)}\n\n`);
+  });
+
+  it("removes the browser notification listener on abort", async () => {
+    const abortController = new AbortController();
+    const res = await GET(makeRequest("", abortController.signal));
+    await startStream(res);
+
+    abortController.abort();
+    await flush();
+
+    expect(mockEventBus.off).toHaveBeenCalledWith(
+      `notification:user:${userUuid}`,
+      expect.any(Function),
+    );
+  });
+
+  it("does not add browser notification forwarding to a registered daemon stream", async () => {
+    mockGetAuthContext.mockResolvedValue(agentAuth);
+    mockParseSelfReport.mockReturnValue({ clientType: "claude_code" });
+    mockRegisterConnection.mockResolvedValue(connHandle);
+
+    const res = await GET(makeRequest("clientType=claude_code"));
+    await startStream(res);
+
+    expect(
+      mockEventBus.on.mock.calls.some(([channel]) =>
+        String(channel).startsWith("notification:"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -53,6 +53,8 @@ export async function GET(request: NextRequest) {
   // handle gets the full lifecycle as before; a null registration leaves both null.
   const conflict = isConnectionConflict(registration) ? registration : null;
   const conn = isConnectionConflict(registration) ? null : registration;
+  const notificationChannel =
+    !conn && !conflict ? `notification:${auth.type}:${auth.actorUuid}` : null;
 
   // Resolve which daemon connections this caller may see (owner/self scoped) so
   // the stream can forward their per-connection `execution:{uuid}` events. The
@@ -129,6 +131,16 @@ export async function GET(request: NextRequest) {
       };
 
       eventBus.on("presence", presenceHandler);
+
+      // Browser notifications share this company-wide dashboard stream. Daemon
+      // clients have a registered connection and keep using the dedicated
+      // /api/events/notifications transport for registration/control/liveness.
+      const notificationHandler = (event: Record<string, unknown>) => {
+        send(`data: ${JSON.stringify(event)}\n\n`);
+      };
+      if (notificationChannel) {
+        eventBus.on(notificationChannel, notificationHandler);
+      }
 
       // Subscribe to per-connection execution-state events for every connection
       // this caller may see. Each event is forwarded tagged with a `type:
@@ -209,6 +221,9 @@ export async function GET(request: NextRequest) {
       request.signal.addEventListener("abort", () => {
         eventBus.off("change", handler);
         eventBus.off("presence", presenceHandler);
+        if (notificationChannel) {
+          eventBus.off(notificationChannel, notificationHandler);
+        }
         for (const channel of executionChannels) {
           eventBus.off(channel, executionHandler);
         }

--- a/src/contexts/__tests__/agent-presence-context.test.tsx
+++ b/src/contexts/__tests__/agent-presence-context.test.tsx
@@ -699,6 +699,7 @@ describe("AgentPresenceProvider — reconnect re-fetches the aggregate", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+    act(() => lastEventSource?.onopen?.());
     const constructionsAfterMount = eventSourceConstructions;
     const execCallsAfterMount = execCall;
 
@@ -714,6 +715,7 @@ describe("AgentPresenceProvider — reconnect re-fetches the aggregate", () => {
       document.dispatchEvent(new Event("visibilitychange"));
     });
     await act(async () => {
+      lastEventSource?.onopen?.();
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -742,6 +744,7 @@ describe("AgentPresenceProvider — reconnect re-fetches the aggregate (closed)"
       await Promise.resolve();
       await Promise.resolve();
     });
+    act(() => lastEventSource?.onopen?.());
     const constructionsAfterMount = eventSourceConstructions;
     const execCallsAfterMount = execCall;
 
@@ -755,6 +758,7 @@ describe("AgentPresenceProvider — reconnect re-fetches the aggregate (closed)"
       document.dispatchEvent(new Event("visibilitychange"));
     });
     await act(async () => {
+      lastEventSource?.onopen?.();
       await Promise.resolve();
       await Promise.resolve();
     });

--- a/src/contexts/__tests__/dashboard-event-context.test.tsx
+++ b/src/contexts/__tests__/dashboard-event-context.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+import React, { useEffect } from "react";
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DashboardEventProvider,
+  useDashboardEvents,
+} from "@/contexts/dashboard-event-context";
+
+class MockEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+  static instances: MockEventSource[] = [];
+
+  url: string;
+  readyState = MockEventSource.CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  close = vi.fn(() => {
+    this.readyState = MockEventSource.CLOSED;
+  });
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+}
+
+function Harness({
+  project,
+  onEvent,
+  onGeneration,
+  exposeSession,
+}: {
+  project: string;
+  onEvent: (event: Record<string, unknown>) => void;
+  onGeneration: (generation: number) => void;
+  exposeSession: (setter: (uuid: string | null) => void) => void;
+}) {
+  const events = useDashboardEvents();
+  useEffect(() => events.subscribe(onEvent), [events.subscribe, onEvent]);
+  useEffect(() => onGeneration(events.openGeneration), [
+    events.openGeneration,
+    onGeneration,
+  ]);
+  useEffect(() => exposeSession(events.setSessionUuid), [
+    events.setSessionUuid,
+    exposeSession,
+  ]);
+  return <div>{project}</div>;
+}
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+  vi.stubGlobal("EventSource", MockEventSource);
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value: "visible",
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("DashboardEventProvider", () => {
+  it("keeps one stream across child navigation and reconnects only for session selection", () => {
+    const onEvent = vi.fn();
+    const onGeneration = vi.fn();
+    let setSessionUuid: (uuid: string | null) => void = () => {};
+    const exposeSession = (setter: typeof setSessionUuid) => {
+      setSessionUuid = setter;
+    };
+
+    const view = render(
+      <DashboardEventProvider>
+        <Harness
+          project="project-a"
+          onEvent={onEvent}
+          onGeneration={onGeneration}
+          exposeSession={exposeSession}
+        />
+      </DashboardEventProvider>,
+    );
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe("/api/events");
+
+    view.rerender(
+      <DashboardEventProvider>
+        <Harness
+          project="project-b"
+          onEvent={onEvent}
+          onGeneration={onGeneration}
+          exposeSession={exposeSession}
+        />
+      </DashboardEventProvider>,
+    );
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    act(() => setSessionUuid("session with space"));
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(MockEventSource.instances[0].close).toHaveBeenCalledOnce();
+    expect(MockEventSource.instances[1].url).toBe(
+      "/api/events?sessionUuid=session%20with%20space",
+    );
+  });
+
+  it("parses once, fans out events, increments opens, recovers visibility, and cleans up", () => {
+    const onEvent = vi.fn();
+    const onGeneration = vi.fn();
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+    const view = render(
+      <DashboardEventProvider>
+        <Harness
+          project="project-a"
+          onEvent={onEvent}
+          onGeneration={onGeneration}
+          exposeSession={() => {}}
+        />
+      </DashboardEventProvider>,
+    );
+    const first = MockEventSource.instances[0];
+
+    act(() => {
+      first.onmessage?.({
+        data: JSON.stringify({ type: "presence", projectUuid: "project-a" }),
+      } as MessageEvent);
+      first.onopen?.();
+      first.onopen?.();
+    });
+    expect(onEvent).toHaveBeenCalledOnce();
+    expect(onEvent).toHaveBeenCalledWith({
+      type: "presence",
+      projectUuid: "project-a",
+    });
+    expect(onGeneration).toHaveBeenLastCalledWith(2);
+
+    act(() => {
+      first.readyState = MockEventSource.CONNECTING;
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(first.close).toHaveBeenCalledOnce();
+
+    const recovered = MockEventSource.instances[1];
+    view.unmount();
+    expect(recovered.close).toHaveBeenCalledOnce();
+    expect(removeSpy).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function),
+    );
+  });
+});

--- a/src/contexts/__tests__/notification-context.test.tsx
+++ b/src/contexts/__tests__/notification-context.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DashboardEventProvider } from "@/contexts/dashboard-event-context";
+import {
+  NotificationProvider,
+  useNotification,
+} from "@/contexts/notification-context";
+import { AgentPresenceProvider } from "@/contexts/agent-presence-context";
+import { RealtimeProvider } from "@/contexts/realtime-context";
+
+const authFetch = vi.fn();
+const toast = vi.fn();
+const stableMocks = vi.hoisted(() => ({
+  router: { push: vi.fn() },
+  translate: (key: string) => key,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authFetch: (...args: unknown[]) => authFetch(...args),
+}));
+vi.mock("@/hooks/use-progress-router", () => ({
+  useRouter: () => stableMocks.router,
+}));
+vi.mock("next-intl", () => ({
+  useTranslations: () => stableMocks.translate,
+}));
+vi.mock("sonner", () => ({ toast: (...args: unknown[]) => toast(...args) }));
+
+class MockEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+  static instances: MockEventSource[] = [];
+  readyState = MockEventSource.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  close = vi.fn();
+  constructor(public url: string) {
+    MockEventSource.instances.push(this);
+  }
+}
+
+function Count() {
+  const { unreadCount } = useNotification();
+  return <div data-testid="count">{unreadCount}</div>;
+}
+
+let visibility: DocumentVisibilityState;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  MockEventSource.instances = [];
+  vi.stubGlobal("EventSource", MockEventSource);
+  visibility = "visible";
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => visibility,
+  });
+  authFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true, data: { unreadCount: 1 } }),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("NotificationProvider shared transport", () => {
+  it("uses receive-time visibility, updates hidden unread, and reconciles without reconnecting", async () => {
+    render(
+      <DashboardEventProvider>
+        <NotificationProvider>
+          <AgentPresenceProvider>
+            <RealtimeProvider projectUuid="project-a">
+              <Count />
+            </RealtimeProvider>
+          </AgentPresenceProvider>
+        </NotificationProvider>
+      </DashboardEventProvider>,
+    );
+    await act(async () => Promise.resolve());
+    expect(screen.getByTestId("count").textContent).toBe("1");
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe("/api/events");
+
+    act(() => {
+      MockEventSource.instances[0].onmessage?.({
+        data: JSON.stringify({
+          type: "new_notification",
+          unreadCount: 2,
+          action: "mentioned",
+          actorName: "Ada",
+          entityTitle: "Task",
+        }),
+      } as MessageEvent);
+    });
+    expect(screen.getByTestId("count").textContent).toBe("2");
+    expect(toast).toHaveBeenCalledTimes(1);
+
+    visibility = "hidden";
+    act(() => {
+      MockEventSource.instances[0].onmessage?.({
+        data: JSON.stringify({
+          type: "new_notification",
+          unreadCount: 3,
+          action: "mentioned",
+          actorName: "Ada",
+          entityTitle: "Task",
+        }),
+      } as MessageEvent);
+    });
+    expect(screen.getByTestId("count").textContent).toBe("3");
+    expect(toast).toHaveBeenCalledTimes(1);
+
+    const notificationFetchesBeforeVisible = authFetch.mock.calls.filter(([url]) =>
+      String(url).startsWith("/api/notifications"),
+    ).length;
+    authFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: { unreadCount: 7 } }),
+    });
+    visibility = "visible";
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("count").textContent).toBe("7");
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(
+      authFetch.mock.calls.filter(([url]) =>
+        String(url).startsWith("/api/notifications"),
+      ),
+    ).toHaveLength(notificationFetchesBeforeVisible + 1);
+  });
+});

--- a/src/contexts/__tests__/realtime-shared-context.test.tsx
+++ b/src/contexts/__tests__/realtime-shared-context.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DashboardEventProvider } from "@/contexts/dashboard-event-context";
+import {
+  RealtimeProvider,
+  useExecutionSubscription,
+  usePresenceSubscription,
+  useRealtimeEntityTypeEvent,
+  useRealtimeEvent,
+} from "@/contexts/realtime-context";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+class MockEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+  static instances: MockEventSource[] = [];
+  readyState = MockEventSource.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  close = vi.fn(() => {
+    this.readyState = MockEventSource.CLOSED;
+  });
+  constructor(public url: string) {
+    MockEventSource.instances.push(this);
+  }
+}
+
+function Consumers({
+  general,
+  entity,
+  presence,
+  execution,
+}: {
+  general: () => void;
+  entity: () => void;
+  presence: () => void;
+  execution: () => void;
+}) {
+  useRealtimeEvent(general);
+  useRealtimeEntityTypeEvent("task", entity);
+  usePresenceSubscription(presence);
+  useExecutionSubscription("connection-1", execution);
+  return null;
+}
+
+function Shared({
+  projectUuid,
+  callbacks,
+}: {
+  projectUuid: string;
+  callbacks: {
+    general: () => void;
+    entity: () => void;
+    presence: () => void;
+    execution: () => void;
+  };
+}) {
+  return (
+    <DashboardEventProvider>
+      <RealtimeProvider projectUuid={projectUuid}>
+        <Consumers {...callbacks} />
+      </RealtimeProvider>
+    </DashboardEventProvider>
+  );
+}
+
+function emit(payload: Record<string, unknown>) {
+  MockEventSource.instances.at(-1)?.onmessage?.({
+    data: JSON.stringify(payload),
+  } as MessageEvent);
+}
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+  vi.stubGlobal("EventSource", MockEventSource);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("RealtimeProvider shared dashboard transport", () => {
+  it("filters project events before all work but keeps execution company-visible", () => {
+    const callbacks = {
+      general: vi.fn(),
+      entity: vi.fn(),
+      presence: vi.fn(),
+      execution: vi.fn(),
+    };
+    render(<Shared projectUuid="project-a" callbacks={callbacks} />);
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(callbacks.general).toHaveBeenCalledTimes(1); // hook initial fetch
+
+    act(() => {
+      emit({
+        companyUuid: "company",
+        projectUuid: "project-b",
+        entityType: "task",
+        entityUuid: "task-b",
+        action: "updated",
+      });
+      emit({
+        type: "presence",
+        companyUuid: "company",
+        projectUuid: "project-b",
+      });
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(callbacks.general).toHaveBeenCalledTimes(1);
+    expect(callbacks.entity).not.toHaveBeenCalled();
+    expect(callbacks.presence).not.toHaveBeenCalled();
+
+    act(() => {
+      emit({
+        companyUuid: "company",
+        projectUuid: "project-a",
+        entityType: "task",
+        entityUuid: "task-a",
+        action: "updated",
+      });
+      emit({
+        type: "presence",
+        companyUuid: "company",
+        projectUuid: "project-a",
+      });
+      emit({
+        type: "execution",
+        companyUuid: "company",
+        projectUuid: "project-b",
+        connectionUuid: "connection-1",
+        executions: [],
+      });
+      vi.advanceTimersByTime(3_000);
+    });
+    expect(callbacks.general).toHaveBeenCalledTimes(2);
+    expect(callbacks.entity).toHaveBeenCalledTimes(1);
+    expect(callbacks.presence).toHaveBeenCalledTimes(1);
+    expect(callbacks.execution).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reconnect for project navigation and catches up only after a reopen", () => {
+    const callbacks = {
+      general: vi.fn(),
+      entity: vi.fn(),
+      presence: vi.fn(),
+      execution: vi.fn(),
+    };
+    const view = render(<Shared projectUuid="project-a" callbacks={callbacks} />);
+    const source = MockEventSource.instances[0];
+    const initialGeneralCalls = callbacks.general.mock.calls.length;
+
+    act(() => source.onopen?.());
+    expect(callbacks.general).toHaveBeenCalledTimes(initialGeneralCalls);
+
+    view.rerender(<Shared projectUuid="project-b" callbacks={callbacks} />);
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    act(() => source.onopen?.());
+    expect(callbacks.general).toHaveBeenCalledTimes(initialGeneralCalls + 1);
+    expect(callbacks.entity).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains a project-scoped standalone fallback and closes it on unmount", () => {
+    const callbacks = {
+      general: vi.fn(),
+      entity: vi.fn(),
+      presence: vi.fn(),
+      execution: vi.fn(),
+    };
+    const view = render(
+      <RealtimeProvider projectUuid="project/a">
+        <Consumers {...callbacks} />
+      </RealtimeProvider>,
+    );
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe(
+      "/api/events?projectUuid=project%2Fa",
+    );
+
+    view.unmount();
+    expect(MockEventSource.instances[0].close).toHaveBeenCalledOnce();
+  });
+});

--- a/src/contexts/agent-presence-context.tsx
+++ b/src/contexts/agent-presence-context.tsx
@@ -1,22 +1,18 @@
 "use client";
 
-// Agent Presence — the single shell-level data spine for the sidebar presence
-// pill, its click popover, and the "View all" modal.
+// Agent Presence — shell-level domain state for the sidebar presence pill, its
+// click popover, and the "View all" modal.
 //
-// WHY a dedicated, shell-mounted provider (not RealtimeContext):
+// WHY a dedicated, shell-mounted domain provider (not RealtimeContext):
 //   The sidebar renders OUTSIDE any `RealtimeProvider` — `RealtimeProvider` is
 //   mounted per-`<main>`, scoped by `projectUuid`, and remounts on navigation;
 //   `/settings` mounts none. So the presence pill (which lives in the always-on
-//   rail) needs its OWN self-contained spine that wraps the whole dashboard shell
-//   and survives route changes. This provider deliberately does NOT depend on or
-//   modify `RealtimeContext`; it opens its own company-wide `/api/events`
-//   EventSource. The two browser EventSource instances are independent — the
-//   server fans out per auth — so a second, shell-level stream coexists with the
-//   page-scoped one (and once the standalone page is removed, net per-tab SSE
-//   count does not increase).
+//   rail) needs state that wraps the whole dashboard shell and survives route
+//   changes. Transport is owned by DashboardEventProvider; AgentPresence and
+//   page Realtime subscribe independently without opening duplicate streams.
 //
-// Data sources (single poll, single SSE — every consumer reads from here, so no
-// duplicate requests across the pill and the modal):
+// Data sources (single poll plus shared SSE subscription — every consumer reads
+// from here, so no duplicate requests across the pill and the modal):
 //   - Connections + online count — polls `GET /api/agent-connections` every 15s,
 //     same cadence/source as the prior page. Online =
 //     `effectiveStatus === "online"`.
@@ -28,8 +24,8 @@
 //     stream opened emits events on a channel this stream isn't subscribed to —
 //     the poll is what surfaces its executions. The poll also recovers from a
 //     silently-dropped SSE message (EventSource has no per-message replay).
-//   - Execution live updates — its own company-wide `EventSource("/api/events")`
-//     (no `projectUuid`) merges `type === "execution"` events by `connectionUuid`
+//   - Execution live updates — the shared company-wide dashboard event stream
+//     merges `type === "execution"` events by `connectionUuid`
 //     into an executions-by-connection map for sub-poll latency. The SSE event
 //     carries the connection's FULL current active set, so a merge replaces that
 //     connection's slice wholesale (no per-row reconcile). Because the poll and
@@ -60,11 +56,17 @@ import {
 } from "react";
 import { authFetch } from "@/lib/auth-client";
 import { clientLogger } from "@/lib/logger-client";
+import {
+  DashboardEventProvider,
+  buildDashboardEventsUrl,
+  useDashboardEvents,
+  useDashboardEventsOptional,
+  type DashboardExecutionEvent,
+} from "@/contexts/dashboard-event-context";
 import type {
   ConnectionView,
   ExecutionView,
 } from "@/components/agent-presence";
-import type { ExecutionEvent } from "@/contexts/realtime-context";
 import type {
   SessionActivityEvent,
   SessionView,
@@ -359,10 +361,7 @@ export function deriveActiveSessionsByIdea(
  * EventSource. The sessionUuid is URL-encoded defensively even though uuids are
  * already URL-safe. Returns the bare stream for a null/empty session.
  */
-export function buildEventsUrl(openSession: string | null): string {
-  if (!openSession) return "/api/events";
-  return `/api/events?sessionUuid=${encodeURIComponent(openSession)}`;
-}
+export { buildDashboardEventsUrl as buildEventsUrl };
 
 /**
  * Decide whether an arbitrary parsed SSE message is a transcript event for the open
@@ -389,6 +388,25 @@ export function routeTranscriptEvent(
 // ===== Provider =====
 
 export function AgentPresenceProvider({ children }: { children: ReactNode }) {
+  const dashboardEvents = useDashboardEventsOptional();
+  if (!dashboardEvents) {
+    return (
+      <DashboardEventProvider>
+        <AgentPresenceProvider>{children}</AgentPresenceProvider>
+      </DashboardEventProvider>
+    );
+  }
+  return <AgentPresenceProviderInner>{children}</AgentPresenceProviderInner>;
+}
+
+function AgentPresenceProviderInner({ children }: { children: ReactNode }) {
+  const dashboardEvents = useDashboardEvents();
+  const {
+    subscribe: subscribeDashboardEvents,
+    openGeneration,
+    sessionUuid: openSession,
+    setSessionUuid: setOpenSession,
+  } = dashboardEvents;
   const [status, setStatus] = useState<AgentPresenceStatus>("loading");
   const [connections, setConnections] = useState<ConnectionView[]>([]);
   const [executionsByConnection, setExecutionsByConnection] =
@@ -400,7 +418,6 @@ export function AgentPresenceProvider({ children }: { children: ReactNode }) {
   // The open conversation. Changing it reconnects the SSE stream with a new
   // `?sessionUuid=` (see the SSE effect). `null` = no conversation open / no transcript
   // channel subscribed.
-  const [openSession, setOpenSession] = useState<string | null>(null);
   // One-shot chat focus target (set by `openChatForAgent`, consumed by `DaemonChat`
   // on modal open). Not a SSE/poll concern — purely UI focus seeding.
   const [focusTarget, setFocusTarget] = useState<ChatFocusTarget | null>(null);
@@ -567,111 +584,44 @@ export function AgentPresenceProvider({ children }: { children: ReactNode }) {
     };
   }, [fetchConnections, fetchExecutions]);
 
-  // SSE spine — one company-wide `/api/events` stream that merges `execution`
-  // events into the map. The aggregate first-paint + periodic re-sync is owned by
-  // the poll loop above; this effect additionally re-pulls the aggregate on a
-  // reconnect so the surface catches up immediately rather than waiting for the
-  // next poll tick. Reconnect on `visibilitychange` whenever the stream is not
-  // OPEN, and close on unmount. Held in a stable effect so the stream is NOT torn
-  // down per navigation (the provider lives at the shell, above route changes).
+  // Consume the shell-owned transport. Subscription changes never replace the
+  // physical EventSource; the DashboardEventProvider owns reconnect/session URL
+  // changes and fans each parsed payload out once.
   useEffect(() => {
-    let es: EventSource | null = null;
-
-    function connect() {
-      disconnect();
-      // No `projectUuid` — this is the company-wide stream that forwards every visible
-      // connection's `execution:{connectionUuid}` events. When a conversation is open it
-      // ALSO carries `?sessionUuid=<uuid>` so the server subscribes that one session's
-      // `transcript:{sessionUuid}` channel; the URL is rebuilt from `openSession` on
-      // every (re)connect so a conversation switch reconnects to the new channel.
-      es = new EventSource(buildEventsUrl(openSession));
-      // EventSource fires `open` for the initial connection and every browser
-      // reconnect. Clear stale tokens before the server replays its authoritative
-      // running snapshot through session_started events.
-      es.onopen = () => {
-        setSessionActivity(emptySessionActivityState());
-      };
-      es.onmessage = (msg) => {
-        let parsed: (Record<string, unknown> & { type?: unknown }) | null = null;
-        try {
-          parsed = JSON.parse(msg.data);
-        } catch {
-          // Non-JSON message (e.g. heartbeat) — ignore.
-          return;
-        }
-        if (!parsed) return;
-        // Transcript events for the open conversation are fanned out to subscribers
-        // (the chat container). The server only subscribes the `?sessionUuid=` it was
-        // asked for, so any transcript event here is for the open session.
-        if (routeTranscriptEvent(parsed, transcriptSubscribersRef.current)) return;
-        if (
-          parsed.type === "session_started" ||
-          parsed.type === "session_ended"
-        ) {
-          setSessionActivity((prev) =>
-            reduceSessionActivity(
-              prev,
-              parsed as unknown as SessionActivityEvent,
-            ),
-          );
-          return;
-        }
-        // Execution events merge into the by-connection map; everything else (change /
-        // presence) is the page-scoped provider's concern.
-        if (parsed.type === "execution") {
-          const event = parsed as unknown as ExecutionEvent;
-          // Bump this connection's write generation so an aggregate poll that is
-          // in flight knows this slice was freshened and must not be clobbered.
-          connGenRef.current[event.connectionUuid] =
-            (connGenRef.current[event.connectionUuid] ?? 0) + 1;
-          setExecutionsByConnection((prev) => mergeExecutionEvent(prev, event));
-        }
-      };
-      es.onerror = () => {
-        // Browser EventSource auto-reconnects on error; nothing to do here.
-      };
-    }
-
-    function disconnect() {
-      if (es) {
-        es.close();
-        es = null;
+    return subscribeDashboardEvents((parsed) => {
+      if (routeTranscriptEvent(parsed, transcriptSubscribersRef.current)) return;
+      if (parsed.type === "session_started" || parsed.type === "session_ended") {
+        setSessionActivity((prev) =>
+          reduceSessionActivity(prev, parsed as unknown as SessionActivityEvent),
+        );
+        return;
       }
-    }
-
-    function handleVisibility() {
-      if (document.visibilityState === "visible") {
-        // A live stream is OPEN (readyState 1). A browser auto-reconnect after a
-        // transient error leaves it CONNECTING (0), and an explicit close leaves
-        // it CLOSED (2) — in BOTH cases events may have been missed and the stream
-        // may be stuck, so anything other than OPEN forces a clean reconnect.
-        // (Checking only === CLOSED never fires for the common auto-reconnect.)
-        const streamHealthy = !!es && es.readyState === EventSource.OPEN;
-        if (!streamHealthy) {
-          // Reconnect and re-fetch the aggregate — execution events were missed
-          // while the tab was hidden / the stream was down.
-          connect();
-          fetchExecutions();
-        }
+      if (parsed.type === "execution") {
+        const event = parsed as unknown as DashboardExecutionEvent;
+        connGenRef.current[event.connectionUuid] =
+          (connGenRef.current[event.connectionUuid] ?? 0) + 1;
+        setExecutionsByConnection((prev) => mergeExecutionEvent(prev, event));
       }
+    });
+  }, [subscribeDashboardEvents]);
+
+  // The initial open relies on the poll's first fetch. Every later open denotes
+  // a possible delivery gap (native recovery, explicit visibility recovery, or
+  // transcript-session URL replacement), so reset replay state and catch up.
+  const seenOpenGenerationRef = useRef<number | null>(null);
+  useEffect(() => {
+    const generation = openGeneration;
+    if (generation === 0) return;
+    setSessionActivity(emptySessionActivityState());
+    if (seenOpenGenerationRef.current === null) {
+      seenOpenGenerationRef.current = generation;
+      return;
     }
-
-    // First paint: open the stream. The aggregate first fetch is owned by the
-    // poll loop above (mount fetch), so we don't double-fetch it here.
-    connect();
-    document.addEventListener("visibilitychange", handleVisibility);
-
-    return () => {
-      disconnect();
-      document.removeEventListener("visibilitychange", handleVisibility);
-    };
-    // `openSession` is a dep so a conversation switch tears down and reconnects the
-    // stream with the new `?sessionUuid=`. The full effect re-runs, so the
-    // execution-merge `onmessage`, the `visibilitychange` reconnect, and the
-    // on-reconnect aggregate re-fetch are all re-established intact across the switch
-    // (the periodic poll loop is a separate effect and is unaffected). Reconnecting on
-    // switch is deliberate and low-frequency (a user action), as the Tech Design notes.
-  }, [fetchExecutions, openSession]);
+    if (generation > seenOpenGenerationRef.current) {
+      seenOpenGenerationRef.current = generation;
+      void fetchExecutions();
+    }
+  }, [openGeneration, fetchExecutions]);
 
   const onlineCount = useMemo(
     () => computeOnlineCount(connections),
@@ -776,6 +726,7 @@ export function AgentPresenceProvider({ children }: { children: ReactNode }) {
       activeSessionsByIdea,
       modalOpen,
       openSession,
+      setOpenSession,
       subscribeTranscript,
       focusTarget,
       openChatForAgent,

--- a/src/contexts/dashboard-event-context.tsx
+++ b/src/contexts/dashboard-event-context.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import type { ExecutionEvent as ExecutionEventBase } from "@/services/daemon-execution.service";
+
+export type DashboardEvent = Record<string, unknown> & { type?: unknown };
+export type DashboardEventSubscriber = (event: DashboardEvent) => void;
+
+export interface DashboardExecutionEvent extends ExecutionEventBase {
+  type: "execution";
+}
+
+interface DashboardEventContextValue {
+  subscribe: (callback: DashboardEventSubscriber) => () => void;
+  openGeneration: number;
+  sessionUuid: string | null;
+  setSessionUuid: (sessionUuid: string | null) => void;
+}
+
+const DashboardEventContext = createContext<DashboardEventContextValue | null>(null);
+
+export function buildDashboardEventsUrl(sessionUuid: string | null): string {
+  if (!sessionUuid) return "/api/events";
+  return `/api/events?sessionUuid=${encodeURIComponent(sessionUuid)}`;
+}
+
+export function DashboardEventProvider({ children }: { children: ReactNode }) {
+  const subscribersRef = useRef<Set<DashboardEventSubscriber>>(new Set());
+  const [openGeneration, setOpenGeneration] = useState(0);
+  const [sessionUuid, setSessionUuid] = useState<string | null>(null);
+
+  const subscribe = useCallback((callback: DashboardEventSubscriber) => {
+    subscribersRef.current.add(callback);
+    return () => {
+      subscribersRef.current.delete(callback);
+    };
+  }, []);
+
+  useEffect(() => {
+    let eventSource: EventSource | null = null;
+
+    const disconnect = () => {
+      if (!eventSource) return;
+      eventSource.close();
+      eventSource = null;
+    };
+
+    const connect = () => {
+      disconnect();
+      eventSource = new EventSource(buildDashboardEventsUrl(sessionUuid));
+      eventSource.onopen = () => {
+        setOpenGeneration((generation) => generation + 1);
+      };
+      eventSource.onmessage = (message) => {
+        let parsed: DashboardEvent;
+        try {
+          parsed = JSON.parse(message.data) as DashboardEvent;
+        } catch {
+          return;
+        }
+        for (const callback of subscribersRef.current) callback(parsed);
+      };
+      eventSource.onerror = () => {
+        // Native EventSource reconnects automatically. Its next open increments
+        // openGeneration so domain consumers can repair any delivery gap.
+      };
+    };
+
+    const handleVisibility = () => {
+      if (document.visibilityState !== "visible") return;
+      const streamHealthy =
+        eventSource != null && eventSource.readyState === EventSource.OPEN;
+      if (!streamHealthy) connect();
+    };
+
+    connect();
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      disconnect();
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [sessionUuid]);
+
+  useEffect(
+    () => () => {
+      subscribersRef.current.clear();
+    },
+    [],
+  );
+
+  const value = useMemo<DashboardEventContextValue>(
+    () => ({ subscribe, openGeneration, sessionUuid, setSessionUuid }),
+    [subscribe, openGeneration, sessionUuid],
+  );
+
+  return (
+    <DashboardEventContext.Provider value={value}>
+      {children}
+    </DashboardEventContext.Provider>
+  );
+}
+
+export function useDashboardEvents(): DashboardEventContextValue {
+  const context = useContext(DashboardEventContext);
+  if (!context) {
+    throw new Error("useDashboardEvents must be used within DashboardEventProvider");
+  }
+  return context;
+}
+
+export function useDashboardEventsOptional(): DashboardEventContextValue | null {
+  return useContext(DashboardEventContext);
+}

--- a/src/contexts/notification-context.tsx
+++ b/src/contexts/notification-context.tsx
@@ -23,6 +23,11 @@ import {
   AtSign,
 } from "lucide-react";
 import { authFetch } from "@/lib/auth-client";
+import {
+  DashboardEventProvider,
+  useDashboardEvents,
+  useDashboardEventsOptional,
+} from "@/contexts/dashboard-event-context";
 
 function getToastIcon(action: string) {
   switch (action) {
@@ -75,6 +80,20 @@ function getEntityPath(entityType: string, entityUuid: string, projectUuid: stri
 }
 
 export function NotificationProvider({ children }: NotificationProviderProps) {
+  const dashboardEvents = useDashboardEventsOptional();
+  if (!dashboardEvents) {
+    return (
+      <DashboardEventProvider>
+        <NotificationProvider>{children}</NotificationProvider>
+      </DashboardEventProvider>
+    );
+  }
+  return <NotificationProviderInner>{children}</NotificationProviderInner>;
+}
+
+function NotificationProviderInner({ children }: NotificationProviderProps) {
+  const dashboardEvents = useDashboardEvents();
+  const subscribeDashboardEvents = dashboardEvents.subscribe;
   const [unreadCount, setUnreadCount] = useState(0);
   const subscribersRef = useRef<Set<() => void>>(new Set());
   const router = useRouter();
@@ -140,62 +159,53 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
   );
 
   useEffect(() => {
-    let es: EventSource | null = null;
-    let debounceTimer: NodeJS.Timeout;
-
-    function connect() {
-      disconnect();
-      es = new EventSource("/api/events/notifications");
-
-      es.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data);
-          if (typeof data.unreadCount === "number") {
-            setUnreadCount(data.unreadCount);
-          }
-          if (data.type === "new_notification") {
-            showToast(data);
-          }
-        } catch {
-          // Ignore parse errors
-        }
-        clearTimeout(debounceTimer);
-        debounceTimer = setTimeout(notify, 300);
-      };
-
-      es.onerror = () => {
-        // Browser EventSource auto-reconnects on error
-      };
-    }
-
-    function disconnect() {
-      if (es) {
-        es.close();
-        es = null;
-      }
-    }
+    let debounceTimer: NodeJS.Timeout | undefined;
 
     function handleVisibility() {
       if (document.visibilityState === "visible") {
-        connect();
-        fetchUnreadCount();
-      } else {
-        disconnect();
+        void fetchUnreadCount();
       }
     }
 
-    // Initial connection and data fetch
-    connect();
-    fetchUnreadCount();
+    const unsubscribe = subscribeDashboardEvents((data) => {
+      const notificationPayload =
+        typeof data.unreadCount === "number" ||
+        data.type === "new_notification" ||
+        data.type === "count_update";
+      if (!notificationPayload) return;
+
+      if (typeof data.unreadCount === "number") {
+        setUnreadCount(data.unreadCount);
+      }
+      if (
+        data.type === "new_notification" &&
+        document.visibilityState === "visible"
+      ) {
+        showToast(
+          data as {
+            action?: string;
+            actorName?: string;
+            entityTitle?: string;
+            entityType?: string;
+            entityUuid?: string;
+            projectUuid?: string;
+          },
+        );
+      }
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(notify, 300);
+    });
+
+    void fetchUnreadCount();
 
     document.addEventListener("visibilitychange", handleVisibility);
 
     return () => {
-      disconnect();
+      unsubscribe();
       clearTimeout(debounceTimer);
       document.removeEventListener("visibilitychange", handleVisibility);
     };
-  }, [fetchUnreadCount, notify, showToast]);
+  }, [subscribeDashboardEvents, fetchUnreadCount, notify, showToast]);
 
   const contextValue = useMemo(
     () => ({ unreadCount, refreshNotifications }),

--- a/src/contexts/realtime-context.tsx
+++ b/src/contexts/realtime-context.tsx
@@ -10,6 +10,11 @@ import {
   type ReactNode,
 } from "react";
 import { useRouter } from "@/hooks/use-progress-router";
+import {
+  useDashboardEventsOptional,
+  type DashboardEvent,
+  type DashboardExecutionEvent,
+} from "@/contexts/dashboard-event-context";
 
 type Subscriber = () => void;
 
@@ -48,15 +53,12 @@ export type {
   ExecutionView,
   ExecutionEvent as ExecutionEventBase,
 } from "@/services/daemon-execution.service";
-import type { ExecutionEvent as ExecutionEventBase } from "@/services/daemon-execution.service";
 
 // SSE-tagged execution event: the backend ExecutionEvent plus the `type`
 // discriminator the SSE route adds so the client can route it. Carries the
 // connection's full current active (`running`/`queued`) set so a subscriber
 // re-renders directly off the event without a follow-up read.
-export interface ExecutionEvent extends ExecutionEventBase {
-  type: "execution";
-}
+export type ExecutionEvent = DashboardExecutionEvent;
 
 type ExecutionSubscriber = (event: ExecutionEvent) => void;
 
@@ -75,6 +77,9 @@ interface RealtimeProviderProps {
 }
 
 export function RealtimeProvider({ projectUuid, children }: RealtimeProviderProps) {
+  const dashboardEvents = useDashboardEventsOptional();
+  const subscribeDashboardEvents = dashboardEvents?.subscribe;
+  const sharedOpenGeneration = dashboardEvents?.openGeneration;
   const subscribersRef = useRef<Set<Subscriber>>(new Set());
   const entitySubscribersRef = useRef<Set<EntitySubscriber>>(new Set());
   const presenceSubscribersRef = useRef<Set<PresenceSubscriber>>(new Set());
@@ -88,9 +93,31 @@ export function RealtimeProvider({ projectUuid, children }: RealtimeProviderProp
     entitySubscribersRef.current.forEach((cb) => cb(event));
   }, []);
 
+  const notifyCatchUp = useCallback(() => {
+    notify();
+    for (const entityType of [
+      "task",
+      "idea",
+      "proposal",
+      "document",
+      "project",
+      "project_group",
+    ]) {
+      notifyEntity({
+        companyUuid: "",
+        projectUuid: "",
+        entityType,
+        entityUuid: "",
+        action: "updated",
+      });
+    }
+  }, [notify, notifyEntity]);
+
   useEffect(() => {
     let es: EventSource | null = null;
-    let debounceTimer: NodeJS.Timeout;
+    let debounceTimer: NodeJS.Timeout | undefined;
+    let unsubscribe: (() => void) | undefined;
+    let hasOpened = false;
 
     let lastNotifyTime = 0;
     const THROTTLE_MS = 3000;  // At most 1 refresh every 3 seconds
@@ -108,16 +135,66 @@ export function RealtimeProvider({ projectUuid, children }: RealtimeProviderProp
       }, ENTITY_DEBOUNCE_MS);
     }
 
-    function connect() {
+    function handleEvent(parsed: DashboardEvent) {
+      // Project-scoped events are rejected before any subscriber, throttle, or
+      // debounce work. Execution events remain company/visibility scoped.
+      if (parsed.type === "presence") {
+        if (projectUuid && parsed.projectUuid !== projectUuid) return;
+        presenceSubscribersRef.current.forEach((cb) =>
+          cb(parsed as unknown as PresenceEvent),
+        );
+        return;
+      }
+
+      if (parsed.type === "execution") {
+        executionSubscribersRef.current.forEach((cb) =>
+          cb(parsed as unknown as ExecutionEvent),
+        );
+        return;
+      }
+
+      // Ignore notification/session/transcript/control payloads riding the
+      // shared transport. Change events are the untagged entity payloads.
+      if (
+        typeof parsed.entityType !== "string" ||
+        typeof parsed.entityUuid !== "string" ||
+        typeof parsed.action !== "string"
+      ) {
+        return;
+      }
+      if (projectUuid && parsed.projectUuid !== projectUuid) return;
+
+      const parsedEvent = parsed as unknown as RealtimeEvent;
+      clearTimeout(debounceTimer);
+      const now = Date.now();
+      const elapsed = now - lastNotifyTime;
+
+      if (elapsed >= THROTTLE_MS) {
+        lastNotifyTime = now;
+        notify();
+      } else {
+        debounceTimer = setTimeout(() => {
+          lastNotifyTime = Date.now();
+          notify();
+        }, Math.max(DEBOUNCE_MS, THROTTLE_MS - elapsed));
+      }
+
+      debouncedNotifyEntity(parsedEvent);
+    }
+
+    function connectStandalone() {
       // Close any existing connection before opening a new one
       disconnect();
       const url = projectUuid
-        ? `/api/events?projectUuid=${projectUuid}`
+        ? `/api/events?projectUuid=${encodeURIComponent(projectUuid)}`
         : `/api/events`;
       es = new EventSource(url);
+      es.onopen = () => {
+        if (hasOpened) notifyCatchUp();
+        hasOpened = true;
+      };
       es.onmessage = (msg) => {
-        // Parse event data
-        let parsed: Record<string, unknown> | null = null;
+        let parsed: DashboardEvent | null = null;
         try {
           parsed = JSON.parse(msg.data);
         } catch {
@@ -126,41 +203,7 @@ export function RealtimeProvider({ projectUuid, children }: RealtimeProviderProp
         }
 
         if (!parsed) return;
-
-        // Route presence events to dedicated subscribers — skip notify/debouncedNotifyEntity
-        if (parsed.type === "presence") {
-          presenceSubscribersRef.current.forEach((cb) => cb(parsed as unknown as PresenceEvent));
-          return;
-        }
-
-        // Route execution-state events to dedicated subscribers. Delivered
-        // immediately (no debounce): execution changes are already coalesced
-        // server-side into a single per-connection snapshot, and the detail pane
-        // must reflect a task starting/finishing without lag.
-        if (parsed.type === "execution") {
-          executionSubscribersRef.current.forEach((cb) => cb(parsed as unknown as ExecutionEvent));
-          return;
-        }
-
-        // Existing change event handling (backward compatible)
-        const parsedEvent = parsed as unknown as RealtimeEvent;
-
-        clearTimeout(debounceTimer);
-        const now = Date.now();
-        const elapsed = now - lastNotifyTime;
-
-        if (elapsed >= THROTTLE_MS) {
-          lastNotifyTime = now;
-          notify();
-        } else {
-          debounceTimer = setTimeout(() => {
-            lastNotifyTime = Date.now();
-            notify();
-          }, Math.max(DEBOUNCE_MS, THROTTLE_MS - elapsed));
-        }
-
-        // Entity-specific events: debounced per entity type (300ms)
-        debouncedNotifyEntity(parsedEvent);
+        handleEvent(parsed);
       };
       es.onerror = () => {
         // Browser EventSource auto-reconnects on error
@@ -178,26 +221,45 @@ export function RealtimeProvider({ projectUuid, children }: RealtimeProviderProp
       if (document.visibilityState === "visible") {
         const connectionLost = !es || es.readyState === EventSource.CLOSED;
         if (connectionLost) {
-          // Reconnect and catch up — events were missed while disconnected.
-          connect();
-          notify();
-          for (const entityType of ["task", "idea", "proposal", "document", "project", "project_group"]) {
-            notifyEntity({ companyUuid: "", projectUuid: "", entityType, entityUuid: "", action: "updated" });
-          }
+          connectStandalone();
         }
       }
     }
 
-    connect();
-    document.addEventListener("visibilitychange", handleVisibility);
+    if (subscribeDashboardEvents) {
+      unsubscribe = subscribeDashboardEvents(handleEvent);
+    } else {
+      connectStandalone();
+      document.addEventListener("visibilitychange", handleVisibility);
+    }
 
     return () => {
+      unsubscribe?.();
       disconnect();
       clearTimeout(debounceTimer);
       for (const key in entityDebounceTimers) clearTimeout(entityDebounceTimers[key]);
       document.removeEventListener("visibilitychange", handleVisibility);
     };
-  }, [projectUuid, notify, notifyEntity]);
+  }, [
+    projectUuid,
+    subscribeDashboardEvents,
+    notify,
+    notifyEntity,
+    notifyCatchUp,
+  ]);
+
+  const seenSharedGenerationRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!subscribeDashboardEvents || !sharedOpenGeneration) return;
+    if (seenSharedGenerationRef.current === null) {
+      seenSharedGenerationRef.current = sharedOpenGeneration;
+      return;
+    }
+    if (sharedOpenGeneration > seenSharedGenerationRef.current) {
+      seenSharedGenerationRef.current = sharedOpenGeneration;
+      notifyCatchUp();
+    }
+  }, [subscribeDashboardEvents, sharedOpenGeneration, notifyCatchUp]);
 
   const subscribe = useCallback((callback: Subscriber) => {
     subscribersRef.current.add(callback);


### PR DESCRIPTION
## Summary
- replace three dashboard SSE connections with one stable `/api/events` spine per tab
- preserve project-scoped change/presence filtering, company-visible execution/session events, notification visibility semantics, and reconnect catch-up
- keep CLI daemon and OpenClaw transport unchanged on `/api/events/notifications`
- archive the OpenSpec change for Issue #521

Closes #521

## Test plan
- [x] 7 focused test files, 97 tests passed
- [x] `pnpm exec tsc --noEmit`
- [x] targeted ESLint: 0 errors
- [x] `openspec validate --all`: 123 passed
- [x] `git diff --check`

## Notes
- Full local suite recorded 5,491 passing tests and 17 unrelated daemon CLI failures caused by the active injected agent profile/multi-agent environment; no SSE-related suite failed.
- Independent Chorus task review and aggregate code review both passed with no blockers.