### PR TITLE
fix: make active session indicator touch friendly

### DIFF
--- a/openspec/changes/archive/2026-09-01-fix-mobile-active-session-indicator/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-01-fix-mobile-active-session-indicator/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/archive/2026-09-01-fix-mobile-active-session-indicator/README.md
+++ b/openspec/changes/archive/2026-09-01-fix-mobile-active-session-indicator/README.md
@@ -1,0 +1,3 @@
+# fix-mobile-active-session-indicator
+
+Fix mobile activation of the Idea Tracker active-session chooser and preserve direct chat navigation for a single active agent.

--- a/openspec/changes/archive/2026-09-01-fix-mobile-active-session-indicator/design.md
+++ b/openspec/changes/archive/2026-09-01-fix-mobile-active-session-indicator/design.md
@@ -1,0 +1,76 @@
+## Context
+
+`ActiveSessionIndicator` is shared by Tracker rows, the Idea detail sidebar, and graph nodes. It
+uses a controlled Radix Popover while also manually opening it from pointer-enter, focus, and
+click handlers. The click handler always prevents the trigger's default behavior and forces the
+controlled state open. That overlap is fragile for touch sequences, where pointer and click
+events are synthesized differently from the mouse-only events covered by current tests.
+
+The existing `onSelect` contract already opens the exact daemon session, including the mobile
+transcript drill-down. The data source already removes the indicator at zero sessions and marks
+sessions that cannot be opened with `canOpen: false`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give touch/click one deterministic activation path for a multi-session chooser.
+- Route one actionable session directly through the existing exact-session callback on every
+  viewport.
+- Preserve hover discovery, keyboard access, status-only entries, and event isolation.
+- Cover the browser-like pointer sequence that exposed the mobile regression.
+
+**Non-Goals:**
+
+- Replacing Popover with a mobile-only Bottom Sheet.
+- Changing chat routing, session authorization, presence data, or Agent ordering.
+- Making another user's status-only session actionable.
+- Changing visuals, translations, APIs, or persistence.
+
+## Decisions
+
+### 1. Separate direct activation from chooser activation
+
+When there is exactly one session and it is actionable, the trigger will invoke `onSelect`
+directly and will not depend on Popover state. Every other non-empty case uses the chooser:
+multiple sessions need selection, while a sole non-actionable session still needs status
+disclosure.
+
+This keeps the user's one-Agent shortcut independent of input modality and avoids briefly
+mounting an unnecessary one-row Popover.
+
+### 2. Let Radix own click/tap state for chooser cases
+
+The chooser trigger will preserve propagation isolation but will not unconditionally suppress
+Radix's native click/tap toggle and then reimplement it with `setOpen(true)`. Controlled
+`onOpenChange` remains the single state bridge. Hover opening is retained for mouse-like pointers
+only; touch pointers rely on the click/tap contract. Keyboard focus continues to open the chooser.
+
+This uses the component library's tested trigger semantics and removes competing state transitions
+from one touch gesture.
+
+### 3. Test complete pointer gestures
+
+Regression tests will use `userEvent.pointer` or an equivalent pointer-down/up/click sequence for
+mobile-like touch activation instead of a click-only shortcut. Assertions cover chooser
+visibility, selection, direct single-session navigation, parent-click isolation, and unchanged
+status-only behavior.
+
+## Risks / Trade-offs
+
+- **Hover and click can still occur in one mouse gesture.** Mouse-only hover handling remains
+  idempotent with controlled `onOpenChange`; tests retain the existing hover-open/click behavior.
+- **Radix/jsdom pointer behavior can differ from a real browser.** Use realistic Testing Library
+  pointer sequences and retain a focused browser acceptance check at a mobile viewport.
+- **Conditional direct rendering can drift in accessibility attributes.** Keep the same Button,
+  label, disabled semantics, and keyboard activation contract; assert them in component tests.
+
+## Migration Plan
+
+This is a frontend-only backward-compatible component change. Deploy normally and roll back the
+component/test commit if the shared graph or sidebar entry regresses.
+
+## Open Questions
+
+None. Elaboration resolved the zero-, one-, and multi-session behaviors and confirmed that the
+single-session shortcut applies on all devices.

--- a/openspec/changes/archive/2026-09-01-fix-mobile-active-session-indicator/proposal.md
+++ b/openspec/changes/archive/2026-09-01-fix-mobile-active-session-indicator/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The Idea Tracker active-session indicator no longer opens its Agent chooser when tapped on
+mobile, so users cannot reach an active conversation when an Idea has multiple sessions. The
+same entry should also avoid an unnecessary one-item chooser whenever its only session is
+actionable.
+
+## What Changes
+
+- Make the active-session indicator's multi-session chooser open reliably from touch/click as
+  well as hover and keyboard focus.
+- When exactly one active session is actionable, activate the existing exact-session chat handoff
+  directly on both mobile and desktop without rendering the chooser.
+- Keep multiple sessions selectable through the existing Popover and keep non-actionable
+  other-user sessions visible as status-only entries.
+- Continue hiding the indicator when an Idea has no active sessions.
+- Add interaction regression coverage using realistic pointer/tap sequences, while preserving
+  parent Idea-card and graph-canvas event isolation.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `idea-daemon-activity`: Clarify deterministic touch/click behavior for the active-session
+  indicator while preserving single-session direct navigation and multi-session selection.
+
+## Impact
+
+- Frontend component: `src/components/active-session-indicator.tsx`.
+- Frontend tests: `src/components/__tests__/active-session-indicator.test.tsx`.
+- Existing consumers in Tracker rows, the Idea detail sidebar, and the project graph keep the same
+  props and exact-session chat callback.
+- No API, persistence, permission, dependency, i18n, or data-model changes.

--- a/openspec/changes/archive/2026-09-01-fix-mobile-active-session-indicator/specs/idea-daemon-activity/spec.md
+++ b/openspec/changes/archive/2026-09-01-fix-mobile-active-session-indicator/specs/idea-daemon-activity/spec.md
@@ -1,0 +1,62 @@
+## MODIFIED Requirements
+
+### Requirement: Idea Tracker SHALL display active daemon sessions
+
+Every Idea row in flat and lineage Tracker views, and the open Idea detail sidebar, SHALL render a
+distinct running indicator based on the shared animated Agent avatar while frontend state contains
+at least one active session for that Idea. The indicator SHALL be operable by touch/click and
+keyboard on mobile and desktop; mouse hover MAY additionally disclose the chooser but SHALL NOT be
+required for activation. Exactly one actionable session SHALL navigate directly to its exact
+conversation without displaying a one-item chooser. Several sessions SHALL display a count and a
+Popover chooser, and a touch/click on the indicator MUST reliably open that chooser so the user can
+select a session. A sole status-only session SHALL remain discoverable but MUST NOT open chat.
+Activating the indicator or an entry SHALL NOT also trigger Idea-detail or graph-canvas navigation.
+The indicator SHALL disappear immediately after the final `session_ended` event and SHALL NOT
+retain recent/history state.
+
+#### Scenario: One active session opens its exact conversation directly
+
+- **WHEN** an Idea row has exactly one actionable active session and the user activates its
+  indicator by touch, click, or keyboard
+- **THEN** daemon chat opens that session's transcript on desktop and mobile without first showing
+  a chooser
+- **AND** the Idea detail panel does not open
+
+#### Scenario: Multiple sessions open a touch-accessible chooser
+
+- **WHEN** an Idea row has multiple active sessions and the user taps or clicks its indicator
+- **THEN** the indicator's Popover chooser MUST open and list every active session with its Agent
+  avatar, identity, location, and ownership-safe status
+- **AND** activating an actionable entry opens that exact conversation
+
+#### Scenario: Hover and keyboard preserve chooser access
+
+- **WHEN** a pointer with hover capability enters the multi-session indicator or keyboard focus
+  reaches it
+- **THEN** the same chooser is disclosed without removing touch/click activation
+- **AND** every actionable chooser entry remains keyboard focusable
+
+#### Scenario: Sole other-user session remains status-only
+
+- **WHEN** an Idea has one active session with `canOpen: false`
+- **THEN** its indicator can disclose the Agent's status but MUST NOT invoke chat navigation from
+  touch, click, or keyboard activation
+
+#### Scenario: Idea detail sidebar mirrors the running state
+
+- **WHEN** an active Idea is open in the Tracker detail sidebar
+- **THEN** its header displays the same zero-, one-, and multi-session behavior as the corresponding
+  Tracker row
+
+#### Scenario: Flat, lineage, and graph surfaces agree
+
+- **WHEN** the same active Idea is rendered in flat Tracker, lineage Tracker, or project graph
+  views
+- **THEN** every surface shows the same active-session count and navigation choices
+- **AND** activating the indicator does not activate the containing Idea row or graph node
+
+#### Scenario: Final end removes the indicator
+
+- **WHEN** the final running activity token for an Idea receives `session_ended`
+- **THEN** its active-session indicator disappears without a page refresh or replacement history
+  marker

--- a/openspec/changes/archive/2026-09-01-fix-mobile-active-session-indicator/tasks.md
+++ b/openspec/changes/archive/2026-09-01-fix-mobile-active-session-indicator/tasks.md
@@ -1,0 +1,9 @@
+## 1. Active-session indicator interaction
+
+- [x] 1.1 Refactor `ActiveSessionIndicator` so one actionable session directly invokes the existing exact-session chat handoff, while chooser cases use Radix's native touch/click state transition and mouse-only hover remains additive.
+- [x] 1.2 Preserve status-only authorization, keyboard behavior, accessibility attributes, close timing, and parent Idea-card/graph event isolation across Tracker, sidebar, and graph surfaces.
+
+## 2. Regression verification
+
+- [x] 2.1 Extend the component tests with realistic touch pointer sequences for single- and multi-session activation, chooser selection, status-only sessions, and parent event isolation.
+- [x] 2.2 Run the focused component suite plus frontend type/lint checks, then verify the multi-session chooser and single-session chat handoff at a mobile viewport.

--- a/openspec/specs/idea-daemon-activity/spec.md
+++ b/openspec/specs/idea-daemon-activity/spec.md
@@ -92,29 +92,61 @@ The shell-level frontend provider SHALL maintain active session state from `sess
 
 ### Requirement: Idea Tracker SHALL display active daemon sessions
 
-Every Idea row in flat and lineage Tracker views, and the open Idea detail sidebar, SHALL render a distinct running indicator based on the shared animated Agent avatar while frontend state contains at least one active session for that Idea. Hovering or focusing the indicator SHALL disclose each active session with its Agent avatar, identity, CWD, and ownership-safe status. One session SHALL navigate directly to its exact conversation; several sessions SHALL display a count and chooser. Activating the indicator SHALL NOT also trigger Idea-detail navigation. The indicator SHALL disappear immediately after the final `session_ended` event and SHALL NOT retain recent/history state.
+Every Idea row in flat and lineage Tracker views, and the open Idea detail sidebar, SHALL render a
+distinct running indicator based on the shared animated Agent avatar while frontend state contains
+at least one active session for that Idea. The indicator SHALL be operable by touch/click and
+keyboard on mobile and desktop; mouse hover MAY additionally disclose the chooser but SHALL NOT be
+required for activation. Exactly one actionable session SHALL navigate directly to its exact
+conversation without displaying a one-item chooser. Several sessions SHALL display a count and a
+Popover chooser, and a touch/click on the indicator MUST reliably open that chooser so the user can
+select a session. A sole status-only session SHALL remain discoverable but MUST NOT open chat.
+Activating the indicator or an entry SHALL NOT also trigger Idea-detail or graph-canvas navigation.
+The indicator SHALL disappear immediately after the final `session_ended` event and SHALL NOT
+retain recent/history state.
 
-#### Scenario: One active session opens its exact conversation
+#### Scenario: One active session opens its exact conversation directly
 
-- **WHEN** an Idea row has exactly one active session and the user activates its indicator
-- **THEN** daemon chat opens that session's transcript on desktop and mobile and the Idea detail panel does not open
+- **WHEN** an Idea row has exactly one actionable active session and the user activates its
+  indicator by touch, click, or keyboard
+- **THEN** daemon chat opens that session's transcript on desktop and mobile without first showing
+  a chooser
+- **AND** the Idea detail panel does not open
 
-#### Scenario: Multiple sessions are selectable
+#### Scenario: Multiple sessions open a touch-accessible chooser
 
-- **WHEN** an Idea row has multiple active sessions
-- **THEN** the indicator shows their count, hover or focus lists every Agent avatar and location, and the chooser opens the selected conversation
+- **WHEN** an Idea row has multiple active sessions and the user taps or clicks its indicator
+- **THEN** the indicator's Popover chooser MUST open and list every active session with its Agent
+  avatar, identity, location, and ownership-safe status
+- **AND** activating an actionable entry opens that exact conversation
+
+#### Scenario: Hover and keyboard preserve chooser access
+
+- **WHEN** a pointer with hover capability enters the multi-session indicator or keyboard focus
+  reaches it
+- **THEN** the same chooser is disclosed without removing touch/click activation
+- **AND** every actionable chooser entry remains keyboard focusable
+
+#### Scenario: Sole other-user session remains status-only
+
+- **WHEN** an Idea has one active session with `canOpen: false`
+- **THEN** its indicator can disclose the Agent's status but MUST NOT invoke chat navigation from
+  touch, click, or keyboard activation
 
 #### Scenario: Idea detail sidebar mirrors the running state
 
 - **WHEN** an active Idea is open in the Tracker detail sidebar
-- **THEN** its header displays the same active-session indicator and choices as the corresponding Tracker row
+- **THEN** its header displays the same zero-, one-, and multi-session behavior as the corresponding
+  Tracker row
 
-#### Scenario: Flat and lineage views agree
+#### Scenario: Flat, lineage, and graph surfaces agree
 
-- **WHEN** the same Idea is rendered in flat and lineage Tracker views
-- **THEN** both show the same active-session count and navigation choices
+- **WHEN** the same active Idea is rendered in flat Tracker, lineage Tracker, or project graph
+  views
+- **THEN** every surface shows the same active-session count and navigation choices
+- **AND** activating the indicator does not activate the containing Idea row or graph node
 
 #### Scenario: Final end removes the indicator
 
 - **WHEN** the final running activity token for an Idea receives `session_ended`
-- **THEN** its Tracker indicator disappears without a page refresh or replacement history marker
+- **THEN** its active-session indicator disappears without a page refresh or replacement history
+  marker

--- a/src/components/__tests__/active-session-indicator.test.tsx
+++ b/src/components/__tests__/active-session-indicator.test.tsx
@@ -69,6 +69,67 @@ describe("ActiveSessionIndicator", () => {
     expect(onParentClick).not.toHaveBeenCalled();
   });
 
+  it("opens one session directly from a touch gesture without mounting a chooser", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const onParentClick = vi.fn();
+    render(
+      <div onClick={onParentClick}>
+        <ActiveSessionIndicator
+          sessions={[session("touch-one")]}
+          onSelect={onSelect}
+          surface="tracker"
+        />
+      </div>,
+    );
+
+    const trigger = screen.getByTestId("tracker-active-session-indicator");
+    await user.pointer([
+      { keys: "[TouchA>]", target: trigger },
+      { keys: "[/TouchA]", target: trigger },
+    ]);
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionUuid: "touch-one" }),
+    );
+    expect(screen.queryByLabelText("chooserLabel")).toBeNull();
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+
+  it("opens a multi-session chooser from a touch gesture and selects one", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const onParentClick = vi.fn();
+    render(
+      <div onClick={onParentClick}>
+        <ActiveSessionIndicator
+          sessions={[session("one"), session("two")]}
+          onSelect={onSelect}
+          surface="tracker"
+        />
+      </div>,
+    );
+
+    const trigger = screen.getByTestId("tracker-active-session-indicator");
+    fireEvent.pointerEnter(trigger, { pointerType: "touch" });
+    expect(screen.queryByText("Agent one")).toBeNull();
+
+    await user.pointer([
+      { keys: "[TouchA>]", target: trigger },
+      { keys: "[/TouchA]", target: trigger },
+    ]);
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Agent one")).toBeTruthy();
+    expect(screen.getByText("Agent two")).toBeTruthy();
+    await user.click(screen.getByText("Agent two"));
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionUuid: "two" }),
+    );
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+
   it("shows a keyboard-focusable chooser for many sessions and selects one", () => {
     const onSelect = vi.fn();
     const onParentClick = vi.fn();
@@ -108,13 +169,27 @@ describe("ActiveSessionIndicator", () => {
     );
 
     const trigger = screen.getByTestId("sidebar-active-session-indicator");
-    fireEvent.pointerEnter(trigger);
+    fireEvent.pointerEnter(trigger, { pointerType: "mouse" });
     expect(trigger.getAttribute("aria-expanded")).toBe("true");
 
     fireEvent.click(trigger);
     expect(trigger.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByText("Agent one")).toBeTruthy();
     expect(screen.getByText("Agent two")).toBeTruthy();
+  });
+
+  it("opens the chooser for a hover-capable pen pointer", () => {
+    render(
+      <ActiveSessionIndicator
+        sessions={[session("one"), session("two")]}
+        onSelect={() => {}}
+        surface="sidebar"
+      />,
+    );
+
+    const trigger = screen.getByTestId("sidebar-active-session-indicator");
+    fireEvent.pointerEnter(trigger, { pointerType: "pen" });
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
   });
 
   it("renders the same live-agent affordance in the Idea Tracker sidebar", () => {
@@ -146,7 +221,7 @@ describe("ActiveSessionIndicator", () => {
     );
 
     const trigger = screen.getByTestId("tracker-active-session-indicator");
-    fireEvent.focus(trigger);
+    trigger.focus();
     await user.keyboard("{Enter}");
 
     expect(onSelect).toHaveBeenCalledWith(
@@ -185,6 +260,7 @@ describe("ActiveSessionIndicator", () => {
   });
 
   it("keeps an activity actionable when connection details are unavailable", () => {
+    const onSelect = vi.fn();
     render(
       <ActiveSessionIndicator
         sessions={[
@@ -195,15 +271,24 @@ describe("ActiveSessionIndicator", () => {
             agentName: null,
           }),
         ]}
-        onSelect={() => {}}
+        onSelect={onSelect}
         surface="tracker"
       />,
     );
-    fireEvent.pointerEnter(
-      screen.getByTestId("tracker-active-session-indicator"),
+
+    const trigger = screen.getByTestId("tracker-active-session-indicator");
+    expect(screen.getByLabelText("agent-fallback")).toBeTruthy();
+    fireEvent.click(trigger);
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionUuid: "fallback",
+        connectionAvailable: false,
+        host: null,
+        cwd: null,
+      }),
     );
-    expect(screen.getByText("agent-fallback")).toBeTruthy();
-    expect(screen.getByText("agentFallback")).toBeTruthy();
+    expect(screen.queryByText("agentFallback")).toBeNull();
   });
 
   it("keeps a single other-user session status-only for mouse and keyboard", async () => {
@@ -221,9 +306,33 @@ describe("ActiveSessionIndicator", () => {
     expect(trigger.getAttribute("aria-disabled")).toBe("true");
     fireEvent.click(trigger);
     await user.keyboard("{Enter}");
-    fireEvent.pointerEnter(trigger);
+    fireEvent.pointerEnter(trigger, { pointerType: "mouse" });
 
     expect(screen.getByText("statusOnly")).toBeTruthy();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("discloses a single status-only session on touch without opening chat", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <ActiveSessionIndicator
+        sessions={[session("other-touch", { canOpen: false })]}
+        onSelect={onSelect}
+        surface="tracker"
+      />,
+    );
+
+    const trigger = screen.getByTestId("tracker-active-session-indicator");
+    await user.pointer([
+      { keys: "[TouchA>]", target: trigger },
+      { keys: "[/TouchA]", target: trigger },
+    ]);
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    const entry = screen.getByText("Agent other-touch").closest("button")!;
+    expect(entry.disabled).toBe(true);
+    await user.click(entry);
     expect(onSelect).not.toHaveBeenCalled();
   });
 

--- a/src/components/active-session-indicator.tsx
+++ b/src/components/active-session-indicator.tsx
@@ -43,6 +43,7 @@ export function ActiveSessionIndicator({
 
   if (sessions.length === 0) return null;
   const hasOpenableSession = sessions.some((session) => session.canOpen);
+  const opensDirectly = sessions.length === 1 && sessions[0].canOpen;
   const leadSession = sessions[0];
   const avatarSize = surface === "graph" ? 22 : 20;
 
@@ -62,64 +63,81 @@ export function ActiveSessionIndicator({
     onSelect(session);
   };
 
+  const trigger = (
+    <Button
+      type="button"
+      variant="outline"
+      size={surface === "tracker" ? "xs" : "icon-sm"}
+      data-testid={`${surface}-active-session-indicator`}
+      aria-label={t(
+        hasOpenableSession ? "indicatorLabel" : "statusOnlyIndicatorLabel",
+        { count: sessions.length },
+      )}
+      aria-disabled={!hasOpenableSession}
+      aria-haspopup={sessions.length > 1 ? "dialog" : undefined}
+      onPointerDown={(event) => event.stopPropagation()}
+      onPointerEnter={
+        opensDirectly
+          ? undefined
+          : (event) => {
+              // Touch emits pointer-enter/leave around a tap but has no hover
+              // intent. Let Radix's click trigger own touch activation.
+              if (event.pointerType === "touch") return;
+              cancelClose();
+              setOpen(true);
+            }
+      }
+      onPointerLeave={
+        opensDirectly
+          ? undefined
+          : (event) => {
+              if (event.pointerType !== "touch") scheduleClose();
+            }
+      }
+      onFocus={opensDirectly ? undefined : () => setOpen(true)}
+      onClick={(event) => {
+        event.stopPropagation();
+        cancelClose();
+
+        if (opensDirectly) {
+          select(leadSession);
+          return;
+        }
+
+        // A chooser opened by hover or keyboard focus must stay open
+        // when the same gesture clicks the trigger. Otherwise, leave the
+        // event unprevented so Radix performs its native click/tap toggle.
+        if (open) event.preventDefault();
+      }}
+      onKeyDown={(event) => event.stopPropagation()}
+      className={cn(
+        "group/active relative gap-1.5 overflow-visible border-emerald-500/35 bg-emerald-500/10 font-semibold text-emerald-700 shadow-none transition-[background-color,border-color,box-shadow] hover:border-emerald-500/60 hover:bg-emerald-500/15 hover:text-emerald-700 hover:shadow-[0_3px_10px_-5px_rgba(16,185,129,0.8)] focus-visible:border-emerald-500 focus-visible:ring-emerald-500/50 dark:border-emerald-500/35 dark:bg-emerald-500/10 dark:text-emerald-300 dark:hover:border-emerald-500/60 dark:hover:bg-emerald-500/15 dark:hover:text-emerald-300",
+        surface === "tracker"
+          ? "h-7 min-w-7 px-1 text-[11px]"
+          : surface === "sidebar"
+            ? "h-8 min-w-8 px-1 text-[11px]"
+            : "h-9 min-w-9 px-1 text-[11px] shadow-sm",
+        className,
+      )}
+    >
+      <span className="relative shrink-0" aria-hidden>
+        <AgentAvatar
+          name={sessionIdentity(leadSession)}
+          size={avatarSize}
+          className="rounded-full ring-1 ring-emerald-600/25"
+        />
+        <span className="absolute -bottom-0.5 -right-0.5 size-2 rounded-full border-2 border-card bg-emerald-500" />
+        <span className="absolute -bottom-0.5 -right-0.5 size-2 rounded-full bg-emerald-400/75 motion-safe:animate-ping motion-reduce:animate-none" />
+      </span>
+      {sessions.length > 1 && <span>{sessions.length}</span>}
+    </Button>
+  );
+
+  if (opensDirectly) return trigger;
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          size={surface === "tracker" ? "xs" : "icon-sm"}
-          data-testid={`${surface}-active-session-indicator`}
-          aria-label={t(
-            hasOpenableSession ? "indicatorLabel" : "statusOnlyIndicatorLabel",
-            { count: sessions.length },
-          )}
-          aria-disabled={!hasOpenableSession}
-          aria-haspopup={sessions.length > 1 ? "dialog" : undefined}
-          onPointerDown={(event) => event.stopPropagation()}
-          onPointerEnter={() => {
-            cancelClose();
-            setOpen(true);
-          }}
-          onPointerLeave={scheduleClose}
-          onFocus={() => setOpen(true)}
-          onClick={(event) => {
-            event.stopPropagation();
-            if (sessions.length === 1 && sessions[0].canOpen) {
-              event.preventDefault();
-              select(sessions[0]);
-              return;
-            }
-            // Hover/focus may already have opened the controlled popover before
-            // the click arrives. Prevent Radix Trigger's default toggle from
-            // immediately closing it again, which presents as a visible flash.
-            event.preventDefault();
-            cancelClose();
-            setOpen(true);
-          }}
-          onKeyDown={(event) => event.stopPropagation()}
-          className={cn(
-            "group/active relative gap-1.5 overflow-visible border-emerald-500/35 bg-emerald-500/10 font-semibold text-emerald-700 shadow-none transition-[background-color,border-color,box-shadow] hover:border-emerald-500/60 hover:bg-emerald-500/15 hover:text-emerald-700 hover:shadow-[0_3px_10px_-5px_rgba(16,185,129,0.8)] focus-visible:border-emerald-500 focus-visible:ring-emerald-500/50 dark:border-emerald-500/35 dark:bg-emerald-500/10 dark:text-emerald-300 dark:hover:border-emerald-500/60 dark:hover:bg-emerald-500/15 dark:hover:text-emerald-300",
-            surface === "tracker"
-              ? "h-7 min-w-7 px-1 text-[11px]"
-              : surface === "sidebar"
-                ? "h-8 min-w-8 px-1 text-[11px]"
-                : "h-9 min-w-9 px-1 text-[11px] shadow-sm",
-            className,
-          )}
-        >
-          <span className="relative shrink-0" aria-hidden>
-            <AgentAvatar
-              name={sessionIdentity(leadSession)}
-              size={avatarSize}
-              className="rounded-full ring-1 ring-emerald-600/25"
-            />
-            <span className="absolute -bottom-0.5 -right-0.5 size-2 rounded-full border-2 border-card bg-emerald-500" />
-            <span className="absolute -bottom-0.5 -right-0.5 size-2 rounded-full bg-emerald-400/75 motion-safe:animate-ping motion-reduce:animate-none" />
-          </span>
-          {sessions.length > 1 && <span>{sessions.length}</span>}
-        </Button>
-      </PopoverTrigger>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent
         align="start"
         sideOffset={6}


### PR DESCRIPTION
## Summary
- make a single actionable active-agent indicator open its exact chat directly
- keep multi-session selection touch-accessible while preserving mouse, pen, focus, keyboard, and parent-navigation isolation
- add touch/status-only/pen regression coverage and archive the OpenSpec change

## Test plan
- [x] `pnpm vitest run src/components/__tests__/active-session-indicator.test.tsx src/contexts/__tests__/agent-presence-context.test.tsx` (49/49)
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm eslint src/components/active-session-indicator.tsx`
- [x] `openspec validate --all` (123/123)
- [x] real mobile browser: single-session direct open and multi-session chooser/select

## Notes
- `docs/design.pen` could not be updated from the headless daemon because Pencil requires an open editor document; the encrypted file was not bypassed or modified directly.

Chorus Idea: `0d6ccddb-012f-4dd9-a2fc-36f077eda945`