### PR TITLE
fix(ci): build Docker multi-arch on native per-arch runners (fix arm64 QEMU timeout)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,64 +5,115 @@ on:
     branches: [develop, main]
   release:
     types: [published]
+  # Manual trigger — used to smoke-test the native per-arch build on a feature
+  # branch. On workflow_dispatch the images are BUILT but never pushed and the
+  # manifest is not created, so it never touches the registry.
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+env:
+  IMAGE: chorusaidlc/chorus-app
+
 jobs:
-  branch-image:
-    name: Build & push branch image (no latest)
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+  # ─── Per-architecture native builds ────────────────────────────────────────
+  # Each architecture builds on its OWN native runner (no QEMU emulation), which
+  # is what keeps the arm64 build fast enough to finish in time. Each job pushes
+  # the image BY DIGEST (no tag); the merge job stitches the digests into one
+  # multi-arch tag. ubuntu-24.04-arm is a free GitHub-hosted runner for public
+  # repos.
+  build:
+    name: Build ${{ matrix.platform }}
+    if: github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
-    # De-dup: only the newest commit per branch survives; older runs are cancelled.
-    concurrency:
-      group: docker-branch-${{ github.ref }}
-      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          # For a release, build the immutable tag ref; otherwise the pushed ref.
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
           persist-credentials: false
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
+        if: github.event_name != 'workflow_dispatch'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build & push branch image
-        env:
-          CI: "true"
-        run: ./scripts/docker-push.sh "${GITHUB_REF_NAME}" --no-latest
+      - name: Prepare platform pair
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
-  release-image:
-    name: Build & push release image (+ latest)
-    if: github.event_name == 'release'
+      # workflow_dispatch: build only (no push, no digest) to smoke-test speed.
+      - name: Build only (dispatch smoke test)
+        if: github.event_name == 'workflow_dispatch'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          target: production
+          push: false
+
+      # push / release: build and push BY DIGEST (no tags here).
+      - name: Build & push by digest
+        id: build
+        if: github.event_name != 'workflow_dispatch'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          target: production
+          labels: |
+            org.opencontainers.image.source=https://github.com/chorusaidlc/chorus-app
+            org.opencontainers.image.revision=${{ github.sha }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ─── Merge per-arch digests into one multi-arch tag ─────────────────────────
+  merge:
+    name: Merge & tag multi-arch manifest
+    # Never runs for workflow_dispatch (build-only smoke test).
+    if: github.event_name == 'push' || github.event_name == 'release'
+    needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    # No concurrency block: a release build must ALWAYS run to completion
-    # (GitHub concurrency keeps at most 1 running + 1 pending per group and
-    # cancels a superseded pending run even with cancel-in-progress: false,
-    # which would violate "releases always complete"). The only residual risk
-    # is that two releases published close together could finish out of order
-    # and leave `latest` on the earlier image — accepted as a known, very
-    # low-probability NOTE rather than cancelling any release.
+    timeout-minutes: 15
     steps:
-      - name: Checkout immutable release tag
-        uses: actions/checkout@v7
+      - name: Download digests
+        uses: actions/download-artifact@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
-          persist-credentials: false
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -73,12 +124,59 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build & push release image + latest
+      - name: Create multi-arch manifest with tags
+        working-directory: ${{ runner.temp }}/digests
         env:
-          CI: "true"
-          # Pass the tag through the environment rather than interpolating
-          # ${{ ... }} directly into the run script — a release tag is
-          # attacker-influenced input and inline expansion is a shell-injection
-          # vector (GitHub Actions security-hardening guidance).
+          EVENT_NAME: ${{ github.event_name }}
+          # Attacker-influenced inputs are passed via env (never inlined into the
+          # run script) and validated below before use.
+          REF_NAME: ${{ github.ref_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: ./scripts/docker-push.sh "$RELEASE_TAG"
+        run: |
+          set -euo pipefail
+
+          # Resolve the moving tag: branch name for push, release version for release.
+          if [ "$EVENT_NAME" = "release" ]; then
+            TAG="$RELEASE_TAG"
+          else
+            TAG="$REF_NAME"
+          fi
+
+          # Validate against Docker's tag grammar — rejects shell metacharacters,
+          # so nothing hostile can reach imagetools/argv even via env.
+          if ! printf '%s' "$TAG" | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'; then
+            echo "Invalid image tag: '$TAG'" >&2
+            exit 1
+          fi
+
+          # Tag args: release also updates :latest; branch builds never do.
+          TAG_ARGS=(-t "${IMAGE}:${TAG}")
+          if [ "$EVENT_NAME" = "release" ]; then
+            TAG_ARGS+=(-t "${IMAGE}:latest")
+          fi
+
+          # One source ref per pushed digest (filenames are the bare sha256 hex).
+          SOURCES=()
+          for f in *; do
+            SOURCES+=("${IMAGE}@sha256:${f}")
+          done
+          if [ "${#SOURCES[@]}" -eq 0 ]; then
+            echo "No digests found to merge" >&2
+            exit 1
+          fi
+
+          docker buildx imagetools create "${TAG_ARGS[@]}" "${SOURCES[@]}"
+
+          echo "Created ${IMAGE}:${TAG}$([ "$EVENT_NAME" = release ] && echo ' + :latest')"
+          docker buildx imagetools inspect "${IMAGE}:${TAG}"
+
+  # ─── De-dup only newest branch build ────────────────────────────────────────
+  # Same-branch cancellation is handled by the workflow-level concurrency below.
+
+concurrency:
+  # push: stable per-branch group + cancel-in-progress → only the newest commit's
+  #   build survives (the cancel-old decision).
+  # release / workflow_dispatch: run_id makes each group unique, so they never
+  #   collide and are never cancelled (releases always complete).
+  group: docker-publish-${{ github.event_name }}-${{ github.event_name == 'push' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -213,11 +213,24 @@ GitHub Actions workflow. Two triggers, two tag policies:
 | Push to `develop` / `main` | moving branch tag (`:develop` / `:main`) | **No** | older in-progress build for the same branch is cancelled |
 | GitHub Release `published` | release version tag (`:vX.Y.Z`) + `:latest` | **Yes** | never cancelled |
 
-Both jobs build multi-arch (`linux/amd64` + `linux/arm64`) via QEMU + Buildx and
-reuse `scripts/docker-push.sh`. Branch builds pass `--no-latest`, so day-to-day
-merges never clobber the `latest` tag that production consumers depend on. The
-release job checks out the immutable release tag ref (not the branch head) so
-the image matches the published release.
+Both triggers build multi-arch (`linux/amd64` + `linux/arm64`) using **native
+per-architecture runners** — amd64 on `ubuntu-latest` and arm64 on the free
+`ubuntu-24.04-arm` hosted runner — rather than QEMU emulation. Each arch is
+built and pushed **by digest** in a matrix `build` job, then a `merge` job
+stitches the digests into a single multi-arch tag with `docker buildx imagetools
+create`. Native arm64 avoids the slow emulated Next.js build that would otherwise
+time out. Branch builds tag only the moving branch name, so day-to-day merges
+never clobber the `latest` tag that production consumers depend on; the release
+job checks out the immutable release tag ref (not the branch head) and also
+updates `:latest`. The tag is resolved and validated in the merge step, and
+attacker-influenced inputs (the release tag) are passed via `env` rather than
+inlined into a shell command.
+
+`scripts/docker-push.sh` remains available for **local / manual** multi-arch
+builds (it uses QEMU + Buildx in a single invocation, which is fine off the
+critical CI path). A `workflow_dispatch` trigger is also available to smoke-test
+the native build on a branch — on manual dispatch the images are built but never
+pushed.
 
 ### Prerequisite: Docker Hub repository secrets
 


### PR DESCRIPTION
## Summary

Fixes the Docker multi-arch publish **timeout** introduced by #534. The first run on `develop` (run `33733490758`) hit the 60-min timeout because building `linux/arm64` under **QEMU emulation** on a single runner is far too slow for a full Next.js image.

Since this repo is **public**, GitHub's native `ubuntu-24.04-arm` runner is free — so we build each architecture natively (no emulation) and merge.

## What changed (Option A — native per-arch matrix)

- **`.github/workflows/docker-publish.yml`** rewritten to Docker's canonical "distribute build across runners" pattern:
  - **`build` matrix job**: `linux/amd64` on `ubuntu-latest`, `linux/arm64` on `ubuntu-24.04-arm`; each builds natively (**no `setup-qemu`**) and pushes **by digest** via `docker/build-push-action@v6` (`push-by-digest=true`).
  - **`merge` job**: `docker buildx imagetools create` stitches the per-arch digests into one multi-arch tag.
  - **Tag policy unchanged**, computed in the merge step: push `develop`/`main` → branch-name tag only (never `latest`); release `published` → version tag + `latest` (tag-pinned checkout).
  - **Security preserved**: release tag/ref passed via `env` (never inlined `${{ }}` in `run:`) and validated against the Docker tag grammar; `persist-credentials: false`.
  - **Concurrency**: push cancels the older same-branch run; release/dispatch use a unique `run_id` group and are never cancelled.
  - Added **`workflow_dispatch`** (build-only, no push) for branch smoke-tests.
- **`docs/DOCKER.md`** updated to describe the native-runner build; `scripts/docker-push.sh` kept for local manual multi-arch builds.

## Verification

- `actionlint` clean; YAML parses.
- **Live smoke test** on this branch via `workflow_dispatch` (run `33740182435`): both native builds **succeeded in ~3 min each** (arm64 09:40:58→09:44:02), vs the prior 60-min QEMU timeout. Merge job correctly skipped for dispatch.
- The merge/real-push path runs only on push/release (canonical `imagetools` pattern, actionlint-clean); it validates end-to-end on the first push to `develop` after merge.

🤖 Chorus AI-DLC follow-up fix (task 2187d7cf), reviewed by chorus-task-reviewer → PASS WITH NOTES.
