### PR TITLE
feat(cli): add `chorus agents run` to launch a configured agent

### DIFF
--- a/cli/__tests__/agent-launcher.test.mjs
+++ b/cli/__tests__/agent-launcher.test.mjs
@@ -1,0 +1,350 @@
+// cli/__tests__/agent-launcher.test.mjs
+// Covers `chorus agents run` (cli/agent-launcher.mjs + resolveLaunchAgent in
+// cli/credentials.mjs): argv split at `--`, agent selection, --type override,
+// type→binary map, PATH resolution, childEnv injection, exit-code/signal
+// forwarding, and the secret-never-printed guarantee. Pure unit tests — spawn,
+// env, daemon.json read, and file-probe are all injected (no real subprocess,
+// disk, or env).
+import { describe, it, expect } from "vitest";
+import {
+  parseRunArgs,
+  resolveBinaryName,
+  resolveBinaryPath,
+  resolveSpawnCommand,
+  buildChildEnv,
+  runAgentLaunch,
+  TYPE_TO_BINARY,
+} from "../agent-launcher.mjs";
+import { resolveLaunchAgent } from "../credentials.mjs";
+
+const LOGIN_PATH = "/home/u/.chorus/daemon.json";
+const SECRET = "cho_SUPERSECRET_KEY_should_never_print";
+
+function cap() {
+  const out = [];
+  const err = [];
+  return {
+    stdout: { write: (s) => out.push(String(s)) },
+    stderr: { write: (s) => err.push(String(s)) },
+    text: () => out.join(""),
+    errText: () => err.join(""),
+    all: () => out.join("") + err.join(""),
+  };
+}
+
+/** A fake spawn that records calls and drives the child's close/error async. */
+function makeSpawn(behavior = {}) {
+  const calls = [];
+  const spawn = (command, argv, options) => {
+    calls.push({ command, argv, options });
+    if (behavior.throwErr) throw behavior.throwErr;
+    const handlers = {};
+    const child = {
+      on: (ev, cb) => {
+        handlers[ev] = cb;
+        return child;
+      },
+    };
+    queueMicrotask(() => {
+      if (behavior.emitError) handlers.error?.(behavior.emitError);
+      else handlers.close?.(behavior.code ?? 0, behavior.signal ?? null);
+    });
+    return child;
+  };
+  return { spawn, calls };
+}
+
+const AGENT = {
+  agentUuid: "11111111-2222-3333-4444-555555555555",
+  agentName: "work",
+  agentType: "claude-code",
+  url: "https://chorus.example.com",
+  apiKey: SECRET,
+};
+
+/** Build opts for runAgentLaunch with a fake daemon.json + spawn + found binary. */
+function opts({ agents = [AGENT], env = {}, spawnBehavior = {}, isFile = () => true } = {}) {
+  const io = cap();
+  const { spawn, calls } = makeSpawn(spawnBehavior);
+  return {
+    io,
+    calls,
+    o: {
+      stdout: io.stdout,
+      stderr: io.stderr,
+      env: { PATH: "/usr/bin", ...env },
+      platform: "linux",
+      loginPath: LOGIN_PATH,
+      readJson: () => ({ agents }),
+      spawnImpl: spawn,
+      isFile,
+      cwd: "/work",
+    },
+  };
+}
+
+describe("parseRunArgs", () => {
+  it("splits chorus flags from verbatim passthrough at `--`", () => {
+    const p = parseRunArgs(["--name", "work", "--type", "codex", "--", "--model", "opus", "--name", "x"]);
+    expect(p.name).toBe("work");
+    expect(p.type).toBe("codex");
+    expect(p.passthrough).toEqual(["--model", "opus", "--name", "x"]);
+    expect(p.help).toBe(false);
+  });
+
+  it("supports --name= / --type= and --agent alias", () => {
+    const p = parseRunArgs(["--agent=work", "--type=pi"]);
+    expect(p.name).toBe("work");
+    expect(p.type).toBe("pi");
+  });
+
+  it("treats the first unknown token as start of passthrough (no `--` needed)", () => {
+    const p = parseRunArgs(["--name", "work", "chat", "--foo"]);
+    expect(p.name).toBe("work");
+    expect(p.passthrough).toEqual(["chat", "--foo"]);
+  });
+
+  it("launches bare when no `--` and no trailing args", () => {
+    const p = parseRunArgs(["--name", "work"]);
+    expect(p.passthrough).toEqual([]);
+  });
+
+  it("errors when a flag is missing its value", () => {
+    expect(parseRunArgs(["--name"]).error).toMatch(/--name needs a value/);
+    expect(parseRunArgs(["--type"]).error).toMatch(/--type needs a value/);
+  });
+
+  it("recognizes --help / -h", () => {
+    expect(parseRunArgs(["--help"]).help).toBe(true);
+    expect(parseRunArgs(["-h"]).help).toBe(true);
+  });
+});
+
+describe("resolveBinaryName", () => {
+  it("maps every known type to its binary", () => {
+    expect(resolveBinaryName(undefined, "claude-code")).toEqual({ type: "claude-code", binary: "claude" });
+    expect(resolveBinaryName("claude", undefined)).toEqual({ type: "claude", binary: "claude" });
+    expect(resolveBinaryName(undefined, "codex")).toEqual({ type: "codex", binary: "codex" });
+    expect(resolveBinaryName(undefined, "kiro")).toEqual({ type: "kiro", binary: "kiro-cli" });
+    expect(resolveBinaryName(undefined, "pi")).toEqual({ type: "pi", binary: "pi" });
+    expect(resolveBinaryName(undefined, "opencode")).toEqual({ type: "opencode", binary: "opencode" });
+    expect(resolveBinaryName(undefined, "openclaw")).toEqual({ type: "openclaw", binary: "openclaw" });
+    expect(resolveBinaryName(undefined, "dsh")).toEqual({ type: "dsh", binary: "dsh-jsonrpc-agent" });
+  });
+
+  it("prefers explicit --type over the stored agentType", () => {
+    expect(resolveBinaryName("codex", "claude-code")).toEqual({ type: "codex", binary: "codex" });
+  });
+
+  it("errors for an `offline` classification with no explicit type", () => {
+    const r = resolveBinaryName(undefined, "offline");
+    expect(r.error).toMatch(/offline/);
+    expect(r.error).toMatch(/--type/);
+  });
+
+  it("errors for an unknown type and when no type is available", () => {
+    expect(resolveBinaryName("banana", undefined).error).toMatch(/unknown agent type/);
+    expect(resolveBinaryName(undefined, undefined).error).toMatch(/no agent type given/);
+  });
+
+  it("TYPE_TO_BINARY has no `offline` key", () => {
+    expect(TYPE_TO_BINARY.offline).toBeUndefined();
+  });
+});
+
+describe("resolveBinaryPath", () => {
+  it("walks PATH and returns the first existing candidate (POSIX)", () => {
+    const seen = [];
+    const p = resolveBinaryPath("claude", {
+      env: { PATH: "/a:/b" },
+      platform: "linux",
+      isFile: (c) => {
+        seen.push(c);
+        return c === "/b/claude";
+      },
+    });
+    expect(p).toBe("/b/claude");
+    expect(seen).toEqual(["/a/claude", "/b/claude"]);
+  });
+
+  it("tries .cmd/.exe on Windows", () => {
+    const p = resolveBinaryPath("claude", {
+      env: { PATH: "C:\\bin" },
+      platform: "win32",
+      isFile: (c) => c === "C:\\bin\\claude.cmd",
+    });
+    expect(p).toBe("C:\\bin\\claude.cmd");
+  });
+
+  it("returns null when not found", () => {
+    expect(resolveBinaryPath("nope", { env: { PATH: "/a" }, platform: "linux", isFile: () => false })).toBeNull();
+  });
+});
+
+describe("resolveSpawnCommand", () => {
+  it("passes a POSIX binary through directly", () => {
+    expect(resolveSpawnCommand("/usr/bin/claude", ["--x"], "linux")).toEqual({
+      command: "/usr/bin/claude",
+      argv: ["--x"],
+    });
+  });
+
+  it("wraps a Windows .cmd shim in cmd.exe", () => {
+    const r = resolveSpawnCommand("C:\\bin\\claude.cmd", ["--x"], "win32", { ComSpec: "cmd.exe" });
+    expect(r.command).toBe("cmd.exe");
+    expect(r.argv).toEqual(["/d", "/s", "/c", "C:\\bin\\claude.cmd", "--x"]);
+  });
+});
+
+describe("buildChildEnv", () => {
+  it("injects the 3 CHORUS_* vars and clears CHORUS_DAEMON_HEADLESS", () => {
+    const env = buildChildEnv(AGENT, { PATH: "/usr/bin", CHORUS_DAEMON_HEADLESS: "1", KEEP: "yes" });
+    expect(env.CHORUS_URL).toBe(AGENT.url);
+    expect(env.CHORUS_API_KEY).toBe(SECRET);
+    expect(env.CHORUS_AGENT_PROFILE).toBe(AGENT.agentUuid);
+    expect(env.CHORUS_DAEMON_HEADLESS).toBeUndefined();
+    expect(env.KEEP).toBe("yes"); // inherited env preserved
+  });
+
+  it("falls back to agentName for the profile when no uuid", () => {
+    const env = buildChildEnv({ agentName: "solo", url: "u", apiKey: "k" }, {});
+    expect(env.CHORUS_AGENT_PROFILE).toBe("solo");
+  });
+});
+
+describe("resolveLaunchAgent (selection)", () => {
+  const two = [AGENT, { agentUuid: "aaaa", agentName: "other", agentType: "codex", url: "u2", apiKey: "cho_two" }];
+  const call = (flags, agents, env = {}) =>
+    resolveLaunchAgent(flags, { env, loginPath: LOGIN_PATH, readJson: () => ({ agents }) });
+
+  it("defaults to the single configured agent", () => {
+    expect(call({}, [AGENT]).agentType).toBe("claude-code");
+  });
+
+  it("selects by name and by uuid", () => {
+    expect(call({ name: "other" }, two).agentName).toBe("other");
+    expect(call({ name: "11111111-2222-3333-4444-555555555555" }, two).agentName).toBe("work");
+  });
+
+  it("honors CHORUS_AGENT_PROFILE", () => {
+    expect(call({}, two, { CHORUS_AGENT_PROFILE: "other" }).agentType).toBe("codex");
+  });
+
+  it("errors on ambiguity", () => {
+    const dup = [AGENT, { ...AGENT, agentUuid: "bbbb" }]; // both agentName "work"
+    expect(() => call({ name: "work" }, dup)).toThrow(/ambiguous/);
+  });
+
+  it("errors when multiple agents and none specified", () => {
+    expect(() => call({}, two)).toThrow(/Multiple agents/);
+  });
+
+  it("errors when no agents are configured", () => {
+    expect(() => call({}, [])).toThrow(/No agents are configured/);
+  });
+
+  it("preserves agentType, url, apiKey, uuid", () => {
+    const a = call({ name: "work" }, two);
+    expect(a).toMatchObject({ agentType: "claude-code", url: AGENT.url, apiKey: SECRET, agentUuid: AGENT.agentUuid });
+  });
+});
+
+describe("runAgentLaunch", () => {
+  it("launches the resolved binary in the foreground with verbatim passthrough", async () => {
+    const { calls, o } = opts();
+    const code = await runAgentLaunch(["--name", "work", "--", "--model", "opus", "--resume", "abc"], o);
+    expect(code).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe("/usr/bin/claude");
+    expect(calls[0].argv).toEqual(["--model", "opus", "--resume", "abc"]);
+    expect(calls[0].options.stdio).toBe("inherit");
+    expect(calls[0].options.shell).toBe(false);
+    expect(calls[0].options.cwd).toBe("/work");
+  });
+
+  it("injects the 3 CHORUS_* vars into the child env", async () => {
+    const { calls, o } = opts({ env: { CHORUS_DAEMON_HEADLESS: "1" } });
+    await runAgentLaunch(["--name", "work"], o);
+    const cenv = calls[0].options.env;
+    expect(cenv.CHORUS_URL).toBe(AGENT.url);
+    expect(cenv.CHORUS_API_KEY).toBe(SECRET);
+    expect(cenv.CHORUS_AGENT_PROFILE).toBe(AGENT.agentUuid);
+    expect(cenv.CHORUS_DAEMON_HEADLESS).toBeUndefined();
+  });
+
+  it("--type overrides the stored agentType", async () => {
+    const { calls, o } = opts();
+    await runAgentLaunch(["--name", "work", "--type", "codex"], o);
+    expect(calls[0].command).toBe("/usr/bin/codex");
+  });
+
+  it("forwards the child exit code", async () => {
+    const { o } = opts({ spawnBehavior: { code: 3 } });
+    expect(await runAgentLaunch(["--name", "work"], o)).toBe(3);
+  });
+
+  it("maps signal death to 128 + signum (SIGINT → 130)", async () => {
+    const { o } = opts({ spawnBehavior: { code: null, signal: "SIGINT" } });
+    expect(await runAgentLaunch(["--name", "work"], o)).toBe(130);
+  });
+
+  it("errors (no spawn) when the agent is offline and no --type is given", async () => {
+    const offline = [{ agentUuid: "x", agentName: "oc", agentType: "offline", url: "u", apiKey: "cho_x" }];
+    const { io, calls, o } = opts({ agents: offline });
+    const code = await runAgentLaunch(["--name", "oc"], o);
+    expect(code).toBe(1);
+    expect(calls).toHaveLength(0);
+    expect(io.errText()).toMatch(/offline/);
+  });
+
+  it("launches an offline-stored agent when --type is given explicitly", async () => {
+    const offline = [{ agentUuid: "x", agentName: "oc", agentType: "offline", url: "u", apiKey: "cho_x" }];
+    const { calls, o } = opts({ agents: offline });
+    const code = await runAgentLaunch(["--name", "oc", "--type", "opencode"], o);
+    expect(code).toBe(0);
+    expect(calls[0].command).toBe("/usr/bin/opencode");
+  });
+
+  it("errors (no spawn) when the binary is not on PATH", async () => {
+    const { io, calls, o } = opts({ isFile: () => false });
+    const code = await runAgentLaunch(["--name", "work"], o);
+    expect(code).toBe(1);
+    expect(calls).toHaveLength(0);
+    expect(io.errText()).toMatch(/claude/);
+  });
+
+  it("errors on ambiguous selection without spawning", async () => {
+    const dup = [AGENT, { ...AGENT, agentUuid: "bbbb" }];
+    const { calls, o } = opts({ agents: dup });
+    expect(await runAgentLaunch(["--name", "work"], o)).toBe(1);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("returns 2 and prints help on a usage error", async () => {
+    const { io, o } = opts();
+    expect(await runAgentLaunch(["--name"], o)).toBe(2);
+    expect(io.errText()).toMatch(/needs a value/);
+  });
+
+  it("prints help and exits 0 for --help", async () => {
+    const { io, calls, o } = opts();
+    expect(await runAgentLaunch(["--help"], o)).toBe(0);
+    expect(io.text()).toMatch(/USAGE/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("NEVER prints the API key on any path", async () => {
+    // success path
+    let t = opts();
+    await runAgentLaunch(["--name", "work", "--", "--model", "opus"], t.o);
+    expect(t.io.all()).not.toContain(SECRET);
+    // missing-binary error path
+    t = opts({ isFile: () => false });
+    await runAgentLaunch(["--name", "work"], t.o);
+    expect(t.io.all()).not.toContain(SECRET);
+    // offline error path
+    t = opts({ agents: [{ agentUuid: "x", agentName: "oc", agentType: "offline", url: "u", apiKey: SECRET }] });
+    await runAgentLaunch(["--name", "oc"], t.o);
+    expect(t.io.all()).not.toContain(SECRET);
+  });
+});

--- a/cli/agent-launcher.mjs
+++ b/cli/agent-launcher.mjs
@@ -1,0 +1,341 @@
+// cli/agent-launcher.mjs
+// `chorus agents run` — launch a configured coding-agent binary in the FOREGROUND
+// with the selected Chorus agent's connection + identity injected into the child
+// environment only. This is the interactive counterpart to the daemon's headless
+// spawners (claude-spawner / codex-spawner / …): it reuses the SAME env-injection
+// contract (CHORUS_URL / CHORUS_API_KEY / CHORUS_AGENT_PROFILE) and the SAME
+// shell-free PATH resolution, but differs deliberately —
+//   • stdio is INHERITED (the agent gets the real TTY; Ctrl-C reaches it directly),
+//   • CHORUS_DAEMON_HEADLESS is NOT set (and is cleared if it leaked in),
+//   • every token after `--` is passed to the agent VERBATIM, with no validation,
+//   • the child's exit (code or signal) is forwarded as this command's exit code.
+//
+// SECRET RULE: the `cho_` API key is injected into the child env only. It is NEVER
+// written to stdout, stderr, or any log — diagnostics name the agent by
+// name/UUID and the resolved binary, nothing else.
+
+import { spawn } from "node:child_process";
+import { statSync } from "node:fs";
+import { win32 as pathWin32, posix as pathPosix } from "node:path";
+import { resolveLaunchAgent } from "./credentials.mjs";
+
+/**
+ * Launch agent-type → executable base name. Launch is a SUPERSET of daemon wake:
+ * it can start ANY known agent, including the ones the daemon classifies
+ * "offline" (opencode / openclaw / dsh) and therefore never auto-wakes. The
+ * "offline" value itself is intentionally ABSENT: it is a wake classification,
+ * not a concrete backend, so it cannot name a binary — a user who added such an
+ * agent must pass an explicit `--type` (see resolveBinaryName).
+ * @type {Readonly<Record<string,string>>}
+ */
+export const TYPE_TO_BINARY = Object.freeze({
+  "claude-code": "claude",
+  claude: "claude",
+  codex: "codex",
+  kiro: "kiro-cli",
+  pi: "pi",
+  opencode: "opencode",
+  openclaw: "openclaw",
+  dsh: "dsh-jsonrpc-agent",
+});
+
+/** Human list of accepted --type values, for help + error text. */
+export const SUPPORTED_TYPES = "claude-code, codex, kiro, pi, opencode, openclaw, dsh";
+
+/**
+ * POSIX signal name → number, for the shell `128 + signum` exit convention when
+ * the launched agent is terminated by a signal (e.g. Ctrl-C = SIGINT → 130).
+ * Node's `close` event yields a signal NAME (or null); a naive `exit(code)` with
+ * code=null would collapse a signal death to exit 0 and hide it.
+ */
+const SIGNUM = Object.freeze({
+  SIGHUP: 1,
+  SIGINT: 2,
+  SIGQUIT: 3,
+  SIGILL: 4,
+  SIGABRT: 6,
+  SIGFPE: 8,
+  SIGKILL: 9,
+  SIGSEGV: 11,
+  SIGPIPE: 13,
+  SIGALRM: 14,
+  SIGTERM: 15,
+});
+
+/** A non-empty trimmed string, or undefined. */
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Split raw `chorus agents run` argv into chorus-owned flags and verbatim
+ * passthrough. The FIRST bare `--` terminates chorus-flag parsing; everything
+ * after it is passthrough, untouched. Chorus flags (before `--`): `--name <v>` /
+ * `--name=<v>`, its `--agent` alias, `--type <v>` / `--type=<v>`, and `--help`/`-h`.
+ * The first token that is NOT a recognized chorus flag also starts the
+ * passthrough (lenient) — so `chorus agents run --name x foo --bar` treats
+ * `foo --bar` as passthrough even without an explicit `--`.
+ *
+ * @param {string[]} argv  argv AFTER the `run` sub-verb.
+ * @returns {{ name?: string, type?: string, help: boolean, passthrough: string[], error?: string }}
+ */
+export function parseRunArgs(argv = []) {
+  const out = { help: false, passthrough: [] };
+  let i = 0;
+  for (; i < argv.length; i += 1) {
+    const tok = argv[i];
+    if (tok === "--") {
+      i += 1; // consume the separator; the rest is passthrough
+      break;
+    }
+    if (tok === "--help" || tok === "-h") {
+      out.help = true;
+      continue;
+    }
+    if (tok === "--name" || tok === "--agent") {
+      const v = argv[i + 1];
+      if (v === undefined) return { ...out, error: `flag ${tok} needs a value` };
+      out.name = v;
+      i += 1;
+      continue;
+    }
+    if (tok.startsWith("--name=")) {
+      out.name = tok.slice("--name=".length);
+      continue;
+    }
+    if (tok.startsWith("--agent=")) {
+      out.name = tok.slice("--agent=".length);
+      continue;
+    }
+    if (tok === "--type") {
+      const v = argv[i + 1];
+      if (v === undefined) return { ...out, error: `flag --type needs a value` };
+      out.type = v;
+      i += 1;
+      continue;
+    }
+    if (tok.startsWith("--type=")) {
+      out.type = tok.slice("--type=".length);
+      continue;
+    }
+    // Unrecognized token → start of verbatim passthrough.
+    break;
+  }
+  out.passthrough = argv.slice(i);
+  return out;
+}
+
+/**
+ * Resolve the agent type (explicit `--type` wins over the stored `agentType`)
+ * and map it to a binary base name. An `offline` classification or any unknown
+ * type has no launchable binary → returns an `error` string instructing the user
+ * to pass an explicit `--type`.
+ * @param {string|undefined} explicitType  the `--type` flag value
+ * @param {string|undefined} configType    the agent's stored agentType
+ * @returns {{ type: string, binary: string } | { error: string }}
+ */
+export function resolveBinaryName(explicitType, configType) {
+  const type = nonEmpty(explicitType) ?? nonEmpty(configType);
+  if (!type) {
+    return { error: `no agent type given and none is configured — pass --type <${SUPPORTED_TYPES}>` };
+  }
+  const binary = TYPE_TO_BINARY[type];
+  if (!binary) {
+    const reason =
+      type === "offline"
+        ? `agent is configured as "offline" (the daemon does not auto-wake it, so its concrete backend is not stored)`
+        : `unknown agent type "${type}"`;
+    return { error: `${reason} — pass an explicit --type <${SUPPORTED_TYPES}>` };
+  }
+  return { type, binary };
+}
+
+/**
+ * Resolve an executable base name to a full path WITHOUT a shell, walking PATH.
+ * On Windows, tries `.cmd` / `.exe` / bare (npm shims are `.cmd`); on POSIX just
+ * the bare name. Mirrors resolveClaudePath's shape. Returns null when not found.
+ * @param {string} binName
+ * @param {{ env?: NodeJS.ProcessEnv, platform?: NodeJS.Platform, isFile?: (p: string) => boolean }} [deps]
+ * @returns {string | null}
+ */
+export function resolveBinaryPath(binName, deps = {}) {
+  const env = deps.env ?? process.env;
+  const platform = deps.platform ?? process.platform;
+  const isFile =
+    deps.isFile ??
+    ((p) => {
+      try {
+        return statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    });
+  const isWin = platform === "win32";
+  const p = isWin ? pathWin32 : pathPosix;
+  const names = isWin ? [`${binName}.cmd`, `${binName}.exe`, binName] : [binName];
+  const pathVar = env.PATH || env.Path || "";
+  const dirs = pathVar.split(p.delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    for (const name of names) {
+      const candidate = p.join(dir, name);
+      if (isFile(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the actual command + argv to spawn. A Windows `.cmd`/`.bat` shim is not
+ * a PE executable, so it must run via `cmd.exe /d /s /c <path> …args`; keep
+ * shell:false and pass argv as an array (no shell word-splitting/injection). On
+ * POSIX (and a real `.exe`) spawn the path directly.
+ * @param {string} binPath @param {string[]} args
+ * @param {NodeJS.Platform} [platform] @param {NodeJS.ProcessEnv} [env]
+ * @returns {{ command: string, argv: string[] }}
+ */
+export function resolveSpawnCommand(binPath, args, platform = process.platform, env = process.env) {
+  const isWin = platform === "win32";
+  const lower = binPath.toLowerCase();
+  if (isWin && (lower.endsWith(".cmd") || lower.endsWith(".bat"))) {
+    const comspec = env.ComSpec || env.COMSPEC || "cmd.exe";
+    return { command: comspec, argv: ["/d", "/s", "/c", binPath, ...args] };
+  }
+  return { command: binPath, argv: args };
+}
+
+/**
+ * Build the child environment: the inherited env plus the selected agent's Chorus
+ * connection + identity. NO CHORUS_DAEMON_HEADLESS — this is an interactive run;
+ * a leaked value from a daemon-run parent is cleared so the agent does not adopt
+ * headless behavior. Only non-empty fields are set.
+ * @param {import("./credentials.mjs").LaunchAgent} agent
+ * @param {NodeJS.ProcessEnv} [baseEnv]
+ * @returns {NodeJS.ProcessEnv}
+ */
+export function buildChildEnv(agent, baseEnv = process.env) {
+  const childEnv = { ...baseEnv };
+  if (agent.url) childEnv.CHORUS_URL = agent.url;
+  if (agent.apiKey) childEnv.CHORUS_API_KEY = agent.apiKey;
+  const profile = agent.agentUuid || agent.agentName;
+  if (profile) childEnv.CHORUS_AGENT_PROFILE = profile;
+  delete childEnv.CHORUS_DAEMON_HEADLESS;
+  return childEnv;
+}
+
+/** Usage text for `chorus agents run`. */
+export function runHelpText(version = "") {
+  const v = version ? ` v${version}` : "";
+  return `\
+Chorus${v} — launch a configured agent
+
+USAGE
+  chorus agents run --name <name|uuid> [--type <type>] [--] [agent args…]
+
+Launches the agent's binary in the FOREGROUND with this agent's Chorus connection
+injected into the child (CHORUS_URL / CHORUS_API_KEY / CHORUS_AGENT_PROFILE).
+Everything after \`--\` is passed to the agent verbatim — the agent's full flag
+surface is available and is never inspected by chorus.
+
+FLAGS
+  --name <name|uuid>   Which configured agent to launch (default: the only one).
+  --type <type>        Override the agent's backend: ${SUPPORTED_TYPES}.
+  -h, --help           Show this help.
+
+Notes
+  • Agents added as opencode / openclaw / dsh are stored as "offline"; pass
+    --type explicitly to launch them.
+  • The API key is injected into the launched process only — never printed.
+`;
+}
+
+/**
+ * Run `chorus agents run …`. Selects the agent, resolves its binary, injects the
+ * Chorus env, and spawns it in the foreground. Resolves with an exit code (never
+ * calls process.exit): the launched agent's code, `128 + signum` on signal death,
+ * `1` on any launch failure, `2` on a usage error, `0` on --help.
+ *
+ * @param {string[]} argv  argv AFTER the `run` sub-verb.
+ * @param {{ stdout?: {write:(s:string)=>void}, stderr?: {write:(s:string)=>void},
+ *   env?: NodeJS.ProcessEnv, readJson?: (p:string)=>any, loginPath?: string,
+ *   platform?: NodeJS.Platform, cwd?: string, version?: string,
+ *   spawnImpl?: Function, isFile?: (p:string)=>boolean }} [opts]
+ * @returns {Promise<number>}
+ */
+export async function runAgentLaunch(argv = [], opts = {}) {
+  const out = opts.stdout ?? process.stdout;
+  const err = opts.stderr ?? process.stderr;
+  const env = opts.env ?? process.env;
+  const platform = opts.platform ?? process.platform;
+  const spawnImpl = opts.spawnImpl ?? spawn;
+  const version = opts.version ?? "";
+
+  const parsed = parseRunArgs(argv);
+  if (parsed.help) {
+    out.write(runHelpText(version));
+    return 0;
+  }
+  if (parsed.error) {
+    err.write(`error: ${parsed.error}\n\n${runHelpText(version)}`);
+    return 2;
+  }
+
+  // 1. Select which configured agent to launch.
+  let agent;
+  try {
+    agent = resolveLaunchAgent({ name: parsed.name }, opts);
+  } catch (e) {
+    err.write(`error: ${e.message}\n`);
+    return 1;
+  }
+
+  // 2. Resolve the type → binary (explicit --type wins over stored agentType).
+  const typeRes = resolveBinaryName(parsed.type, agent.agentType);
+  if (typeRes.error) {
+    err.write(`error: ${agent.label}: ${typeRes.error}\n`);
+    return 1;
+  }
+
+  // 3. Locate the binary on PATH.
+  const binPath = resolveBinaryPath(typeRes.binary, { env, platform, isFile: opts.isFile });
+  if (!binPath) {
+    err.write(
+      `error: could not find the \`${typeRes.binary}\` executable on PATH ` +
+        `(agent "${agent.label}", type "${typeRes.type}"). Is it installed?\n`,
+    );
+    return 1;
+  }
+
+  // 4. Build the child env and the spawn command.
+  const childEnv = buildChildEnv(agent, env);
+  const { command, argv: spawnArgv } = resolveSpawnCommand(binPath, parsed.passthrough, platform, env);
+
+  // Diagnostic — agent name/uuid + binary ONLY. Never the key or url userinfo.
+  out.write(`Launching ${agent.label} (${agent.agentUuid ?? "no uuid"}) → ${typeRes.binary}\n`);
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawnImpl(command, spawnArgv, {
+        cwd: opts.cwd ?? process.cwd(),
+        stdio: "inherit",
+        env: childEnv,
+        shell: false,
+      });
+    } catch (e) {
+      err.write(`error: failed to launch ${typeRes.binary}: ${e.message}\n`);
+      resolve(1);
+      return;
+    }
+    child.on("error", (e) => {
+      err.write(`error: ${typeRes.binary} failed to start: ${e.message}\n`);
+      resolve(1);
+    });
+    child.on("close", (code, signal) => {
+      if (signal) {
+        resolve(128 + (SIGNUM[signal] ?? 0));
+        return;
+      }
+      resolve(typeof code === "number" ? code : 0);
+    });
+  });
+}

--- a/cli/agents.mjs
+++ b/cli/agents.mjs
@@ -67,6 +67,10 @@ USAGE
   chorus agents add [flags]         Configure agent(s): detect, install plugin, seed
                                     credentials (formerly \`chorus init\`; same flags —
                                     see \`chorus agents add --help\`)
+  chorus agents run --name <n> [--type <t>] -- [args…]
+                                    Launch an agent's binary in the foreground with its
+                                    Chorus connection injected; args after \`--\` pass
+                                    through verbatim (see \`chorus agents run --help\`)
   chorus agents remove <name|uuid>  Remove a configured agent from ~/.chorus/daemon.json
 
 Each listed UUID or name is a valid value for \`chorus mcp --agent <name|uuid>\` or the
@@ -315,6 +319,14 @@ export function runAgents(argv = [], opts = {}) {
     // list/remove paths from loading the heavier init subsystem.
     const runInit = opts.runInit ?? (async (a, o) => (await import("./init.mjs")).runInit(a, o));
     return runInit(argv.slice(1), { version });
+  }
+  if (first === "run") {
+    // Foreground agent launch. Dynamic import keeps the list/remove paths from
+    // loading the launcher (and its child_process import). Forward the full opts
+    // (env/readJson/loginPath/spawnImpl/stdio) so tests can inject them.
+    const runAgentLaunch =
+      opts.runAgentLaunch ?? (async (a, o) => (await import("./agent-launcher.mjs")).runAgentLaunch(a, o));
+    return runAgentLaunch(argv.slice(1), { ...opts, version });
   }
   if (first === "remove") {
     return removeAgent(argv.slice(1), opts);

--- a/cli/credentials.mjs
+++ b/cli/credentials.mjs
@@ -380,3 +380,105 @@ export function resolveMcpCredentials(flags = {}, deps = {}) {
   const flat = resolveCredentials(flags, deps);
   return { url: flat.url, apiKey: flat.apiKey, label: flat.source };
 }
+
+/**
+ * @typedef {Object} LaunchAgent
+ * @property {string|undefined} url
+ * @property {string|undefined} apiKey
+ * @property {string|undefined} agentUuid
+ * @property {string|undefined} agentName
+ * @property {string|undefined} agentType   The daemon agentType stored in daemon.json
+ *   ("claude-code" | "codex" | "kiro" | "pi" | "offline" | …). The launcher maps this
+ *   (or an explicit --type) to a binary.
+ * @property {string} label                 Diagnostic display label (name/uuid), never the key.
+ */
+
+/**
+ * Resolve WHICH configured agent to launch (`chorus agents run`), returning the
+ * selected `agents[]` entry INCLUDING its `agentType` — the field the launcher
+ * needs to pick a binary and which `resolveMcpCredentials` deliberately drops.
+ *
+ * Selection precedence (mirrors `resolveMcpCredentials`, minus the url+key env/flag
+ * fallbacks — a launch always acts as a configured agent):
+ *   1. explicit selector: `flags.name` (the `--name` flag) or `flags.agent`
+ *      (`--agent` alias), matched against each entry's agentUuid / agentName /
+ *      label / name (exact). No match → error; >1 match → ambiguity error.
+ *   2. `CHORUS_AGENT_PROFILE` env, same matching.
+ *   3. exactly one configured agent → that agent.
+ *   4. more than one and nothing specified → error (never pick silently).
+ * No `agents[]` at all → error telling the user to configure one.
+ *
+ * Each entry's url/apiKey merges over the top-level per-field defaults
+ * (`resolveCredentialDefaults`), same as `resolveMcpCredentials`. This never
+ * imports daemon-config.mjs (which imports this module) — it reads `agents[]`
+ * directly to stay cycle-free.
+ *
+ * @param {{ name?: string, agent?: string, url?: string, apiKey?: string }} flags
+ * @param {ResolveDeps} [deps]
+ * @returns {LaunchAgent}
+ * @throws {Error} on ambiguity, no match, or no configured agents.
+ */
+export function resolveLaunchAgent(flags = {}, deps = {}) {
+  const env = deps.env ?? process.env;
+  const readJson = deps.readJson ?? readJsonSafe;
+  const loginPath = deps.loginPath ?? loginFilePath();
+  const wanted = nonEmpty(flags.name) ?? nonEmpty(flags.agent) ?? nonEmpty(env.CHORUS_AGENT_PROFILE);
+
+  const file = readJson(loginPath);
+  const agentEntries =
+    file && Array.isArray(file.agents)
+      ? file.agents.filter((a) => a && typeof a === "object")
+      : [];
+  if (agentEntries.length === 0) {
+    throw new Error(
+      `No agents are configured in ${loginPath}. Run \`chorus agents add\` to configure one.`,
+    );
+  }
+
+  const defaults = resolveCredentialDefaults(flags, deps);
+  const labelOf = (entry, i) =>
+    nonEmpty(entry.agentName) ?? nonEmpty(entry.label) ?? nonEmpty(entry.name) ?? `agents[${i}]`;
+  const resolved = agentEntries.map((entry, i) => ({
+    label: labelOf(entry, i),
+    keys: [entry.agentUuid, entry.agentName, entry.label, entry.name]
+      .map((k) => nonEmpty(k))
+      .filter((k) => k !== undefined),
+    url: nonEmpty(entry.url) ?? defaults.url,
+    apiKey: nonEmpty(entry.apiKey) ?? defaults.apiKey,
+    agentUuid: nonEmpty(entry.agentUuid),
+    agentName: nonEmpty(entry.agentName) ?? nonEmpty(entry.name),
+    agentType: nonEmpty(entry.agentType),
+  }));
+  const labels = resolved.map((a) => a.label).join(", ");
+
+  let selected;
+  if (wanted) {
+    const matches = resolved.filter((a) => a.keys.includes(wanted));
+    if (matches.length === 0) {
+      throw new Error(`No configured agent matches "${wanted}" in ${loginPath}. Available: ${labels}.`);
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `"${wanted}" is ambiguous in ${loginPath} — it matches ${matches.length} agents ` +
+          `(${matches.map((m) => m.label).join(", ")}). Use the agent UUID to disambiguate.`,
+      );
+    }
+    selected = matches[0];
+  } else if (resolved.length === 1) {
+    selected = resolved[0];
+  } else {
+    throw new Error(
+      `Multiple agents are configured in ${loginPath} (${labels}). ` +
+        `Specify which one to launch with --name <name|uuid> or CHORUS_AGENT_PROFILE.`,
+    );
+  }
+
+  return {
+    url: selected.url,
+    apiKey: selected.apiKey,
+    agentUuid: selected.agentUuid,
+    agentName: selected.agentName,
+    agentType: selected.agentType,
+    label: selected.label,
+  };
+}

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -15,6 +15,41 @@ See `chorus daemon --help` and `chorus login --help` for the full flag list.
 
 ---
 
+## Launch an agent interactively (`chorus agents run`)
+
+The daemon wakes an agent **headlessly** on dispatch. When you instead want to
+start a configured agent **yourself, in your terminal**, use `chorus agents run` —
+the foreground counterpart. It saves you from hand-exporting the connection
+variables before every launch: a child process cannot write to your shell anyway,
+so `run` injects the environment into the launched agent process directly.
+
+```bash
+chorus agents run --name work -- --model opus        # launch agent "work"; pass --model opus to it
+chorus agents run                                    # launch the only configured agent
+chorus agents run --name work --type codex -- resume # override the backend, then pass `resume` through
+```
+
+- **Which agent.** `--name <name|uuid>` selects from `~/.chorus/daemon.json`
+  `agents[]`. With one configured agent it is optional; with several, pass
+  `--name` (or set `CHORUS_AGENT_PROFILE`) or you get an error — it never guesses.
+- **What gets injected** (into the launched process only — never your shell, never
+  printed): `CHORUS_URL`, `CHORUS_API_KEY`, and `CHORUS_AGENT_PROFILE`. The
+  harness's own credentials were already written to its config by
+  `chorus agents add`, so they are not re-handled here.
+- **Which binary.** The backend defaults to the agent's stored `agentType`;
+  `--type <type>` overrides it. Types map to binaries: `claude-code`/`claude` →
+  `claude`, `codex` → `codex`, `kiro` → `kiro-cli`, `pi` → `pi`, `opencode` →
+  `opencode`, `openclaw` → `openclaw`, `dsh` → `dsh-jsonrpc-agent`. Agents added as
+  opencode / openclaw / dsh are stored as `offline` (the daemon does not auto-wake
+  them), so pass `--type` explicitly to launch those.
+- **Passthrough.** Everything after `--` is handed to the agent **verbatim** and
+  never inspected, so the agent's full flag surface is available. The launched
+  agent inherits your terminal, and `chorus agents run` exits with its exit code.
+
+See `chorus agents run --help`.
+
+---
+
 ## Credentials
 
 The daemon resolves the server URL + `cho_` API key in this precedence (first

--- a/openspec/changes/archive/2026-09-04-add-cli-agent-launch/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-04-add-cli-agent-launch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/archive/2026-09-04-add-cli-agent-launch/README.md
+++ b/openspec/changes/archive/2026-09-04-add-cli-agent-launch/README.md
@@ -1,0 +1,3 @@
+# add-cli-agent-launch
+
+Add chorus agents run to launch a configured coding agent with injected Chorus creds

--- a/openspec/changes/archive/2026-09-04-add-cli-agent-launch/design.md
+++ b/openspec/changes/archive/2026-09-04-add-cli-agent-launch/design.md
@@ -1,0 +1,127 @@
+# Design — `chorus agents run`
+
+## Context
+
+`chorus agents` (`cli/agents.mjs`) already dispatches `list` / `add` / `remove`.
+Credentials live in `~/.chorus/daemon.json` under `agents[]`, each entry carrying
+`agentUuid`, `agentName`, `url`, `apiKey`, and `agentType`. `cli/credentials.mjs`
+`resolveMcpCredentials(flags, deps)` already resolves *which* agent to act as
+(flag `--agent`/name → `CHORUS_AGENT_PROFILE` → single-agent default → hard error
+on ambiguity) but returns only `{ url, apiKey, label }` — it discards `agentType`,
+which the launcher needs to pick the binary.
+
+The daemon spawners (`cli/claude-spawner.mjs`, `codex-spawner.mjs`, etc.) show
+the injection contract to reuse: they build `childEnv = { ...process.env }` and
+set `CHORUS_URL`, `CHORUS_API_KEY`, and `CHORUS_AGENT_PROFILE` (from
+`agentUuid || agentName`). They spawn **headless** (`claude -p`, `codex exec`)
+with piped stdio and `CHORUS_DAEMON_HEADLESS=1`. The launcher differs: it is
+**interactive/foreground** — it inherits stdio, sets NO `CHORUS_DAEMON_HEADLESS`,
+passes the user's args verbatim, and forwards the child exit code.
+
+## Goals / Non-goals
+
+- **Goal:** one command to launch any configured agent with creds injected and
+  arbitrary agent args passed through untouched.
+- **Non-goal (v1):** env-export / `eval` output; `--profile` sub-selection beyond
+  agent identity; interactive agent picker; cleanup/unset semantics (a child
+  process's env dies with it).
+
+## Decisions
+
+### D1 — Command shape & passthrough boundary (`run_dashdash`)
+
+`chorus agents run --name <name|uuid> [--type <type>] [--] <agent args…>`
+
+- Only `--name`, `--type`, `--help`/`-h` are chorus-owned flags, parsed from the
+  front of argv.
+- The first bare `--` token terminates chorus-flag parsing; **every token after
+  it is passed to the agent binary verbatim** (no validation, no
+  interpretation). This guarantees an agent's own `--name` / `--type` / anything
+  never collides with chorus's flags.
+- `--` is optional when there are no passthrough args (`chorus agents run --name X`
+  launches the agent bare). If non-flag tokens appear before any `--`, treat the
+  first such token as the start of passthrough too (lenient), but the documented
+  form uses `--`.
+
+### D2 — Type coverage (`all_known`) & type → binary map
+
+Launch is a **superset** of daemon wake. The binary is resolved from a launch map
+independent of the wake `agentType` classification:
+
+| type (`--type` value or config `agentType`) | binary |
+|---|---|
+| `claude-code`, `claude` | `claude` |
+| `codex` | `codex` |
+| `kiro` | `kiro-cli` |
+| `pi` | `pi` |
+| `opencode` | `opencode` |
+| `openclaw` | `openclaw` |
+| `dsh` | `dsh-jsonrpc-agent` |
+
+- Precedence: explicit `--type` > selected agent's `agentType` from daemon.json.
+- **`offline` is intentionally not in the map.** Because `chorus agents add`
+  stores `opencode` / `openclaw` / `dsh` as the daemon `agentType` `"offline"`
+  (they are not daemon-wakeable), a config type of `offline` cannot be resolved
+  to a binary. In that case the launcher errors, telling the user to pass an
+  explicit `--type <claude|codex|kiro|pi|opencode|openclaw|dsh>`.
+- Binary resolution walks `PATH` (shell-free, Windows `.cmd`/`.exe` aware),
+  reusing the same resolver shape as the spawners
+  (`resolveClaudePath`/`resolveCodexPath`/…). A missing binary is a clear,
+  non-zero-exit error naming the binary and the `PATH` that was searched — never
+  a silent failure.
+
+### D3 — Environment injection (child only)
+
+`childEnv = { ...process.env }` plus, from the selected agent:
+
+- `CHORUS_URL` ← agent `url`
+- `CHORUS_API_KEY` ← agent `apiKey`
+- `CHORUS_AGENT_PROFILE` ← agent `agentUuid || agentName`
+
+No `CHORUS_DAEMON_HEADLESS` (this is an interactive run). The harness's own
+credentials (e.g. Codex `~/.codex/.env`, Claude `~/.claude/settings.json`) are
+written by `chorus agents add` into each harness's own config and are NOT
+re-handled here.
+
+### D4 — Spawn & lifecycle
+
+- `spawn(command, argv, { stdio: "inherit", env: childEnv, shell: false, cwd: process.cwd() })`.
+  `stdio: "inherit"` gives the agent the real TTY, so Ctrl-C reaches the child
+  directly (shared process group) — no manual signal forwarding needed for the
+  common case.
+- Windows `.cmd`/`.bat` shims are launched via `cmd.exe /d /s /c <path> …args`
+  (reusing the `resolveSpawnCommand` pattern) so `shell: false` stays true and
+  there is no shell word-splitting/injection surface.
+- The command resolves with the child's exit code; the CLI process exits with
+  the same code. A spawn failure (ENOENT, etc.) exits non-zero with a visible
+  error.
+
+### D5 — Credential resolver addition
+
+Add `resolveLaunchAgent(flags, deps)` to `cli/credentials.mjs` returning
+`{ url, apiKey, agentUuid, agentName, agentType, label }` for the selected agent,
+mirroring `resolveMcpCredentials`'s selection precedence but preserving
+`agentType`. Ambiguity and "no agents configured" produce the same clear errors.
+
+## Secret handling
+
+The `cho_` API key is injected into the child env only. It is never written to
+stdout, never logged, and never included in any error message. `chorus agents
+run` prints at most a one-line diagnostic naming the selected agent (name/uuid)
+and the binary — never the key or the url userinfo.
+
+## Risks
+
+- **dsh is a JSON-RPC runtime, not a REPL.** Launching `dsh-jsonrpc-agent`
+  interactively is unusual but honored under the `all_known` decision + verbatim
+  passthrough; the user owns what they pass.
+- **`offline` type ambiguity** is handled by requiring an explicit `--type`
+  rather than guessing.
+
+## Testing
+
+Unit tests (Vitest, injecting `spawnImpl` / `env` / `readJson` — no real disk,
+env, or subprocess), covering: argv split at `--`, flag parsing, agent selection
+(single/multi/ambiguous/`--name`/profile), `--type` override vs config default,
+`offline`-without-`--type` error, type→binary map, missing-binary error,
+childEnv contents, exit-code forwarding, and absence of any secret in stdout/err.

--- a/openspec/changes/archive/2026-09-04-add-cli-agent-launch/proposal.md
+++ b/openspec/changes/archive/2026-09-04-add-cli-agent-launch/proposal.md
@@ -1,0 +1,56 @@
+# Add `chorus agents run` — launch a configured coding agent
+
+## Why
+
+Today, to start a coding agent (Claude Code, Codex, Kiro, pi, …) wired to a
+Chorus instance, a user must manually discover and export the right connection
+and identity variables (`CHORUS_URL`, `CHORUS_API_KEY`, `CHORUS_AGENT_PROFILE`)
+before running the agent binary. That is fiddly and error-prone, especially on a
+machine that has several agents configured in `~/.chorus/daemon.json`.
+
+The original idea framed this as "load the variables into the current shell".
+That is not achievable: a child process cannot mutate its parent shell's
+environment (a POSIX invariant — the child receives a *copy*). The owner
+redirected the work to the robust path instead: **have the CLI launch the agent
+itself as a child process, injecting the environment only into that child.** This
+sidesteps the parent-shell problem entirely and never leaks the API key into the
+parent shell or terminal history.
+
+The credential-injection machinery already exists — the daemon's spawners
+(`ClaudeSpawner`, `CodexSpawner`, …) inject exactly this environment when they
+wake an agent headlessly. This change surfaces the same injection as a
+foreground, interactive command.
+
+## What Changes
+
+- **New subcommand `chorus agents run`** (peer of `list` / `add` / `remove`):
+  `chorus agents run --name <name|uuid> [--type <type>] -- <agent args…>`.
+  - Selects which configured agent (profile) to act as, reusing the existing
+    `resolveMcpCredentials` selection semantics.
+  - Resolves the agent binary from the agent's `agentType` (overridable with
+    `--type`), then `exec`s it in the **foreground** with the user's TTY.
+  - Injects `CHORUS_URL` / `CHORUS_API_KEY` / `CHORUS_AGENT_PROFILE` into the
+    child environment only.
+  - Passes every token after `--` through to the agent binary **verbatim, with
+    no validation** — the agent's full flag surface is available.
+  - Forwards the child's exit code as the command's own exit code.
+- **No env-export path in v1.** Emitting `export …` lines for `eval` is deferred
+  as a possible later enhancement.
+
+## Capabilities
+
+- `cli-agent-launch` — the `chorus agents run` command: agent selection, type →
+  binary resolution, credential injection, verbatim passthrough, foreground
+  launch, and its error surface.
+
+## Impact
+
+- **Affected code:** a new `cli/agent-launcher.mjs` module, a `run` branch in
+  `cli/agents.mjs` (`runAgents` dispatch + group help), and a small credential
+  resolver addition in `cli/credentials.mjs` (return the selected agent's
+  `agentType` alongside url/apiKey). All plain ESM, zero new dependencies —
+  ships in the npm package.
+- **Docs:** the `chorus-cli` skill gains the `run` command contract; user docs
+  gain a short "launch an agent" section.
+- **No schema, API, or web changes.** No secret is ever printed to stdout, logs,
+  or error messages.

--- a/openspec/changes/archive/2026-09-04-add-cli-agent-launch/specs/cli-agent-launch/spec.md
+++ b/openspec/changes/archive/2026-09-04-add-cli-agent-launch/specs/cli-agent-launch/spec.md
@@ -1,0 +1,101 @@
+# cli-agent-launch
+
+## ADDED Requirements
+
+### Requirement: Launch a configured agent via `chorus agents run`
+
+The CLI SHALL provide a `chorus agents run` subcommand that launches a locally
+installed coding-agent binary as a foreground child process, with the selected
+Chorus agent's connection and identity environment injected into that child only.
+The command form SHALL be
+`chorus agents run --name <name|uuid> [--type <type>] [--] <agent args…>`.
+
+#### Scenario: Launch the single configured agent
+
+- **WHEN** `~/.chorus/daemon.json` has exactly one configured agent and the user
+  runs `chorus agents run` with no `--name`
+- **THEN** the launcher SHALL select that agent, resolve its binary from its
+  `agentType`, and spawn it in the foreground with `CHORUS_URL`,
+  `CHORUS_API_KEY`, and `CHORUS_AGENT_PROFILE` set in the child environment.
+
+#### Scenario: Select an agent by name or UUID
+
+- **WHEN** the user runs `chorus agents run --name <name|uuid>`
+- **THEN** the launcher SHALL select the matching `agents[]` entry, and if the
+  value matches more than one entry it SHALL exit non-zero with an ambiguity
+  error listing the candidates, without spawning anything.
+
+#### Scenario: No agent can be selected
+
+- **WHEN** multiple agents are configured and no `--name` / `CHORUS_AGENT_PROFILE`
+  is given, or no agents are configured at all
+- **THEN** the launcher SHALL exit non-zero with a message telling the user how
+  to specify or configure an agent, without spawning anything.
+
+### Requirement: Resolve the agent binary by type
+
+The launcher SHALL determine which binary to launch from the agent type, taking
+an explicit `--type` flag over the selected agent's stored `agentType`, and SHALL
+map the type to a binary name.
+
+#### Scenario: Type maps to a known binary
+
+- **WHEN** the resolved type is one of `claude-code`/`claude`, `codex`, `kiro`,
+  `pi`, `opencode`, `openclaw`, or `dsh`
+- **THEN** the launcher SHALL resolve, respectively, the `claude`, `codex`,
+  `kiro-cli`, `pi`, `opencode`, `openclaw`, or `dsh-jsonrpc-agent` executable on
+  `PATH` and launch it.
+
+#### Scenario: `--type` overrides the stored type
+
+- **WHEN** the user passes `--type codex` for an agent whose stored `agentType`
+  is `claude-code`
+- **THEN** the launcher SHALL launch the `codex` binary.
+
+#### Scenario: Offline-classified agent without an explicit type
+
+- **WHEN** the selected agent's stored `agentType` is `offline` and no `--type`
+  is given
+- **THEN** the launcher SHALL exit non-zero with a message instructing the user
+  to pass an explicit `--type` (one of the supported types), because the concrete
+  backend cannot be recovered from an `offline` classification.
+
+#### Scenario: Agent binary not found on PATH
+
+- **WHEN** the resolved binary does not exist on `PATH`
+- **THEN** the launcher SHALL exit non-zero with an error naming the missing
+  binary, without spawning anything.
+
+### Requirement: Pass agent arguments through verbatim
+
+The launcher SHALL pass every token after the `--` separator to the agent binary
+unmodified and without validation, so the agent's full argument surface is
+available.
+
+#### Scenario: Passthrough after `--`
+
+- **WHEN** the user runs `chorus agents run --name X -- --model opus --resume abc`
+- **THEN** the launcher SHALL invoke the resolved binary with exactly
+  `--model opus --resume abc` as its arguments, unaltered and unchecked.
+
+#### Scenario: Launch with no passthrough args
+
+- **WHEN** the user runs `chorus agents run --name X` with no `--` and no trailing
+  args
+- **THEN** the launcher SHALL launch the binary with no extra arguments.
+
+### Requirement: Forward exit code and protect secrets
+
+The command SHALL exit with the launched agent's exit code, and SHALL never
+write the agent's API key to stdout, logs, or error messages.
+
+#### Scenario: Exit code propagation
+
+- **WHEN** the launched agent exits with code N
+- **THEN** `chorus agents run` SHALL exit with code N.
+
+#### Scenario: No secret in output
+
+- **WHEN** the command runs (success or any error path)
+- **THEN** the `cho_` API key SHALL NOT appear in any stdout, stderr, or log
+  output; diagnostics SHALL identify the agent by name/UUID only.

--- a/openspec/changes/archive/2026-09-04-add-cli-agent-launch/tasks.md
+++ b/openspec/changes/archive/2026-09-04-add-cli-agent-launch/tasks.md
@@ -1,0 +1,14 @@
+# Tasks — add-cli-agent-launch
+
+## 1. Implement `chorus agents run`
+
+- [ ] 1.1 Add `resolveLaunchAgent(flags, deps)` to `cli/credentials.mjs` returning the selected agent's `{ url, apiKey, agentUuid, agentName, agentType, label }` (reuse `resolveMcpCredentials` selection precedence).
+- [ ] 1.2 New `cli/agent-launcher.mjs`: argv split at `--`, chorus flag parse (`--name`/`--type`/`--help`), type→binary map, PATH-walk binary resolution (Windows `.cmd` aware), childEnv build (3 `CHORUS_*`, no headless), foreground spawn (`stdio: "inherit"`), exit-code forwarding, `offline`/missing-binary/ambiguous errors.
+- [ ] 1.3 Wire the `run` branch into `runAgents` (`cli/agents.mjs`) + `chorus agents run --help` + group help update.
+- [ ] 1.4 Unit tests (Vitest) covering selection, `--type` override, `offline` error, type→binary map, missing binary, childEnv contents, passthrough after `--`, exit-code forwarding, no-secret-in-output.
+- [ ] 1.5 `pnpm test` (new tests) + `npx tsc --noEmit` + `pnpm lint` clean.
+
+## 2. Document `chorus agents run`
+
+- [ ] 2.1 Add the `run` command contract to the `chorus-cli` skill across all plugin surfaces.
+- [ ] 2.2 Add a short "launch an agent" section to the user docs.

--- a/openspec/specs/cli-agent-launch/spec.md
+++ b/openspec/specs/cli-agent-launch/spec.md
@@ -1,0 +1,103 @@
+# cli-agent-launch Specification
+
+## Purpose
+TBD - created by archiving change add-cli-agent-launch. Update Purpose after archive.
+## Requirements
+### Requirement: Launch a configured agent via `chorus agents run`
+
+The CLI SHALL provide a `chorus agents run` subcommand that launches a locally
+installed coding-agent binary as a foreground child process, with the selected
+Chorus agent's connection and identity environment injected into that child only.
+The command form SHALL be
+`chorus agents run --name <name|uuid> [--type <type>] [--] <agent args…>`.
+
+#### Scenario: Launch the single configured agent
+
+- **WHEN** `~/.chorus/daemon.json` has exactly one configured agent and the user
+  runs `chorus agents run` with no `--name`
+- **THEN** the launcher SHALL select that agent, resolve its binary from its
+  `agentType`, and spawn it in the foreground with `CHORUS_URL`,
+  `CHORUS_API_KEY`, and `CHORUS_AGENT_PROFILE` set in the child environment.
+
+#### Scenario: Select an agent by name or UUID
+
+- **WHEN** the user runs `chorus agents run --name <name|uuid>`
+- **THEN** the launcher SHALL select the matching `agents[]` entry, and if the
+  value matches more than one entry it SHALL exit non-zero with an ambiguity
+  error listing the candidates, without spawning anything.
+
+#### Scenario: No agent can be selected
+
+- **WHEN** multiple agents are configured and no `--name` / `CHORUS_AGENT_PROFILE`
+  is given, or no agents are configured at all
+- **THEN** the launcher SHALL exit non-zero with a message telling the user how
+  to specify or configure an agent, without spawning anything.
+
+### Requirement: Resolve the agent binary by type
+
+The launcher SHALL determine which binary to launch from the agent type, taking
+an explicit `--type` flag over the selected agent's stored `agentType`, and SHALL
+map the type to a binary name.
+
+#### Scenario: Type maps to a known binary
+
+- **WHEN** the resolved type is one of `claude-code`/`claude`, `codex`, `kiro`,
+  `pi`, `opencode`, `openclaw`, or `dsh`
+- **THEN** the launcher SHALL resolve, respectively, the `claude`, `codex`,
+  `kiro-cli`, `pi`, `opencode`, `openclaw`, or `dsh-jsonrpc-agent` executable on
+  `PATH` and launch it.
+
+#### Scenario: `--type` overrides the stored type
+
+- **WHEN** the user passes `--type codex` for an agent whose stored `agentType`
+  is `claude-code`
+- **THEN** the launcher SHALL launch the `codex` binary.
+
+#### Scenario: Offline-classified agent without an explicit type
+
+- **WHEN** the selected agent's stored `agentType` is `offline` and no `--type`
+  is given
+- **THEN** the launcher SHALL exit non-zero with a message instructing the user
+  to pass an explicit `--type` (one of the supported types), because the concrete
+  backend cannot be recovered from an `offline` classification.
+
+#### Scenario: Agent binary not found on PATH
+
+- **WHEN** the resolved binary does not exist on `PATH`
+- **THEN** the launcher SHALL exit non-zero with an error naming the missing
+  binary, without spawning anything.
+
+### Requirement: Pass agent arguments through verbatim
+
+The launcher SHALL pass every token after the `--` separator to the agent binary
+unmodified and without validation, so the agent's full argument surface is
+available.
+
+#### Scenario: Passthrough after `--`
+
+- **WHEN** the user runs `chorus agents run --name X -- --model opus --resume abc`
+- **THEN** the launcher SHALL invoke the resolved binary with exactly
+  `--model opus --resume abc` as its arguments, unaltered and unchecked.
+
+#### Scenario: Launch with no passthrough args
+
+- **WHEN** the user runs `chorus agents run --name X` with no `--` and no trailing
+  args
+- **THEN** the launcher SHALL launch the binary with no extra arguments.
+
+### Requirement: Forward exit code and protect secrets
+
+The command SHALL exit with the launched agent's exit code, and SHALL never
+write the agent's API key to stdout, logs, or error messages.
+
+#### Scenario: Exit code propagation
+
+- **WHEN** the launched agent exits with code N
+- **THEN** `chorus agents run` SHALL exit with code N.
+
+#### Scenario: No secret in output
+
+- **WHEN** the command runs (success or any error path)
+- **THEN** the `cho_` API key SHALL NOT appear in any stdout, stderr, or log
+  output; diagnostics SHALL identify the agent by name/UUID only.
+

--- a/packages/chorus-dsh/skills/chorus-cli/SKILL.md
+++ b/packages/chorus-dsh/skills/chorus-cli/SKILL.md
@@ -35,6 +35,16 @@ Agent configuration lives in `~/.chorus/daemon.json`; `chorus agents` is the CRU
 - `chorus agents remove <name|uuid>` — remove a configured agent from `~/.chorus/daemon.json`
   (matched by UUID or name; an ambiguous name → use the UUID).
 
+- `chorus agents run --name <name|uuid> [--type <type>] [--] [agent args…]` — launch a
+  configured agent's binary in the FOREGROUND with its Chorus connection injected into the
+  child only (`CHORUS_URL` / `CHORUS_API_KEY` / `CHORUS_AGENT_PROFILE`; nothing is exported to
+  the parent shell, and the key is never printed). Agent selection: single agent by default; else `--name`, else `CHORUS_AGENT_PROFILE`; ambiguous/none →
+  error. Backend defaults to the agent's stored `agentType`, overridable with `--type`.
+  Everything after `--` is passed to the agent **verbatim** (never inspected). Type → binary:
+  `claude-code`/`claude`→`claude`, `codex`→`codex`, `kiro`→`kiro-cli`, `pi`→`pi`,
+  `opencode`→`opencode`, `openclaw`→`openclaw`, `dsh`→`dsh-jsonrpc-agent`. Agents added as
+  opencode/openclaw/dsh are stored as `offline` → pass `--type` explicitly to launch them.
+
 ## 3. Connection environment variables
 
 - `CHORUS_URL` — the Chorus instance URL.

--- a/packages/chorus-pi/skills/chorus-cli/SKILL.md
+++ b/packages/chorus-pi/skills/chorus-cli/SKILL.md
@@ -35,6 +35,16 @@ Agent configuration lives in `~/.chorus/daemon.json`; `chorus agents` is the CRU
 - `chorus agents remove <name|uuid>` — remove a configured agent from `~/.chorus/daemon.json`
   (matched by UUID or name; an ambiguous name → use the UUID).
 
+- `chorus agents run --name <name|uuid> [--type <type>] [--] [agent args…]` — launch a
+  configured agent's binary in the FOREGROUND with its Chorus connection injected into the
+  child only (`CHORUS_URL` / `CHORUS_API_KEY` / `CHORUS_AGENT_PROFILE`; nothing is exported to
+  the parent shell, and the key is never printed). Agent selection: single agent by default; else `--name`, else `CHORUS_AGENT_PROFILE`; ambiguous/none →
+  error. Backend defaults to the agent's stored `agentType`, overridable with `--type`.
+  Everything after `--` is passed to the agent **verbatim** (never inspected). Type → binary:
+  `claude-code`/`claude`→`claude`, `codex`→`codex`, `kiro`→`kiro-cli`, `pi`→`pi`,
+  `opencode`→`opencode`, `openclaw`→`openclaw`, `dsh`→`dsh-jsonrpc-agent`. Agents added as
+  opencode/openclaw/dsh are stored as `offline` → pass `--type` explicitly to launch them.
+
 ## 3. Connection environment variables
 
 - `CHORUS_URL` — the Chorus instance URL.

--- a/packages/openclaw-plugin/skills/chorus-cli/SKILL.md
+++ b/packages/openclaw-plugin/skills/chorus-cli/SKILL.md
@@ -35,6 +35,16 @@ Agent configuration lives in `~/.chorus/daemon.json`; `chorus agents` is the CRU
 - `chorus agents remove <name|uuid>` — remove a configured agent from `~/.chorus/daemon.json`
   (matched by UUID or name; an ambiguous name → use the UUID).
 
+- `chorus agents run --name <name|uuid> [--type <type>] [--] [agent args…]` — launch a
+  configured agent's binary in the FOREGROUND with its Chorus connection injected into the
+  child only (`CHORUS_URL` / `CHORUS_API_KEY` / `CHORUS_AGENT_PROFILE`; nothing is exported to
+  the parent shell, and the key is never printed). Agent selection: single agent by default; else `--name`, else `CHORUS_AGENT_PROFILE`; ambiguous/none →
+  error. Backend defaults to the agent's stored `agentType`, overridable with `--type`.
+  Everything after `--` is passed to the agent **verbatim** (never inspected). Type → binary:
+  `claude-code`/`claude`→`claude`, `codex`→`codex`, `kiro`→`kiro-cli`, `pi`→`pi`,
+  `opencode`→`opencode`, `openclaw`→`openclaw`, `dsh`→`dsh-jsonrpc-agent`. Agents added as
+  opencode/openclaw/dsh are stored as `offline` → pass `--type` explicitly to launch them.
+
 ## 3. Connection environment variables
 
 - `CHORUS_URL` — the Chorus instance URL.

--- a/plugins/chorus/skills/chorus-cli/SKILL.md
+++ b/plugins/chorus/skills/chorus-cli/SKILL.md
@@ -35,6 +35,16 @@ Agent configuration lives in `~/.chorus/daemon.json`; `chorus agents` is the CRU
 - `chorus agents remove <name|uuid>` — remove a configured agent from `~/.chorus/daemon.json`
   (matched by UUID or name; an ambiguous name → use the UUID).
 
+- `chorus agents run --name <name|uuid> [--type <type>] [--] [agent args…]` — launch a
+  configured agent's binary in the FOREGROUND with its Chorus connection injected into the
+  child only (`CHORUS_URL` / `CHORUS_API_KEY` / `CHORUS_AGENT_PROFILE`; nothing is exported to
+  the parent shell, and the key is never printed). Agent selection: single agent by default; else `--name`, else `CHORUS_AGENT_PROFILE`; ambiguous/none →
+  error. Backend defaults to the agent's stored `agentType`, overridable with `--type`.
+  Everything after `--` is passed to the agent **verbatim** (never inspected). Type → binary:
+  `claude-code`/`claude`→`claude`, `codex`→`codex`, `kiro`→`kiro-cli`, `pi`→`pi`,
+  `opencode`→`opencode`, `openclaw`→`openclaw`, `dsh`→`dsh-jsonrpc-agent`. Agents added as
+  opencode/openclaw/dsh are stored as `offline` → pass `--type` explicitly to launch them.
+
 ## 3. Connection environment variables
 
 - `CHORUS_URL` — the Chorus instance URL.

--- a/public/chorus-plugin/skills/chorus-cli/SKILL.md
+++ b/public/chorus-plugin/skills/chorus-cli/SKILL.md
@@ -35,6 +35,16 @@ Agent configuration lives in `~/.chorus/daemon.json`; `chorus agents` is the CRU
 - `chorus agents remove <name|uuid>` — remove a configured agent from `~/.chorus/daemon.json`
   (matched by UUID or name; an ambiguous name → use the UUID).
 
+- `chorus agents run --name <name|uuid> [--type <type>] [--] [agent args…]` — launch a
+  configured agent's binary in the FOREGROUND with its Chorus connection injected into the
+  child only (`CHORUS_URL` / `CHORUS_API_KEY` / `CHORUS_AGENT_PROFILE`; nothing is exported to
+  the parent shell, and the key is never printed). Agent selection: single agent by default; else `--name`, else `CHORUS_AGENT_PROFILE`; ambiguous/none →
+  error. Backend defaults to the agent's stored `agentType`, overridable with `--type`.
+  Everything after `--` is passed to the agent **verbatim** (never inspected). Type → binary:
+  `claude-code`/`claude`→`claude`, `codex`→`codex`, `kiro`→`kiro-cli`, `pi`→`pi`,
+  `opencode`→`opencode`, `openclaw`→`openclaw`, `dsh`→`dsh-jsonrpc-agent`. Agents added as
+  opencode/openclaw/dsh are stored as `offline` → pass `--type` explicitly to launch them.
+
 ## 3. Connection environment variables
 
 - `CHORUS_URL` — the Chorus instance URL.

--- a/public/kiro-plugin/.kiro/skills/chorus-cli/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-cli/SKILL.md
@@ -35,6 +35,16 @@ Agent configuration lives in `~/.chorus/daemon.json`; `chorus agents` is the CRU
 - `chorus agents remove <name|uuid>` — remove a configured agent from `~/.chorus/daemon.json`
   (matched by UUID or name; an ambiguous name → use the UUID).
 
+- `chorus agents run --name <name|uuid> [--type <type>] [--] [agent args…]` — launch a
+  configured agent's binary in the FOREGROUND with its Chorus connection injected into the
+  child only (`CHORUS_URL` / `CHORUS_API_KEY` / `CHORUS_AGENT_PROFILE`; nothing is exported to
+  the parent shell, and the key is never printed). Agent selection: single agent by default; else `--name`, else `CHORUS_AGENT_PROFILE`; ambiguous/none →
+  error. Backend defaults to the agent's stored `agentType`, overridable with `--type`.
+  Everything after `--` is passed to the agent **verbatim** (never inspected). Type → binary:
+  `claude-code`/`claude`→`claude`, `codex`→`codex`, `kiro`→`kiro-cli`, `pi`→`pi`,
+  `opencode`→`opencode`, `openclaw`→`openclaw`, `dsh`→`dsh-jsonrpc-agent`. Agents added as
+  opencode/openclaw/dsh are stored as `offline` → pass `--type` explicitly to launch them.
+
 ## 3. Connection environment variables
 
 - `CHORUS_URL` — the Chorus instance URL.


### PR DESCRIPTION
## Summary
Adds `chorus agents run --name <name|uuid> [--type <type>] -- <agent args…>` — the foreground counterpart to the daemon's headless wake. It launches a configured coding-agent binary with that agent's Chorus connection injected into the child process only, and passes everything after `--` through verbatim.

- **Selection** reuses the `resolveMcpCredentials` semantics (single default / `--name` / `CHORUS_AGENT_PROFILE`; ambiguous/none → error, no spawn).
- **Type → binary**: `--type` overrides the stored `agentType`; maps claude-code/claude→`claude`, codex→`codex`, kiro→`kiro-cli`, pi→`pi`, opencode→`opencode`, openclaw→`openclaw`, dsh→`dsh-jsonrpc-agent`. Agents stored as `offline` (opencode/openclaw/dsh) require an explicit `--type`.
- **Env**: injects `CHORUS_URL` / `CHORUS_API_KEY` / `CHORUS_AGENT_PROFILE` into the child only (never the parent shell); `CHORUS_DAEMON_HEADLESS` is cleared. The `cho_` key is never printed.
- **Lifecycle**: `stdio: "inherit"` (real TTY), `shell:false`, Windows `.cmd` via `cmd.exe`; forwards the child exit code, mapping signal death to `128+signum`.

Built via the AI-DLC pipeline (idea → elaboration → OpenSpec proposal → 2 tasks → task/code review). env-export/`eval` output intentionally deferred.

## Changed files
| File | Change |
|------|--------|
| `cli/agent-launcher.mjs` | New launcher (arg parse, type→binary, PATH resolve, env, spawn) |
| `cli/credentials.mjs` | `resolveLaunchAgent` (selection incl. `agentType`) |
| `cli/agents.mjs` | `run` dispatch branch + `run --help` + group help line |
| `cli/__tests__/agent-launcher.test.mjs` | 37 unit tests |
| `docs/DAEMON.md` | "Launch an agent interactively" section |
| `*/skills/chorus-cli/SKILL.md` (×6) | `run` command contract |
| `openspec/changes/archive/2026-09-04-add-cli-agent-launch/`, `openspec/specs/cli-agent-launch/` | Spec (archived) |

## Test plan
- [x] `pnpm exec vitest run cli/__tests__/agent-launcher.test.mjs cli/__tests__/agents.test.mjs` → 62 pass
- [x] `npx tsc --noEmit` clean; `eslint` clean on changed files
- [x] End-to-end: real CLI launched a stub binary — env injected, args passed verbatim, exit code forwarded, key absent from output
- [ ] Note: `develop` has pre-existing unrelated daemon/spawner test failures (verified identical on clean base)

Generated with [Claude Code](https://claude.com/claude-code)