### PR TITLE
fix(presence): stabilize Idea Tracker daemon active-session marker (wipe/replay race)

### DIFF
--- a/openspec/changes/archive/2026-09-03-fix-idea-tracker-active-marker-race/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-03-fix-idea-tracker-active-marker-race/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/archive/2026-09-03-fix-idea-tracker-active-marker-race/README.md
+++ b/openspec/changes/archive/2026-09-03-fix-idea-tracker-active-marker-race/README.md
@@ -1,0 +1,3 @@
+# fix-idea-tracker-active-marker-race
+
+Fix unstable daemon active-session marker on Idea Tracker caused by wipe-vs-replay race

--- a/openspec/changes/archive/2026-09-03-fix-idea-tracker-active-marker-race/design.md
+++ b/openspec/changes/archive/2026-09-03-fix-idea-tracker-active-marker-race/design.md
@@ -1,0 +1,128 @@
+# Design — Deterministic connect-time reset for daemon session-activity
+
+## Current architecture (pre-fix)
+
+- `DashboardEventProvider` (`src/contexts/dashboard-event-context.tsx`) owns the one
+  shell-level `EventSource` for the tab. On `onopen` it bumps `openGeneration`; on
+  `onmessage` it JSON-parses the payload and fans it out synchronously to every
+  subscriber.
+- `AgentPresenceProvider` (`src/contexts/agent-presence-context.tsx`) subscribes to
+  the transport. It reduces `session_started`/`session_ended` events into
+  `sessionActivity` (via `reduceSessionActivity`), from which
+  `activeSessionsByIdea` is derived and read by `IdeaCard`.
+- On connect, the server (`/api/events`, `listVisibleRunningSessionActivities`)
+  replays a `session_started` for every currently-running visible session.
+- Today the client resets `sessionActivity` in a `useEffect` keyed on
+  `openGeneration`:
+
+  ```ts
+  useEffect(() => {
+    if (openGeneration === 0) return;
+    setSessionActivity(emptySessionActivityState());   // ← the racy wipe
+    // ... fetchExecutions() on later generations
+  }, [openGeneration, fetchExecutions]);
+  ```
+
+## The race
+
+`onopen` (→ `setOpenGeneration`) and the replay `onmessage` (→ `setSessionActivity`)
+are separate browser event turns. The wipe runs as a **passive effect** scheduled
+after the `openGeneration` commit; the replay is reduced synchronously in the
+message handler. React gives no ordering guarantee between the scheduled passive
+effect and a subsequently-dispatched message handler. When the replay reduces before
+the deferred wipe effect runs, the wipe erases the just-replayed sessions → marker
+blank until the next live event. This is intermittent by nature.
+
+The unit test hid this by serializing `onopen()` and replay into separate `act()`
+flushes, which forces the intended order.
+
+## The fix — synthetic `stream_reset` on `onopen`
+
+Move the reset out of a passive effect and into the **same synchronous, ordered
+channel as the messages**, so transport ordering (open-before-message, guaranteed by
+the EventSource spec) becomes the ordering guarantee for reset-before-replay.
+
+### `DashboardEventProvider`
+
+In `connect()`, `onopen` additionally fans a synthetic reset event to subscribers
+**before returning** (i.e. before any `onmessage` can run):
+
+```ts
+eventSource.onopen = () => {
+  setOpenGeneration((g) => g + 1);
+  // Synchronous, in-band reset: dispatched through the SAME subscriber fan-out as
+  // messages, so it is ordered strictly before any replay `onmessage` for this
+  // connection (EventSource guarantees `open` fires before any `message`).
+  for (const cb of subscribersRef.current) cb({ type: STREAM_RESET_EVENT });
+};
+```
+
+`STREAM_RESET_EVENT = "stream_reset"` is a client-synthetic type the server never
+emits. Export it so subscribers can match it by name.
+
+### `AgentPresenceProvider`
+
+- In the transport subscriber, handle the new type first:
+
+  ```ts
+  if (parsed.type === STREAM_RESET_EVENT) {
+    setSessionActivity(emptySessionActivityState());
+    return;
+  }
+  ```
+
+- Remove `setSessionActivity(emptySessionActivityState())` from the `openGeneration`
+  effect. Keep the `fetchExecutions()` self-heal there unchanged (executions are
+  order-insensitive; a fetch is idempotent).
+
+Because `stream_reset` is dispatched synchronously in `onopen` and the replay
+`session_started` events arrive in later `onmessage` turns, the reduction order is
+deterministically: reset (empty) → replay (repopulate) → live deltas. On a
+reconnect the same holds, so the marker re-syncs every connect.
+
+### Other subscribers
+
+- `RealtimeProvider.handleEvent`: `stream_reset` has no `presence`/`execution` type
+  and no `entityType/entityUuid/action` fields, so it falls through the existing
+  guards and is ignored. Its reconnect catch-up continues to run off
+  `sharedOpenGeneration` (unchanged).
+- `NotificationProvider`: switches on known notification event types; an unknown
+  `stream_reset` is ignored.
+
+## Ordering guarantee (why this is race-free)
+
+1. EventSource spec: the `open` event fires before any `message` event on a
+   connection.
+2. `DashboardEventProvider` dispatches `stream_reset` synchronously within the
+   `open` handler, and messages synchronously within `message` handlers.
+3. Therefore every subscriber receives `stream_reset` before any replay message of
+   that connection.
+4. `setSessionActivity` updates are applied in call order (functional reducer for
+   deltas; a plain replace for the reset), so `empty()` then `reduce(...)` yields the
+   populated map regardless of React batching.
+
+No passive effect participates in the reset ordering, so effect-scheduling timing
+can no longer invert it.
+
+## Risks / alternatives
+
+- **Alternative: server snapshot begin/end bracket.** More invasive (server event
+  contract change); rejected — the synthetic client reset is minimal and sufficient.
+- **Alternative: diff-reconcile replay against current state (no wipe).** Harder —
+  the replay is a stream of individual `session_started` events with no end marker,
+  so the client cannot tell when the full set has arrived to diff against. Rejected.
+- **Risk: a subscriber mid-mount misses the first `stream_reset`.** The first reset
+  is a no-op on an already-empty state, and the pre-existing subscribe-before-events
+  ordering is unchanged, so this is not a regression.
+
+## Test plan
+
+- `dashboard-event-context.test.tsx`: on `onopen`, subscribers receive a
+  `{ type: "stream_reset" }` event; assert it is delivered (and that a subsequent
+  `onmessage` still fans out) — proving reset is in-band and ordered before messages.
+- `agent-presence-context.test.tsx`: (a) a `stream_reset` event clears
+  `activeSessionsByIdea`; (b) reset-then-replay leaves the session present (the
+  intended order); (c) the existing "rebuild on stream open" test continues to pass
+  now that the wipe is driven by `stream_reset` rather than the `openGeneration`
+  effect.
+- Full `pnpm test` + `pnpm lint` + `npx tsc --noEmit` green.

--- a/openspec/changes/archive/2026-09-03-fix-idea-tracker-active-marker-race/proposal.md
+++ b/openspec/changes/archive/2026-09-03-fix-idea-tracker-active-marker-race/proposal.md
@@ -1,0 +1,65 @@
+# Fix unstable daemon active-session marker on Idea Tracker
+
+## Why
+
+The Idea Tracker shows a green "active session" marker on ideas that have a running
+daemon session. Users report the marker **does not display stably** — entering the
+Tracker (especially via a full reload, a `/ideas`→`/dashboard` 308 redirect, a
+notification/search deep link, or any navigation that coincides with an SSE
+reconnect) intermittently shows no marker even though a session is running.
+
+Root cause (confirmed by code reading): the client-side session-activity state that
+drives the marker is fed **only** by live SSE `session_started`/`session_ended`
+events plus a one-shot server replay sent on each stream connect
+(`listVisibleRunningSessionActivities`). On every EventSource open
+(`openGeneration` bump) the provider wipes that state in a **passive `useEffect`**,
+intending "wipe → then the replay refills it". But the wipe (a post-commit effect)
+and the replay (reduced synchronously in the SSE `onmessage` handler) have **no
+ordering guarantee**. When they batch together — common on reconnect — the wipe
+effect runs *after* the replay has already populated the map and erases the
+just-replayed sessions, so the marker vanishes until the next live event. The
+timing dependence is exactly the reported "cannot display stably".
+
+The existing unit test masks the bug because it wraps `onopen()` and each replay
+dispatch in **separate `act()` blocks**, artificially forcing wipe-before-replay —
+an ordering production never guarantees.
+
+A second, related fragility: unlike the executions surface (self-healed by a 15s
+poll), session-activity has no durable/poll-backed source, so a reconnect that
+wipes-then-loses-the-replay leaves the marker blank with nothing to re-seed it.
+
+## What Changes
+
+- Make the connect-time reset **deterministic relative to the replay**: the shared
+  dashboard event transport (`DashboardEventProvider`) emits a synthetic
+  `stream_reset` event to its subscribers **synchronously inside `onopen`**, before
+  any `onmessage` replay can arrive (the browser guarantees `open` fires before any
+  `message`). The agent-presence provider clears its session-activity state on that
+  `stream_reset` event instead of in a passive effect keyed on `openGeneration`.
+  Because both the reset and the replay now flow through the same synchronous
+  subscriber channel in transport order, the reset always precedes the replay — the
+  race is eliminated.
+- Remove the session-activity wipe from the `openGeneration` `useEffect` in the
+  agent-presence provider (the `fetchExecutions()` self-heal in that effect is
+  retained, unchanged).
+- Other transport subscribers (`RealtimeProvider`, `NotificationProvider`) ignore
+  the new `stream_reset` event type (they already switch on known `type` values and
+  drop unknowns) — no behavior change for them.
+
+Out of scope (deliberately): adding a new periodic REST poll for active sessions.
+The deterministic reset already re-syncs on every connect/reconnect (the same
+cadence as the executions self-heal is triggered), which satisfies the accepted
+`initial_and_live` + `realtime_short` acceptance from elaboration. A dedicated poll
+would be belt-and-suspenders and is left for a follow-up if ever needed.
+
+## Impact
+
+- Affected code: `src/contexts/dashboard-event-context.tsx`,
+  `src/contexts/agent-presence-context.tsx`.
+- Affected tests: `src/contexts/__tests__/dashboard-event-context.test.tsx`,
+  `src/contexts/__tests__/agent-presence-context.test.tsx`.
+- User-visible: the daemon active-session marker on the Idea Tracker (flat + lineage
+  views) and any other `activeSessionsByIdea` consumer becomes stable across
+  reloads, redirects, deep links, and reconnects.
+- No API, schema, or server-contract change. The server replay contract is
+  unchanged; only the client's reset ordering changes.

--- a/openspec/changes/archive/2026-09-03-fix-idea-tracker-active-marker-race/specs/daemon-activity-presence/spec.md
+++ b/openspec/changes/archive/2026-09-03-fix-idea-tracker-active-marker-race/specs/daemon-activity-presence/spec.md
@@ -1,0 +1,58 @@
+# daemon-activity-presence — delta
+
+## ADDED Requirements
+
+### Requirement: Deterministic connect-time reset of client session-activity state
+
+The client session-activity state SHALL be reset on each dashboard event-stream
+connect in a way that is deterministically ordered **before** the server's on-connect
+replay of currently-running sessions (this state drives the Idea Tracker
+active-session marker). The reset MUST NOT be scheduled in a way whose timing can
+interleave with, and erase, the replay events for the same connection.
+
+#### Scenario: Reset is delivered in-band on stream open, before any message
+
+- **WHEN** the shared dashboard `EventSource` fires its `open` event
+- **THEN** the transport dispatches a synthetic `stream_reset` event to its
+  subscribers synchronously within the open handler
+- **AND** because the EventSource spec guarantees `open` fires before any `message`,
+  every subscriber receives `stream_reset` before any replayed `session_started`
+  message of that connection
+
+#### Scenario: Replayed sessions after a reset survive
+
+- **WHEN** a `stream_reset` event is processed and is then followed by the server's
+  replayed `session_started` events for the currently-running sessions
+- **THEN** the derived active-session set contains exactly those replayed sessions
+- **AND** the reset does not run again after the replay to erase them
+
+#### Scenario: openGeneration bump alone does not clear session-activity
+
+- **WHEN** the stream's `openGeneration` changes (used elsewhere for reconnect
+  catch-up and the executions self-heal fetch)
+- **THEN** the session-activity state is NOT cleared by that generation change alone
+- **AND** clearing happens only in response to the in-band `stream_reset` event
+
+### Requirement: Stable Idea Tracker active-session marker across entry paths
+
+The Idea Tracker SHALL stably display the daemon active-session marker for any idea
+that has a running, caller-visible daemon session, regardless of how the Tracker was
+entered — direct load, full page reload, a `/ideas`→`/dashboard` redirect, a
+notification/search deep link, or an in-app navigation that coincides with an
+event-stream reconnect. The marker MAY appear shortly after the stream connects
+(realtime, sub-second) rather than on the very first frame, but once the connection's
+replay has arrived it MUST NOT be spuriously cleared while the session is still
+running.
+
+#### Scenario: Marker survives a stream reconnect
+
+- **WHEN** a daemon session is running on an idea and the dashboard event stream
+  reconnects (e.g. tab refocus, network blip, or opening/closing the daemon chat)
+- **THEN** after the reconnect's replay the idea's active-session marker is shown
+- **AND** it is not left blank by a connect-time reset racing the replay
+
+#### Scenario: Live start/stop still updates the marker
+
+- **WHEN** a daemon session starts or ends on an idea while the Tracker is open
+- **THEN** the idea's active-session marker appears or disappears accordingly via the
+  live `session_started` / `session_ended` events

--- a/openspec/specs/daemon-activity-presence/spec.md
+++ b/openspec/specs/daemon-activity-presence/spec.md
@@ -1,0 +1,60 @@
+# daemon-activity-presence Specification
+
+## Purpose
+TBD - created by archiving change fix-idea-tracker-active-marker-race. Update Purpose after archive.
+## Requirements
+### Requirement: Deterministic connect-time reset of client session-activity state
+
+The client session-activity state SHALL be reset on each dashboard event-stream
+connect in a way that is deterministically ordered **before** the server's on-connect
+replay of currently-running sessions (this state drives the Idea Tracker
+active-session marker). The reset MUST NOT be scheduled in a way whose timing can
+interleave with, and erase, the replay events for the same connection.
+
+#### Scenario: Reset is delivered in-band on stream open, before any message
+
+- **WHEN** the shared dashboard `EventSource` fires its `open` event
+- **THEN** the transport dispatches a synthetic `stream_reset` event to its
+  subscribers synchronously within the open handler
+- **AND** because the EventSource spec guarantees `open` fires before any `message`,
+  every subscriber receives `stream_reset` before any replayed `session_started`
+  message of that connection
+
+#### Scenario: Replayed sessions after a reset survive
+
+- **WHEN** a `stream_reset` event is processed and is then followed by the server's
+  replayed `session_started` events for the currently-running sessions
+- **THEN** the derived active-session set contains exactly those replayed sessions
+- **AND** the reset does not run again after the replay to erase them
+
+#### Scenario: openGeneration bump alone does not clear session-activity
+
+- **WHEN** the stream's `openGeneration` changes (used elsewhere for reconnect
+  catch-up and the executions self-heal fetch)
+- **THEN** the session-activity state is NOT cleared by that generation change alone
+- **AND** clearing happens only in response to the in-band `stream_reset` event
+
+### Requirement: Stable Idea Tracker active-session marker across entry paths
+
+The Idea Tracker SHALL stably display the daemon active-session marker for any idea
+that has a running, caller-visible daemon session, regardless of how the Tracker was
+entered — direct load, full page reload, a `/ideas`→`/dashboard` redirect, a
+notification/search deep link, or an in-app navigation that coincides with an
+event-stream reconnect. The marker MAY appear shortly after the stream connects
+(realtime, sub-second) rather than on the very first frame, but once the connection's
+replay has arrived it MUST NOT be spuriously cleared while the session is still
+running.
+
+#### Scenario: Marker survives a stream reconnect
+
+- **WHEN** a daemon session is running on an idea and the dashboard event stream
+  reconnects (e.g. tab refocus, network blip, or opening/closing the daemon chat)
+- **THEN** after the reconnect's replay the idea's active-session marker is shown
+- **AND** it is not left blank by a connect-time reset racing the replay
+
+#### Scenario: Live start/stop still updates the marker
+
+- **WHEN** a daemon session starts or ends on an idea while the Tracker is open
+- **THEN** the idea's active-session marker appears or disappears accordingly via the
+  live `session_started` / `session_ended` events
+

--- a/src/contexts/__tests__/agent-presence-context.test.tsx
+++ b/src/contexts/__tests__/agent-presence-context.test.tsx
@@ -551,6 +551,57 @@ describe("AgentPresenceProvider — session activity and navigation", () => {
     expect(result.current.activeSessionsByIdea.size).toBe(0);
   });
 
+  it("clears session-activity on an in-band stream_reset event", async () => {
+    routeAuthFetch({
+      connections: () => okJson({ connections: [conn("c1", "online")] }),
+      executions: () => okJson({ executions: [] }),
+    });
+    const { result } = renderProvider();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => dispatchSse(sessionActivityEvent() as unknown as Record<string, unknown>));
+    expect(result.current.activeSessionsByIdea.get("idea-1")).toHaveLength(1);
+
+    // The transport delivers stream_reset in-band on connection open; it clears
+    // the derived session set (the reset no longer lives in the openGeneration
+    // passive effect).
+    act(() => dispatchSse({ type: "stream_reset" }));
+    expect(result.current.activeSessionsByIdea.size).toBe(0);
+  });
+
+  it("keeps replayed sessions that arrive after a stream_reset (reset-before-replay, race guard)", async () => {
+    routeAuthFetch({
+      connections: () => okJson({ connections: [conn("c1", "online")] }),
+      executions: () => okJson({ executions: [] }),
+    });
+    const { result } = renderProvider();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Seed a stale session, then the connect reset, then the connection's replay.
+    // The replayed session must survive and the stale one must be gone — the reset
+    // does NOT run again after the replay to wipe it (the regression this fixes).
+    act(() =>
+      dispatchSse(
+        sessionActivityEvent({
+          sessionUuid: "stale",
+          activityUuid: "stale-act",
+        }) as unknown as Record<string, unknown>,
+      ),
+    );
+    act(() => dispatchSse({ type: "stream_reset" }));
+    act(() => dispatchSse(sessionActivityEvent() as unknown as Record<string, unknown>));
+
+    const sessions = result.current.activeSessionsByIdea.get("idea-1");
+    expect(sessions).toHaveLength(1);
+    expect(sessions?.[0].sessionUuid).toBe("session-1");
+  });
+
   it("opens the exact active session via agent+host+CWD and falls back to session+agent when the connection is missing", async () => {
     routeAuthFetch({
       connections: () => okJson({ connections: [conn("c1", "online")] }),

--- a/src/contexts/__tests__/dashboard-event-context.test.tsx
+++ b/src/contexts/__tests__/dashboard-event-context.test.tsx
@@ -108,6 +108,35 @@ describe("DashboardEventProvider", () => {
     );
   });
 
+  it("dispatches an in-band stream_reset to subscribers on open, ordered before any message", () => {
+    const received: Array<Record<string, unknown>> = [];
+    render(
+      <DashboardEventProvider>
+        <Harness
+          project="project-a"
+          onEvent={(event) => received.push(event)}
+          onGeneration={() => {}}
+          exposeSession={() => {}}
+        />
+      </DashboardEventProvider>,
+    );
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.onopen?.();
+      es.onmessage?.({
+        data: JSON.stringify({ type: "presence", projectUuid: "project-a" }),
+      } as MessageEvent);
+    });
+
+    // onopen fires before any onmessage (EventSource spec), and the reset is
+    // dispatched synchronously inside onopen — so subscribers see stream_reset
+    // strictly before the connection's first replayed message. This ordering is
+    // what eliminates the wipe-vs-replay race.
+    expect(received[0]).toEqual({ type: "stream_reset" });
+    expect(received[1]).toEqual({ type: "presence", projectUuid: "project-a" });
+  });
+
   it("parses once, fans out events, increments opens, recovers visibility, and cleans up", () => {
     const onEvent = vi.fn();
     const onGeneration = vi.fn();
@@ -131,11 +160,18 @@ describe("DashboardEventProvider", () => {
       first.onopen?.();
       first.onopen?.();
     });
-    expect(onEvent).toHaveBeenCalledOnce();
-    expect(onEvent).toHaveBeenCalledWith({
+    // The presence message is fanned out once; each onopen ALSO fans out a
+    // synthetic stream_reset (in-band connect reset), so filter those to assert
+    // the parsed message delivery.
+    const nonReset = onEvent.mock.calls.filter(
+      ([event]) => (event as { type?: unknown }).type !== "stream_reset",
+    );
+    expect(nonReset).toHaveLength(1);
+    expect(nonReset[0][0]).toEqual({
       type: "presence",
       projectUuid: "project-a",
     });
+    expect(onEvent).toHaveBeenCalledWith({ type: "stream_reset" });
     expect(onGeneration).toHaveBeenLastCalledWith(2);
 
     act(() => {

--- a/src/contexts/agent-presence-context.tsx
+++ b/src/contexts/agent-presence-context.tsx
@@ -61,6 +61,7 @@ import {
   buildDashboardEventsUrl,
   useDashboardEvents,
   useDashboardEventsOptional,
+  STREAM_RESET_EVENT,
   type DashboardExecutionEvent,
 } from "@/contexts/dashboard-event-context";
 import type {
@@ -589,6 +590,16 @@ function AgentPresenceProviderInner({ children }: { children: ReactNode }) {
   // changes and fans each parsed payload out once.
   useEffect(() => {
     return subscribeDashboardEvents((parsed) => {
+      if (parsed.type === STREAM_RESET_EVENT) {
+        // Connect-time reset, delivered in-band by the transport on `onopen` and
+        // therefore ordered strictly BEFORE this connection's replayed
+        // `session_started` events. Clearing here — not in the openGeneration
+        // effect below — is what makes reset-before-replay deterministic: a passive
+        // effect could run after the replay had already repopulated the map and
+        // wipe it (the wipe-vs-replay race that made the tracker marker unstable).
+        setSessionActivity(emptySessionActivityState());
+        return;
+      }
       if (routeTranscriptEvent(parsed, transcriptSubscribersRef.current)) return;
       if (parsed.type === "session_started" || parsed.type === "session_ended") {
         setSessionActivity((prev) =>
@@ -605,14 +616,19 @@ function AgentPresenceProviderInner({ children }: { children: ReactNode }) {
     });
   }, [subscribeDashboardEvents]);
 
-  // The initial open relies on the poll's first fetch. Every later open denotes
-  // a possible delivery gap (native recovery, explicit visibility recovery, or
-  // transcript-session URL replacement), so reset replay state and catch up.
+  // Executions self-heal on reconnect. The initial open relies on the poll's
+  // first fetch. Every later open denotes a possible delivery gap (native
+  // recovery, explicit visibility recovery, or transcript-session URL
+  // replacement), so re-fetch the executions aggregate to catch up.
+  //
+  // Session-activity is NOT reset here — that reset now rides the in-band
+  // `STREAM_RESET_EVENT` (dispatched by the transport on `onopen`, before this
+  // connection's replay), so it is deterministically ordered before the replay
+  // instead of racing it from a passive effect.
   const seenOpenGenerationRef = useRef<number | null>(null);
   useEffect(() => {
     const generation = openGeneration;
     if (generation === 0) return;
-    setSessionActivity(emptySessionActivityState());
     if (seenOpenGenerationRef.current === null) {
       seenOpenGenerationRef.current = generation;
       return;

--- a/src/contexts/dashboard-event-context.tsx
+++ b/src/contexts/dashboard-event-context.tsx
@@ -15,6 +15,15 @@ import type { ExecutionEvent as ExecutionEventBase } from "@/services/daemon-exe
 export type DashboardEvent = Record<string, unknown> & { type?: unknown };
 export type DashboardEventSubscriber = (event: DashboardEvent) => void;
 
+// Client-synthetic event `type` the transport fans out to subscribers on every
+// EventSource `open`, BEFORE any `message` of that connection (the EventSource
+// spec guarantees `open` fires first). Domain consumers whose derived state must
+// be reset per-connection (e.g. agent-presence session-activity) clear it on this
+// in-band event instead of in a passive effect keyed on `openGeneration` — a
+// passive effect can run AFTER the connection's replay has already repopulated the
+// state and erase it (the wipe-vs-replay race). The server never emits this type.
+export const STREAM_RESET_EVENT = "stream_reset";
+
 export interface DashboardExecutionEvent extends ExecutionEventBase {
   type: "execution";
 }
@@ -59,6 +68,14 @@ export function DashboardEventProvider({ children }: { children: ReactNode }) {
       eventSource = new EventSource(buildDashboardEventsUrl(sessionUuid));
       eventSource.onopen = () => {
         setOpenGeneration((generation) => generation + 1);
+        // In-band, synchronous connect reset. Dispatched through the SAME
+        // subscriber fan-out as messages, so every subscriber receives it BEFORE
+        // any replay `onmessage` of this connection (open fires before message).
+        // This is the ordering guarantee that lets domain consumers reset
+        // per-connection state without racing the server's on-connect replay.
+        for (const callback of subscribersRef.current) {
+          callback({ type: STREAM_RESET_EVENT });
+        }
       };
       eventSource.onmessage = (message) => {
         let parsed: DashboardEvent;


### PR DESCRIPTION
## Problem

The Idea Tracker's green **daemon active-session marker** displays unstably — entering the Tracker via a full reload, the `/ideas`→`/dashboard` 308 redirect, a notification/search deep link, or any navigation that coincides with an SSE reconnect intermittently shows **no marker** even when a session is running. Reported as "标记不能稳定显示" on idea `fbe183d1`.

## Root cause

The client session-activity state that drives the marker (`activeSessionsByIdea` in `AgentPresenceProvider`) is fed only by live SSE `session_started`/`session_ended` plus a one-shot server replay on each connect. On every stream open (`openGeneration` bump) the provider wiped that state in a **passive `useEffect`**, intending "wipe → then the replay refills it". But the wipe (a post-commit effect) and the replay (reduced synchronously in the SSE `onmessage` handler) have **no ordering guarantee** — when they batch on reconnect, the wipe runs *after* the replay has already repopulated the map and erases it until the next live event. Timing-dependent → "cannot display stably". The old unit test hid this by serializing `onopen()` and the replay into separate `act()` blocks.

## Fix

Make the connect-time reset deterministic relative to the replay by moving it into the same synchronous, ordered channel as the messages:

- `dashboard-event-context.tsx`: export `STREAM_RESET_EVENT` and, in `onopen`, synchronously fan out `{ type: "stream_reset" }` to subscribers. The EventSource spec fires `open` before any `message`, so this reset is delivered before the connection's replayed `session_started` events.
- `agent-presence-context.tsx`: clear `sessionActivity` on the `stream_reset` event; **removed** the wipe from the `openGeneration` effect (kept the `fetchExecutions()` self-heal).
- The other two transport subscribers (`RealtimeProvider`, `NotificationProvider`) ignore the unknown type — no behavior change.

Out of scope (per resolved elaboration): a new periodic REST poll for active sessions. The deterministic reset already re-syncs on every connect/reconnect.

## Testing

- New `dashboard-event-context` test: `onopen` delivers `stream_reset` **ordered before** a subsequent `onmessage`.
- New `agent-presence-context` tests: `stream_reset` clears the set; reset-then-replay keeps the replayed session (race regression guard).
- `vitest run src/contexts/__tests__/*` → 40/40 pass (64/64 across the context dir incl. realtime + notification suites). `tsc --noEmit` clean.
- Reviewed through the Chorus pipeline: proposal-reviewer, task-reviewer, and code-reviewer all PASS WITH NOTES (no blockers).

No API / schema / server-contract change. OpenSpec change `fix-idea-tracker-active-marker-race` archived (capability `daemon-activity-presence`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)