### PR TITLE
fix(release): tolerate npm provenance propagation delays

### DIFF
--- a/scripts/coordinated-npm-release/__tests__/coordinated-npm-release.test.mjs
+++ b/scripts/coordinated-npm-release/__tests__/coordinated-npm-release.test.mjs
@@ -264,6 +264,10 @@ if (args.join(" ") === "config get registry") {
 } else if (args[0] === "view" && args[2] === "dist.attestations") {
   if (scenario === "first-published-provenance-missing" && index === 0) {
     console.log(JSON.stringify({}));
+  } else if (scenario === "first-published-provenance-not-visible" && index === 0) {
+    console.error("npm error code E404");
+    console.error("npm error 404 No match found for version - " + spec);
+    process.exitCode = 1;
   } else if (scenario === "first-published-provenance-error" && index === 0) {
     console.error("E503 attestation metadata unavailable");
     process.exitCode = 1;
@@ -514,6 +518,23 @@ test("missing provenance on an already-published version fails the rerun", async
   assert.match(summary, /chorus-openclaw-plugin` \| not-attempted/);
 });
 
+test("a not-yet-visible npm version retries provenance until the budget is exhausted", async (t) => {
+  const root = await prepareFixture(t);
+  const { result, calls, summary } = await runPublish(
+    root,
+    "first-published-provenance-not-visible",
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /E404/);
+  assert.equal(calls.filter(({ args }) => args[0] === "publish").length, 0);
+  assert.equal(
+    calls.filter(({ args }) => args[2] === "dist.attestations").length,
+    5,
+  );
+  assert.match(summary, /@chorus-aidlc\/chorus` \| failed/);
+  assert.match(summary, /chorus-openclaw-plugin` \| not-attempted/);
+});
+
 test("provenance query failure on an already-published version fails the rerun", async (t) => {
   const root = await prepareFixture(t);
   const { result, calls, summary } = await runPublish(
@@ -525,10 +546,22 @@ test("provenance query failure on an already-published version fails the rerun",
   assert.equal(calls.filter(({ args }) => args[0] === "publish").length, 0);
   assert.equal(
     calls.filter(({ args }) => args[2] === "dist.attestations").length,
-    5,
+    1,
   );
   assert.match(summary, /@chorus-aidlc\/chorus` \| failed/);
   assert.match(summary, /chorus-openclaw-plugin` \| not-attempted/);
+});
+
+test("default provenance retry window tolerates slow npm registry propagation", async () => {
+  const source = await readFile(resolve(sourceDirectory, "publish.mjs"), "utf8");
+  assert.match(
+    source,
+    /CHORUS_RELEASE_PROVENANCE_RETRY_DELAY_MS\s*\?\?\s*"3000"/,
+  );
+  assert.match(
+    source,
+    /CHORUS_RELEASE_PROVENANCE_RETRY_ATTEMPTS\s*\?\?\s*"60"/,
+  );
 });
 
 test("registry lookup errors stop later uploads and mark failed/not-attempted", async (t) => {

--- a/scripts/coordinated-npm-release/__tests__/coordinated-npm-release.test.mjs
+++ b/scripts/coordinated-npm-release/__tests__/coordinated-npm-release.test.mjs
@@ -263,7 +263,7 @@ if (args.join(" ") === "config get registry") {
   }
 } else if (args[0] === "view" && args[2] === "dist.attestations") {
   if (scenario === "first-published-provenance-missing" && index === 0) {
-    console.log(JSON.stringify({}));
+    // npm prints an empty successful response when this property is not yet present.
   } else if (scenario === "first-published-provenance-not-visible" && index === 0) {
     console.error("npm error code E404");
     console.error("npm error 404 No match found for version - " + spec);

--- a/scripts/coordinated-npm-release/publish.mjs
+++ b/scripts/coordinated-npm-release/publish.mjs
@@ -135,20 +135,25 @@ async function verifyProvenance(packageName, cwd) {
       { cwd, capture: true },
     );
     if (lookup.status === 0) {
-      try {
-        const attestations = JSON.parse(lookup.stdout);
-        if (
-          typeof attestations?.url === "string" &&
-          attestations.provenance?.predicateType === "https://slsa.dev/provenance/v1"
-        ) {
-          console.log(`${spec} provenance attestation verified`);
-          return;
-        }
+      const response = lookup.stdout.trim();
+      if (response === "") {
         lastDetail = "registry metadata does not contain an SLSA provenance attestation";
-      } catch {
-        throw new Error(
-          `Unable to verify automatic provenance for ${spec}: registry returned invalid attestation JSON`,
-        );
+      } else {
+        try {
+          const attestations = JSON.parse(response);
+          if (
+            typeof attestations?.url === "string" &&
+            attestations.provenance?.predicateType === "https://slsa.dev/provenance/v1"
+          ) {
+            console.log(`${spec} provenance attestation verified`);
+            return;
+          }
+          lastDetail = "registry metadata does not contain an SLSA provenance attestation";
+        } catch {
+          throw new Error(
+            `Unable to verify automatic provenance for ${spec}: registry returned invalid attestation JSON`,
+          );
+        }
       }
     } else {
       lastDetail = [lookup.stdout, lookup.stderr].filter(Boolean).join("\n").trim();

--- a/scripts/coordinated-npm-release/publish.mjs
+++ b/scripts/coordinated-npm-release/publish.mjs
@@ -21,9 +21,9 @@ const provenanceRetryDelayMs = Number(
   process.env.CHORUS_RELEASE_PROVENANCE_RETRY_DELAY_MS ?? "3000",
 );
 // Fresh publishes need time for the registry/CDN to expose the attestation.
-// Default budget ~= (attempts - 1) * delay ≈ 57s; both are env-overridable.
+// Default budget ~= (attempts - 1) * delay ≈ 177s; both are env-overridable.
 const provenanceRetryAttempts = Number(
-  process.env.CHORUS_RELEASE_PROVENANCE_RETRY_ATTEMPTS ?? "20",
+  process.env.CHORUS_RELEASE_PROVENANCE_RETRY_ATTEMPTS ?? "60",
 );
 const npmPublicRegistry = "https://registry.npmjs.org/";
 const manifest = await loadManifest();
@@ -146,10 +146,17 @@ async function verifyProvenance(packageName, cwd) {
         }
         lastDetail = "registry metadata does not contain an SLSA provenance attestation";
       } catch {
-        lastDetail = "registry returned invalid attestation JSON";
+        throw new Error(
+          `Unable to verify automatic provenance for ${spec}: registry returned invalid attestation JSON`,
+        );
       }
     } else {
       lastDetail = [lookup.stdout, lookup.stderr].filter(Boolean).join("\n").trim();
+      const versionNotVisibleYet =
+        /\bE404\b/.test(lastDetail) && lastDetail.includes(spec);
+      if (!versionNotVisibleYet) {
+        throw new Error(`Unable to query automatic provenance for ${spec}: ${lastDetail}`);
+      }
     }
     if (attempt < provenanceRetryAttempts) {
       await new Promise((resolve) => setTimeout(resolve, provenanceRetryDelayMs));


### PR DESCRIPTION
## Summary
- extend the default npm provenance verification window from ~57 seconds to ~177 seconds
- retry only registry propagation states (E404 or missing attestation metadata)
- fail immediately for authorization, service, and malformed-response errors
- add release-contract coverage for delayed visibility and fail-fast behavior

## Test plan
- [x] `npm run test:release-contract` (19 tests passed)