### PR TITLE
feat(chorus-pi): support async/detached subagent runs + nicobailon coexistence

### DIFF
--- a/packages/chorus-pi/README.md
+++ b/packages/chorus-pi/README.md
@@ -101,14 +101,74 @@ spawn → run → exit within one tool call, so the extension closes the Chorus
 session at `tool_result`. If you instead use the nicobailon `pi-subagents`
 package's `subagent` tool, top-level launches are **async (detached)** by
 default: `tool_result` returns immediately with `details.asyncId` and the run
-completes later. The extension detects this case (`asyncId`/`runId` in details
-or JSON content) and defers session close to `subagent:async-complete` /
+completes later. The extension detects this case (`asyncId`/`runId` in
+`details`) and defers session close to `subagent:async-complete` /
 `subagent:process-terminal` (with `session_shutdown` sweep as a final guard).
 Tasks that already carry an injected `--- Chorus session` block (e.g. a
 main-agent wave template) are never re-injected.
 
-Note: the bundled subagent and nicobailon `pi-subagents` both register a tool
-named `subagent` — install only one of the two to avoid a tool-name clash.
+### Coexistence with nicobailon `pi-subagents`: load-order rule
+
+The bundled subagent (pi's official reference pattern, at `extensions/subagent/`)
+registers a tool named `subagent`. The nicobailon `pi-subagents` package registers
+a tool with the **same name**. pi's extension loader rejects a duplicate tool
+registration with a conflict error (verified on pi 0.84.4:
+`Tool "subagent" conflicts with ...`), so the two cannot both register.
+
+**Recommended setup (keep nicobailon, zero conflicts)**: exclude the bundled
+subagent extension via a package filter in `settings.packages` — pi's package
+entries accept an object form with per-resource glob patterns:
+
+```json
+"packages": [
+  "npm:pi-subagents",
+  {
+    "source": "git:github.com/Chorus-AIDLC/chorus/packages/chorus-pi",
+    "extensions": ["!extensions/subagent/**"]
+  }
+]
+```
+
+This keeps `chorus.ts` (session hooks) and the `agents/*.md` files (discovered
+via `pi.subagents.agents`) while the bundled `subagent` tool never registers —
+no conflict error, nicobailon wins deterministically.
+
+| Setup | What happens |
+|-------|--------------|
+| Only `@chorus-aidlc/chorus-pi` (no external subagents) | Bundled subagent registers and handles dispatch (single/parallel/chain, blocking) |
+| Both installed, with the filter above | nicobailon's `subagent` tool is the only one. Chorus session hooks keep working (they match on the tool name) |
+| Both installed, no filter: `npm:pi-subagents` listed **before** chorus-pi | nicobailon wins; the bundled subagent reports a conflict error at load (harmless inside an interactive session, noisy for CLI commands like `pi packages list`) |
+| Both installed, no filter: `npm:pi-subagents` listed **after** chorus-pi | Bundled subagent wins (it loaded first); nicobailon's tool is rejected. Flip the order to switch |
+
+**How to verify which implementation is active**: run
+`subagent({ action: "list" })`. nicobailon output shows `Package agents /
+Builtin agents / User agents` sections; the bundled subagent's output has no
+such sections.
+### Tips when combining with nicobailon `pi-subagents`
+
+- **Sessions work with either tool.** Chorus hooks match on the tool name,
+  so `checkin → in_progress → report → checkout → submit_for_verify` flows are
+  identical; only close timing differs (blocking closes at `tool_result`, async
+  closes on `subagent:async-complete`/`process-terminal`).
+- **`workflowScript` / `runs.run` / `runs.all`**: nicobailon-only. The bundled
+  subagent has no `workflowScript` mode — use `parallel`/`chain` via its own
+  schema, or keep nicobailon for scripted waves.
+- **Model selection per reviewer**: nicobailon honors `subagent({..., model})`
+  per call, `subagents.agentOverrides.<name>.model` in settings, and agent
+  frontmatter `model:`. The bundled subagent honors only agent frontmatter
+  `model:` (it reads `name`/`description`/`tools`/`model`; its schema has no
+  per-call model parameter) — set it in `~/.pi/agent/agents/chorus-*-reviewer.md`.
+- **Agent files**: bundled subagent reads package `agents/*.md` + `~/.pi/agent/agents/*.md`
+  (user overrides package). nicobailon reads builtin/package/user/project with
+  richer frontmatter (`excludeTools`, `thinking`, `inheritSkills`, `extensions`,
+  per-agent `tools` allowlists, `model`, ...).
+- **Tool-name clash**: both register a `subagent` tool and pi rejects a duplicate
+  registration with a conflict error. To keep nicobailon (needed for its
+  async/`workflowScript` features), use the package filter above (exclude
+  `extensions/subagent/**`); if you instead rely on ordering, list
+  `npm:pi-subagents` **before** chorus-pi. Either way, verify with
+  `subagent({ action: "list" })` (nicobailon shows `Package/Builtin/User agents`
+  sections; bundled does not).
 ## License
 
 AGPL-3.0

--- a/packages/chorus-pi/README.md
+++ b/packages/chorus-pi/README.md
@@ -93,6 +93,22 @@ packages/chorus-pi/
 
 The extension goes beyond the Codex port in one key way: by using Pi's `tool_call` event (pre-execution, mutable input), it **auto-injects the Chorus session UUID + workflow into each dispatched worker's task** — the Pi-native equivalent of Claude's `SubagentStart` hook. The Codex port has no pre-spawn mutation channel, so its workers must manage sessions manually. On Pi, dispatch a worker via the `subagent` tool and the extension handles session creation + context injection, then closes the session when the (ephemeral) tool call returns.
 
+
+### Subagent run modes: blocking (bundled) vs async (nicobailon `pi-subagents`)
+
+The bundled `subagent` tool (pi's official reference pattern) is **blocking**:
+spawn → run → exit within one tool call, so the extension closes the Chorus
+session at `tool_result`. If you instead use the nicobailon `pi-subagents`
+package's `subagent` tool, top-level launches are **async (detached)** by
+default: `tool_result` returns immediately with `details.asyncId` and the run
+completes later. The extension detects this case (`asyncId`/`runId` in details
+or JSON content) and defers session close to `subagent:async-complete` /
+`subagent:process-terminal` (with `session_shutdown` sweep as a final guard).
+Tasks that already carry an injected `--- Chorus session` block (e.g. a
+main-agent wave template) are never re-injected.
+
+Note: the bundled subagent and nicobailon `pi-subagents` both register a tool
+named `subagent` — install only one of the two to avoid a tool-name clash.
 ## License
 
 AGPL-3.0

--- a/packages/chorus-pi/README.md
+++ b/packages/chorus-pi/README.md
@@ -139,11 +139,11 @@ no conflict error, nicobailon wins deterministically.
 | Both installed, with the filter above | nicobailon's `subagent` tool is the only one. Chorus session hooks keep working (they match on the tool name) |
 | Both installed, no filter: `npm:pi-subagents` listed **before** chorus-pi | nicobailon wins; the bundled subagent reports a conflict error at load (harmless inside an interactive session, noisy for CLI commands like `pi packages list`) |
 | Both installed, no filter: `npm:pi-subagents` listed **after** chorus-pi | Bundled subagent wins (it loaded first); nicobailon's tool is rejected. Flip the order to switch |
-
 **How to verify which implementation is active**: run
 `subagent({ action: "list" })`. nicobailon output shows `Package agents /
 Builtin agents / User agents` sections; the bundled subagent's output has no
 such sections.
+
 ### Tips when combining with nicobailon `pi-subagents`
 
 - **Sessions work with either tool.** Chorus hooks match on the tool name,

--- a/packages/chorus-pi/README.md
+++ b/packages/chorus-pi/README.md
@@ -151,7 +151,7 @@ such sections.
   identical; only close timing differs (blocking closes at `tool_result`, async
   closes on `subagent:async-complete`/`process-terminal`).
 - **Why the packaged agents do not set `async: false`.** Under nicobailon
-  0.64 a foreground (`async: false`) child runs inside the parent process
+  0.65 a foreground (`async: false`) child runs inside the parent process
   and never loads the parent's ambient extensions — tools registered by an
   ambient adapter such as `pi-mcp-adapter` (`mcp`, `mcpScript`) are
   unavailable, and nicobailon's child-tool diagnostic treats an allowlist

--- a/packages/chorus-pi/README.md
+++ b/packages/chorus-pi/README.md
@@ -150,6 +150,17 @@ such sections.
   so `checkin → in_progress → report → checkout → submit_for_verify` flows are
   identical; only close timing differs (blocking closes at `tool_result`, async
   closes on `subagent:async-complete`/`process-terminal`).
+- **Why the packaged agents do not set `async: false`.** Under nicobailon
+  0.64 a foreground (`async: false`) child runs inside the parent process
+  and never loads the parent's ambient extensions — tools registered by an
+  ambient adapter such as `pi-mcp-adapter` (`mcp`, `mcpScript`) are
+  unavailable, and nicobailon's child-tool diagnostic treats an allowlist
+  that declares them as a failed run (exit 1) even if the agent never
+  called them. The Chorus reviewers/worker need `mcp` to post verdicts and
+  check in, so they run as background children (nicobailon default). Wait
+  for completion with `bg_wait`/the run notification; the bundled subagent
+  is unaffected because its child is a separate `pi --mode json` process
+  that loads extensions.
 - **`workflowScript` / `runs.run` / `runs.all`**: nicobailon-only. The bundled
   subagent has no `workflowScript` mode — use `parallel`/`chain` via its own
   schema, or keep nicobailon for scripted waves.

--- a/packages/chorus-pi/agents/chorus-code-reviewer.md
+++ b/packages/chorus-pi/agents/chorus-code-reviewer.md
@@ -2,7 +2,6 @@
 name: chorus-code-reviewer
 description: Final ship-time review of an Idea's aggregate code change — the whole feature across all its tasks, not one task. Read-only; posts a VERDICT comment on the Idea. Spawn via the blocking subagent tool after the last task of an idea-rooted proposal is verified.
 tools: read, grep, find, ls, bash, mcp, mcpScript
-async: false
 acceptance: { level: "none", reason: "read-only chorus reviewer; verdict is posted via chorus_add_comment to Chorus, not returned to parent; suppress acceptance-report injection" }
 ---
 

--- a/packages/chorus-pi/agents/chorus-code-reviewer.md
+++ b/packages/chorus-pi/agents/chorus-code-reviewer.md
@@ -1,7 +1,9 @@
 ---
 name: chorus-code-reviewer
 description: Final ship-time review of an Idea's aggregate code change — the whole feature across all its tasks, not one task. Read-only; posts a VERDICT comment on the Idea. Spawn via the blocking subagent tool after the last task of an idea-rooted proposal is verified.
-tools: read, grep, find, ls, bash, mcp
+tools: read, grep, find, ls, bash, mcp, mcpScript
+async: false
+acceptance: { level: "none", reason: "read-only chorus reviewer; verdict is posted via chorus_add_comment to Chorus, not returned to parent; suppress acceptance-report injection" }
 ---
 
 CRITICAL: READ-ONLY code review of an ENTIRE Idea's aggregate change. You CANNOT edit, write, or create files in the project directory.

--- a/packages/chorus-pi/agents/chorus-proposal-reviewer.md
+++ b/packages/chorus-pi/agents/chorus-proposal-reviewer.md
@@ -2,7 +2,6 @@
 name: chorus-proposal-reviewer
 description: Review submitted Chorus proposals for quality — check document completeness, task granularity, AC alignment, and cross-task dependencies. Spawn via the blocking subagent tool after chorus_pm_submit_proposal.
 tools: read, grep, find, ls, bash, mcp, mcpScript
-async: false
 acceptance: { level: "none", reason: "read-only chorus reviewer; verdict is posted via chorus_add_comment to Chorus, not returned to parent; suppress acceptance-report injection" }
 ---
 

--- a/packages/chorus-pi/agents/chorus-proposal-reviewer.md
+++ b/packages/chorus-pi/agents/chorus-proposal-reviewer.md
@@ -1,7 +1,9 @@
 ---
 name: chorus-proposal-reviewer
 description: Review submitted Chorus proposals for quality — check document completeness, task granularity, AC alignment, and cross-task dependencies. Spawn via the blocking subagent tool after chorus_pm_submit_proposal.
-tools: read, grep, find, ls, bash, mcp
+tools: read, grep, find, ls, bash, mcp, mcpScript
+async: false
+acceptance: { level: "none", reason: "read-only chorus reviewer; verdict is posted via chorus_add_comment to Chorus, not returned to parent; suppress acceptance-report injection" }
 ---
 
 CRITICAL: READ-ONLY proposal review. You CANNOT edit, write, create files, or run Bash commands beyond read-only inspection.

--- a/packages/chorus-pi/agents/chorus-task-reviewer.md
+++ b/packages/chorus-pi/agents/chorus-task-reviewer.md
@@ -1,7 +1,9 @@
 ---
 name: chorus-task-reviewer
 description: Review submitted Chorus tasks — verify implementation against AC and proposal documents. Spawn via the blocking subagent tool after chorus_submit_for_verify.
-tools: read, grep, find, ls, bash, mcp
+tools: read, grep, find, ls, bash, mcp, mcpScript
+async: false
+acceptance: { level: "none", reason: "read-only chorus reviewer; verdict is posted via chorus_add_comment to Chorus, not returned to parent; suppress acceptance-report injection" }
 ---
 
 CRITICAL: READ-ONLY task review. You CANNOT edit, write, or create files in the project directory.

--- a/packages/chorus-pi/agents/chorus-task-reviewer.md
+++ b/packages/chorus-pi/agents/chorus-task-reviewer.md
@@ -2,7 +2,6 @@
 name: chorus-task-reviewer
 description: Review submitted Chorus tasks — verify implementation against AC and proposal documents. Spawn via the blocking subagent tool after chorus_submit_for_verify.
 tools: read, grep, find, ls, bash, mcp, mcpScript
-async: false
 acceptance: { level: "none", reason: "read-only chorus reviewer; verdict is posted via chorus_add_comment to Chorus, not returned to parent; suppress acceptance-report injection" }
 ---
 

--- a/packages/chorus-pi/agents/chorus-worker.md
+++ b/packages/chorus-pi/agents/chorus-worker.md
@@ -1,7 +1,6 @@
 ---
 name: chorus-worker
 description: General-purpose Chorus implementer subagent that claims and completes ONE Chorus task end-to-end via the develop workflow. Dispatch it via the blocking subagent tool (single or parallel mode) for wave-based execution.
-async: false
 ---
 
 You are a Chorus implementer. Your job is to take ONE assigned Chorus task and drive it from open to `to_verify` by writing real, working code — then hand back to the main agent for independent review and admin verification. You do NOT review, verify, or approve your own work.

--- a/packages/chorus-pi/agents/chorus-worker.md
+++ b/packages/chorus-pi/agents/chorus-worker.md
@@ -1,6 +1,7 @@
 ---
 name: chorus-worker
 description: General-purpose Chorus implementer subagent that claims and completes ONE Chorus task end-to-end via the develop workflow. Dispatch it via the blocking subagent tool (single or parallel mode) for wave-based execution.
+async: false
 ---
 
 You are a Chorus implementer. Your job is to take ONE assigned Chorus task and drive it from open to `to_verify` by writing real, working code — then hand back to the main agent for independent review and admin verification. You do NOT review, verify, or approve your own work.

--- a/packages/chorus-pi/extensions/chorus.ts
+++ b/packages/chorus-pi/extensions/chorus.ts
@@ -18,9 +18,13 @@
  *                              lacks (Codex has no pre-spawn mutation channel, so its
  *                              workers must manage sessions manually).
  *   - tool_result            → close the ephemeral worker session(s) once the `subagent`
- *                              tool call returns (the official children are ephemeral:
- *                              spawn → run → exit within one tool call, so there is no
- *                              persistent agentId and no separate close tool).
+ *   - tool_result            → for the official blocking subagent, close the ephemeral
+ *                              worker session(s) once the `subagent` tool call returns
+ *                              (spawn → run → exit within one tool call, so there is no
+ *                              persistent agentId and no separate close tool). For the
+ *                              nicobailon `pi-subagents` tool (async/detached by default,
+ *                              `details.asyncId` on tool_result) the sessions are deferred
+ *                              and closed on subagent:async-complete / process-terminal.
  *                            → reviewer nudges after submit_proposal / submit_for_verify
  *                              / admin_verify_task (the 3 PostToolUse hooks)
  *   - tool_execution_end     → fallback close of the worker session(s) if tool_result
@@ -40,6 +44,8 @@ import {
   isWorkerAgent,
   subagentTaskItems,
   sessionWorkflow,
+  hasSessionMarker,
+  extractRunIdFromToolResultEvent,
   detectOpenSpec,
   buildSessionBanner,
   parseMaxCodeReviewRounds,
@@ -196,6 +202,10 @@ async function mcpCall<T = unknown>(tool: string, args: Record<string, unknown> 
 //
 // toolCallId → the Chorus session UUIDs created for that `subagent` invocation.
 const callSessions = new Map<string, string[]>();
+// runId (nicobailon async/detached `subagent` runs) → sessionUuid(s); closed on
+// subagent:async-complete / subagent:process-terminal (blocking runs close at
+// tool_result via callSessions and never enter this map).
+const runIdToSid = new Map<string, string[]>();
 let checkinContext: string | null = null;
 let injectedOnce = false;
 
@@ -360,6 +370,8 @@ export default function (pi: ExtensionAPI) {
     const created: string[] = [];
     for (const item of subagentTaskItems(event.input)) {
       if (!isWorkerAgent(item.agent)) continue;
+      // Manual main-agent template already injected — never double-inject.
+      if (hasSessionMarker(item.task)) continue;
       try {
         const session = await mcpCall<{ uuid?: string }>("chorus_create_session", { name: item.agent });
         if (!session?.uuid) continue;
@@ -382,10 +394,24 @@ export default function (pi: ExtensionAPI) {
     if (!CONFIGURED) return;
 
     // ── subagent tool finished → close the worker session(s) ───────────
-    // Close on success OR error: the sessions were created at tool_call start,
-    // so they must be closed either way. closeCallSessions is idempotent and
-    // retains any session whose close fails for a shutdown retry.
+    // The official blocking subagent closes sessions at tool_result; the
+    // nicobailon `pi-subagents` tool is async (detached) by default, so its
+    // tool_result carries `details.asyncId` and the run completes later via
+    // the pi event bus — in that case move the sessions to runIdToSid and
+    // let subagent:async-complete / subagent:process-terminal close them.
     if (event.toolName === "subagent") {
+      const runId = extractRunIdFromToolResultEvent(event);
+      if (runId) {
+        const sids = callSessions.get(event.toolCallId);
+        if (sids && sids.length > 0) {
+          runIdToSid.set(runId, [...(runIdToSid.get(runId) ?? []), ...sids]);
+          callSessions.delete(event.toolCallId);
+          ctx.ui.notify(`Chorus session(s): ${sids.map((s) => s.slice(0, 8)).join(",")}… deferred to async run ${runId.slice(0, 8)}…`, "info");
+        }
+        return;
+      }
+      // Blocking run (or no run id) — close now. closeCallSessions is
+      // idempotent and retains any session whose close fails for a shutdown retry.
       await closeCallSessions(event.toolCallId, ctx);
       return;
     }
@@ -431,8 +457,42 @@ export default function (pi: ExtensionAPI) {
   pi.on("tool_execution_end", async (event, ctx) => {
     if (!CONFIGURED) return;
     if (event.toolName === "subagent") {
+      // tool_result already moved async sessions to runIdToSid — nothing left
+      // in callSessions for them. Blocking runs (or failed injection) close here.
       await closeCallSessions(event.toolCallId, ctx);
     }
+  });
+
+  // ── nicobailon async/detached `subagent` runs: close by runId ──────
+  // tool_result deferred these sessions to runIdToSid; completion arrives on
+  // the pi event bus. Delete the mapping BEFORE issuing the close so a
+  // duplicate lifecycle event cannot double-close; re-add on failure so the
+  // shutdown sweep can still retry it.
+  const closeRunSessions = (runId: string): void => {
+    const sids = runIdToSid.get(runId);
+    if (!sids || sids.length === 0) return;
+    runIdToSid.delete(runId);
+    void (async () => {
+      const failed: string[] = [];
+      for (const sid of sids) {
+        try { await mcpCall("chorus_close_session", { sessionUuid: sid }); } catch { failed.push(sid); }
+      }
+      if (failed.length > 0) runIdToSid.set(runId, failed);
+    })();
+  };
+  const eventBusRunId = (data: unknown): string | null => {
+    const d = (data ?? {}) as Record<string, unknown>;
+    if (typeof d.runId === "string" && d.runId) return d.runId;
+    if (typeof d.id === "string" && d.id) return d.id;
+    return null;
+  };
+  pi.events.on("subagent:async-complete", (data) => {
+    const runId = eventBusRunId(data);
+    if (runId) closeRunSessions(runId);
+  });
+  pi.events.on("subagent:process-terminal", (data) => {
+    const runId = eventBusRunId(data);
+    if (runId) closeRunSessions(runId);
   });
 
   // SessionEnd → close any stray worker sessions (replaces Claude's on-session-end.sh).
@@ -444,7 +504,13 @@ export default function (pi: ExtensionAPI) {
         await mcpCall("chorus_close_session", { sessionUuid: sid }).catch(() => {});
       }
     }
+    for (const sids of runIdToSid.values()) {
+      for (const sid of sids) {
+        await mcpCall("chorus_close_session", { sessionUuid: sid }).catch(() => {});
+      }
+    }
     callSessions.clear();
+    runIdToSid.clear();
     injectedOnce = false;
     checkinContext = null;
     mcpSessionId = null;

--- a/packages/chorus-pi/extensions/chorus.ts
+++ b/packages/chorus-pi/extensions/chorus.ts
@@ -468,30 +468,40 @@ export default function (pi: ExtensionAPI) {
   // the pi event bus. Delete the mapping BEFORE issuing the close so a
   // duplicate lifecycle event cannot double-close; re-add on failure so the
   // shutdown sweep can still retry it.
+  //
+  // In-flight closes are tracked so session_shutdown can await them before
+  // sweeping: a close that fails after the sweep ran would otherwise re-add
+  // its entry after the map was cleared (retry lost + stale entry).
+  const inflightCloses = new Set<Promise<void>>();
   const closeRunSessions = (runId: string): void => {
     const sids = runIdToSid.get(runId);
     if (!sids || sids.length === 0) return;
     runIdToSid.delete(runId);
-    void (async () => {
+    const p: Promise<void> = (async () => {
       const failed: string[] = [];
       for (const sid of sids) {
         try { await mcpCall("chorus_close_session", { sessionUuid: sid }); } catch { failed.push(sid); }
       }
       if (failed.length > 0) runIdToSid.set(runId, failed);
     })();
+    inflightCloses.add(p);
+    void p.finally(() => inflightCloses.delete(p));
   };
-  const eventBusRunId = (data: unknown): string | null => {
+  // Only `runId` is trusted on async-complete; `id` (runId-or-id shape) is
+  // accepted only on process-terminal, since async-complete could carry an
+  // unrelated id field alongside runId.
+  const eventBusRunId = (data: unknown, allowId: boolean): string | null => {
     const d = (data ?? {}) as Record<string, unknown>;
     if (typeof d.runId === "string" && d.runId) return d.runId;
-    if (typeof d.id === "string" && d.id) return d.id;
+    if (allowId && typeof d.id === "string" && d.id) return d.id;
     return null;
   };
   pi.events.on("subagent:async-complete", (data) => {
-    const runId = eventBusRunId(data);
+    const runId = eventBusRunId(data, false);
     if (runId) closeRunSessions(runId);
   });
   pi.events.on("subagent:process-terminal", (data) => {
-    const runId = eventBusRunId(data);
+    const runId = eventBusRunId(data, true);
     if (runId) closeRunSessions(runId);
   });
 
@@ -499,6 +509,10 @@ export default function (pi: ExtensionAPI) {
   // Retries every session still tracked in callSessions (e.g. a subagent call whose
   // close failed and was retained, or that never saw a tool_result/tool_execution_end).
   pi.on("session_shutdown", async () => {
+    // Wait for in-flight async closes to settle FIRST: a close that fails
+    // re-adds into runIdToSid, and the sweep below must see it (otherwise the
+    // retry is lost and a stale entry survives the clear).
+    await Promise.allSettled([...inflightCloses]);
     for (const sids of callSessions.values()) {
       for (const sid of sids) {
         await mcpCall("chorus_close_session", { sessionUuid: sid }).catch(() => {});

--- a/packages/chorus-pi/extensions/chorus.ts
+++ b/packages/chorus-pi/extensions/chorus.ts
@@ -482,7 +482,10 @@ export default function (pi: ExtensionAPI) {
       for (const sid of sids) {
         try { await mcpCall("chorus_close_session", { sessionUuid: sid }); } catch { failed.push(sid); }
       }
-      if (failed.length > 0) runIdToSid.set(runId, failed);
+      if (failed.length > 0) {
+        runIdToSid.set(runId, failed);
+        console.warn(`[chorus-pi] failed to close ${failed.length} session(s) for run ${runId}: ${failed.join(", ")} — will retry at session_shutdown`);
+      }
     })();
     inflightCloses.add(p);
     void p.finally(() => inflightCloses.delete(p));

--- a/packages/chorus-pi/lib/lib.ts
+++ b/packages/chorus-pi/lib/lib.ts
@@ -188,9 +188,11 @@ export function sessionWorkflow(sessionUuid: string): string {
  * Matches the block header at the start of a line (`--- Chorus session`), so
  * prose that merely mentions "Chorus session" does not suppress injection.
  * Covers both this extension's injected block and any main-agent template.
+ * The header is exactly "--- Chorus session" followed by " (…)" or end of line;
+ * a hyphenated continuation like "--- Chorus session-notes" is not a header.
  */
 export function hasSessionMarker(task: string): boolean {
-  return /^--- Chorus session\b/m.test(task);
+  return /^--- Chorus session(?=[ (\u2014]|$)/m.test(task);
 }
 
 /**
@@ -203,25 +205,17 @@ export function hasSessionMarker(task: string): boolean {
  * launches async (detached) by default: spawn returns immediately with
  * `details.asyncId`, and completion arrives later on the pi event bus as
  * `subagent:async-complete` / `subagent:process-terminal` with `{runId}`/`{id}`.
- * Only `asyncId`/`runId` are trusted as run ids — generic `id`/`prefix` fields
- * of blocking results are not run ids.
+ * Only `details.asyncId`/`details.runId` are trusted — the nicobailon contract
+ * always carries the run id in `details` for async launches, and a blocking
+ * run's worker output (even standalone JSON) must never be misclassified as
+ * an async run (which would leak the session until session_shutdown).
  */
 export function extractRunIdFromToolResultEvent(event: {
   details?: unknown;
-  content?: { text?: string }[];
 }): string | null {
   const d = (event.details ?? {}) as Record<string, unknown>;
   for (const key of ["asyncId", "runId"]) {
     if (typeof d[key] === "string" && (d[key] as string).length > 0) return d[key] as string;
-  }
-  const text = event.content?.map((c) => c?.text ?? "").join(" ") ?? "";
-  try {
-    const parsed = JSON.parse(text) as Record<string, unknown>;
-    for (const key of ["asyncId", "runId"]) {
-      if (typeof parsed[key] === "string" && (parsed[key] as string).length > 0) return parsed[key] as string;
-    }
-  } catch {
-    /* not JSON */
   }
   return null;
 }

--- a/packages/chorus-pi/lib/lib.ts
+++ b/packages/chorus-pi/lib/lib.ts
@@ -183,6 +183,50 @@ export function sessionWorkflow(sessionUuid: string): string {
 }
 
 /**
+ * True when a worker task already carries an injected session block.
+ *
+ * Matches the block header at the start of a line (`--- Chorus session`), so
+ * prose that merely mentions "Chorus session" does not suppress injection.
+ * Covers both this extension's injected block and any main-agent template.
+ */
+export function hasSessionMarker(task: string): boolean {
+  return /^--- Chorus session\b/m.test(task);
+}
+
+/**
+ * Detect an async (detached) nicobailon pi-subagents `subagent` run from its
+ * tool_result EVENT, and extract the run id that its completion events will
+ * carry.
+ *
+ * The official bundled subagent (blocking) returns at tool_result with no run
+ * id — the session lifecycle closes there. The nicobailon `pi-subagents` tool
+ * launches async (detached) by default: spawn returns immediately with
+ * `details.asyncId`, and completion arrives later on the pi event bus as
+ * `subagent:async-complete` / `subagent:process-terminal` with `{runId}`/`{id}`.
+ * Only `asyncId`/`runId` are trusted as run ids — generic `id`/`prefix` fields
+ * of blocking results are not run ids.
+ */
+export function extractRunIdFromToolResultEvent(event: {
+  details?: unknown;
+  content?: { text?: string }[];
+}): string | null {
+  const d = (event.details ?? {}) as Record<string, unknown>;
+  for (const key of ["asyncId", "runId"]) {
+    if (typeof d[key] === "string" && (d[key] as string).length > 0) return d[key] as string;
+  }
+  const text = event.content?.map((c) => c?.text ?? "").join(" ") ?? "";
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    for (const key of ["asyncId", "runId"]) {
+      if (typeof parsed[key] === "string" && (parsed[key] as string).length > 0) return parsed[key] as string;
+    }
+  } catch {
+    /* not JSON */
+  }
+  return null;
+}
+
+/**
  * Resolved OpenSpec mode for a repo. `active` is the effective on/off; `reason`
  * is a human-readable explanation; `optout` marks an explicit opt-out (so the
  * banner does not nag); `hint` is an optional install hint when the directory

--- a/packages/chorus-pi/lib/lib.ts
+++ b/packages/chorus-pi/lib/lib.ts
@@ -206,9 +206,14 @@ export function hasSessionMarker(task: string): boolean {
  * `details.asyncId`, and completion arrives later on the pi event bus as
  * `subagent:async-complete` / `subagent:process-terminal` with `{runId}`/`{id}`.
  * Only `details.asyncId`/`details.runId` are trusted — the nicobailon contract
- * always carries the run id in `details` for async launches, and a blocking
- * run's worker output (even standalone JSON) must never be misclassified as
- * an async run (which would leak the session until session_shutdown).
+ * always carries the run id in `details` for async launches (verified against
+ * pi-subagents src/runs/foreground/subagent-executor.ts: async started returns
+ * `details: { mode, results, asyncId, asyncDir }` (:1584/:1375), and nicobailon
+ * itself reads `result.details.asyncId` (:1711/:1967/:2119); `id`/`prefix`
+ * appear only in completion-event payloads, never in tool_result details), and
+ * a blocking run's worker output (even standalone JSON) must never be
+ * misclassified as an async run (which would leak the session until
+ * session_shutdown).
  */
 export function extractRunIdFromToolResultEvent(event: {
   details?: unknown;

--- a/packages/chorus-pi/package.json
+++ b/packages/chorus-pi/package.json
@@ -52,7 +52,10 @@
   },
   "pi": {
     "extensions": ["./extensions"],
-    "skills": ["./skills"]
+    "skills": ["./skills"],
+    "subagents": {
+      "agents": ["./agents"]
+    }
   },
   "//note": "Reviewer subagents use pi's official subagent pattern, bundled at extensions/subagent/ (index.ts + agents.ts, copied from earendil-works/pi's examples). The copied agents.ts discovers this package's own agents/*.md via a package-relative BUNDLED_DIR, so the 3 reviewer agents load with ZERO manual copy into ~/.pi/agent/agents/. pi auto-loads extensions/subagent/index.ts as a subdirectory-with-index extension (no manifest entry needed)."
 }

--- a/packages/chorus-pi/test/all.sh
+++ b/packages/chorus-pi/test/all.sh
@@ -21,6 +21,8 @@ echo "──────── Layer B: extension events ───────�
 bun test test/ext-events.test.ts 2>&1 | tail -8
 be=$?
 echo ""
+
+echo ""
 echo "══════════════════════════════════════════"
 if [ $a -eq 0 ] && [ $b -eq 0 ] && [ $be -eq 0 ]; then
   echo "  ALL OFFLINE TESTS PASSED (A: static, B: unit + extension events)"

--- a/packages/chorus-pi/test/all.sh
+++ b/packages/chorus-pi/test/all.sh
@@ -21,7 +21,6 @@ echo "──────── Layer B: extension events ───────�
 bun test test/ext-events.test.ts 2>&1 | tail -8
 be=$?
 echo ""
-
 echo ""
 echo "══════════════════════════════════════════"
 if [ $a -eq 0 ] && [ $b -eq 0 ] && [ $be -eq 0 ]; then

--- a/packages/chorus-pi/test/ext-events.test.ts
+++ b/packages/chorus-pi/test/ext-events.test.ts
@@ -85,9 +85,16 @@ installDefaultFetch();
 const handlers: Record<string, (event: any, ctx: any) => Promise<unknown>> = {};
 const notifyMessages: { msg: string; level: string }[] = [];
 const userMessages: string[] = [];
+const eventBus: Record<string, (data: unknown) => void> = {};
 const pi: any = {
   on: (ev: string, fn: (event: any, ctx: any) => Promise<unknown>) => {
     handlers[ev] = fn;
+  },
+  events: {
+    on: (name: string, fn: (data: unknown) => void) => {
+      eventBus[name] = fn;
+    },
+    emit: () => {},
   },
   sendUserMessage: (msg: string) => {
     userMessages.push(msg);
@@ -320,4 +327,57 @@ test("no nudge for a non-trigger chorus tool", async () => {
     ctx,
   );
   expect(userMessages.length).toBe(0);
+});
+
+// ─── async (nicobailon pi-subagents) lifecycle ────────────────────
+
+test("async subagent: session deferred on tool_result and closed on async-complete", async () => {
+  await resetState();
+  const input: any = { agent: "worker", task: "do async work" };
+  await handlers["tool_call"]({ toolName: "subagent", toolCallId: "tc-a1", input }, ctx);
+  // tool_result carries details.asyncId → session NOT closed, moved to runIdToSid.
+  await handlers["tool_result"](
+    { toolName: "subagent", toolCallId: "tc-a1", isError: false, input, details: { asyncId: "RUN-A" }, content: [] },
+    ctx,
+  );
+  expect(toolCalls).not.toContain("chorus_close_session");
+  // async-complete closes it.
+  eventBus["subagent:async-complete"]!({ runId: "RUN-A" });
+  await new Promise((r) => setTimeout(r, 20));
+  expect(toolCalls.filter((t) => t === "chorus_close_session").length).toBe(1);
+});
+
+test("async subagent: process-terminal also closes the deferred session", async () => {
+  await resetState();
+  const input: any = { agent: "worker", task: "do async work" };
+  await handlers["tool_call"]({ toolName: "subagent", toolCallId: "tc-a2", input }, ctx);
+  await handlers["tool_result"](
+    { toolName: "subagent", toolCallId: "tc-a2", isError: false, input, details: { asyncId: "RUN-B" }, content: [] },
+    ctx,
+  );
+  eventBus["subagent:process-terminal"]!({ runId: "RUN-B" });
+  await new Promise((r) => setTimeout(r, 20));
+  expect(toolCalls.filter((t) => t === "chorus_close_session").length).toBe(1);
+});
+
+test("async subagent: duplicate events close only once", async () => {
+  await resetState();
+  const input: any = { agent: "worker", task: "do async work" };
+  await handlers["tool_call"]({ toolName: "subagent", toolCallId: "tc-a3", input }, ctx);
+  await handlers["tool_result"](
+    { toolName: "subagent", toolCallId: "tc-a3", isError: false, input, details: { asyncId: "RUN-C" }, content: [] },
+    ctx,
+  );
+  eventBus["subagent:async-complete"]!({ runId: "RUN-C" });
+  eventBus["subagent:process-terminal"]!({ runId: "RUN-C" });
+  await new Promise((r) => setTimeout(r, 20));
+  expect(toolCalls.filter((t) => t === "chorus_close_session").length).toBe(1);
+});
+
+test("manual session marker in task suppresses double injection", async () => {
+  await resetState();
+  const input: any = { agent: "worker", task: "--- Chorus session (managed by main agent) ---\nSession UUID: 00000000-0000-0000-0000-000000000000\ndo work" };
+  await handlers["tool_call"]({ toolName: "subagent", toolCallId: "tc-mk", input }, ctx);
+  expect(toolCalls.filter((t) => t === "chorus_create_session").length).toBe(0);
+  expect(input.task).toContain("managed by main agent");
 });

--- a/packages/chorus-pi/test/ext-events.test.ts
+++ b/packages/chorus-pi/test/ext-events.test.ts
@@ -381,3 +381,101 @@ test("manual session marker in task suppresses double injection", async () => {
   expect(toolCalls.filter((t) => t === "chorus_create_session").length).toBe(0);
   expect(input.task).toContain("managed by main agent");
 });
+
+test("process-terminal closes via the {id} shape (runId absent)", async () => {
+  await resetState();
+  const input: any = { agent: "worker", task: "do async work" };
+  await handlers["tool_call"]({ toolName: "subagent", toolCallId: "tc-id", input }, ctx);
+  await handlers["tool_result"](
+    { toolName: "subagent", toolCallId: "tc-id", isError: false, input, details: { asyncId: "RUN-ID" }, content: [] },
+    ctx,
+  );
+  eventBus["subagent:process-terminal"]!({ id: "RUN-ID" });
+  await new Promise((r) => setTimeout(r, 20));
+  expect(toolCalls.filter((t) => t === "chorus_close_session").length).toBe(1);
+});
+
+test("async-complete ignores id-only payloads (runId must be present)", async () => {
+  await resetState();
+  const input: any = { agent: "worker", task: "do async work" };
+  await handlers["tool_call"]({ toolName: "subagent", toolCallId: "tc-idonly", input }, ctx);
+  await handlers["tool_result"](
+    { toolName: "subagent", toolCallId: "tc-idonly", isError: false, input, details: { asyncId: "RUN-IO" }, content: [] },
+    ctx,
+  );
+  eventBus["subagent:async-complete"]!({ id: "RUN-IO" });
+  await new Promise((r) => setTimeout(r, 20));
+  expect(toolCalls.filter((t) => t === "chorus_close_session").length).toBe(0);
+});
+
+test("parallel async: one runId maps several session ids, all closed once", async () => {
+  await resetState();
+  const tasks = [
+    { agent: "worker", task: "build a" },
+    { agent: "worker", task: "build b" },
+  ];
+  await handlers["tool_call"]({ toolName: "subagent", toolCallId: "tc-parasync", input: { tasks } }, ctx);
+  expect(toolCalls.filter((t) => t === "chorus_create_session").length).toBe(2);
+  await handlers["tool_result"](
+    { toolName: "subagent", toolCallId: "tc-parasync", isError: false, input: { tasks }, details: { asyncId: "RUN-PAR" }, content: [] },
+    ctx,
+  );
+  expect(toolCalls).not.toContain("chorus_close_session");
+  eventBus["subagent:async-complete"]!({ runId: "RUN-PAR" });
+  await new Promise((r) => setTimeout(r, 20));
+  expect(toolCalls.filter((t) => t === "chorus_close_session").length).toBe(2);
+});
+
+test("parallel async: marker on one task suppresses only that session", async () => {
+  await resetState();
+  const tasks = [
+    { agent: "worker", task: "--- Chorus session (managed by main agent) ---\nSession UUID: 00000000-0000-0000-0000-000000000000\ndo a" },
+    { agent: "worker", task: "build b" },
+  ];
+  await handlers["tool_call"]({ toolName: "subagent", toolCallId: "tc-parmix", input: { tasks } }, ctx);
+  expect(toolCalls.filter((t) => t === "chorus_create_session").length).toBe(1);
+});
+
+test("async close failure is re-added and the shutdown sweep retries it", async () => {
+  await resetState();
+  const closeUuids: string[] = [];
+  (globalThis as any).fetch = (async (url: any, init: any) => {
+    const body = init?.body ? JSON.parse(init.body) : {};
+    if (body.method === "initialize") {
+      return new Response('{"jsonrpc":"2.0","id":1,"result":{}}', {
+        status: 200, headers: { "mcp-session-id": "mcp-sess-1", "content-type": "application/json" },
+      }) as unknown as Response;
+    }
+    if (body.method === "notifications/initialized") return new Response("", { status: 200 }) as unknown as Response;
+    if (body.method === "tools/call") {
+      const name: string = body.params?.name ?? "";
+      toolCalls.push(name);
+      if (name === "chorus_close_session") {
+        closeUuids.push(body.params?.arguments?.sessionUuid);
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: 2, error: { code: -32603, message: "server boom" } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ) as unknown as Response;
+      }
+      const text = name === "chorus_create_session" ? JSON.stringify({ uuid: "S-pfail" }) : "{}";
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text }] } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ) as unknown as Response;
+    }
+    return new Response("", { status: 200 }) as unknown as Response;
+  }) as any;
+  const input: any = { agent: "worker", task: "do async work" };
+  await handlers["tool_call"]({ toolName: "subagent", toolCallId: "tc-pfail", input }, ctx);
+  await handlers["tool_result"](
+    { toolName: "subagent", toolCallId: "tc-pfail", isError: false, input, details: { asyncId: "RUN-FAIL" }, content: [] },
+    ctx,
+  );
+  eventBus["subagent:async-complete"]!({ runId: "RUN-FAIL" });
+  await new Promise((r) => setTimeout(r, 20));
+  expect(closeUuids.length).toBe(1); // attempted, failed
+  // restore a working close and let the shutdown sweep retry the retained sid
+  installDefaultFetch();
+  await handlers["session_shutdown"]({}, ctx);
+  expect(toolCalls.filter((t) => t === "chorus_close_session").length).toBeGreaterThan(1);
+});

--- a/packages/chorus-pi/test/lib.test.ts
+++ b/packages/chorus-pi/test/lib.test.ts
@@ -543,20 +543,20 @@ test("hasSessionMarker: matches injected block header at line start only", () =>
   expect(hasSessionMarker("plain implementation task, no chorus")).toBe(false);
   // prose that merely mentions the phrase must NOT suppress injection
   expect(hasSessionMarker("this task is about the Chorus session lifecycle")).toBe(false);
+  // a hyphenated continuation is not a header
+  expect(hasSessionMarker("--- Chorus session-notes for the team")).toBe(false);
   expect(hasSessionMarker("")).toBe(false);
 });
 
-test("extractRunIdFromToolResultEvent: asyncId/runId from details or JSON content", () => {
-  expect(extractRunIdFromToolResultEvent({ details: { asyncId: "run-1" }, content: [] })).toBe("run-1");
-  expect(extractRunIdFromToolResultEvent({ details: { runId: "run-2" }, content: [] })).toBe("run-2");
-  expect(extractRunIdFromToolResultEvent({ details: {}, content: [{ text: JSON.stringify({ asyncId: "run-3" }) }] })).toBe("run-3");
-  expect(extractRunIdFromToolResultEvent({ details: {}, content: [{ text: JSON.stringify({ runId: "run-4" }) }] })).toBe("run-4");
+test("extractRunIdFromToolResultEvent: asyncId/runId trusted from details only", () => {
+  expect(extractRunIdFromToolResultEvent({ details: { asyncId: "run-1" } })).toBe("run-1");
+  expect(extractRunIdFromToolResultEvent({ details: { runId: "run-2" } })).toBe("run-2");
 });
 
-test("extractRunIdFromToolResultEvent: generic id/prefix are NOT trusted run ids", () => {
-  expect(extractRunIdFromToolResultEvent({ details: { id: "job-1" }, content: [] })).toBe(null);
-  expect(extractRunIdFromToolResultEvent({ details: { prefix: "abc" }, content: [] })).toBe(null);
-  expect(extractRunIdFromToolResultEvent({ details: {}, content: [{ text: JSON.stringify({ id: "job-1", results: [] }) }] })).toBe(null);
-  expect(extractRunIdFromToolResultEvent({ details: {}, content: [{ text: "plain text" }] })).toBe(null);
-  expect(extractRunIdFromToolResultEvent({ details: {}, content: [] })).toBe(null);
+test("extractRunIdFromToolResultEvent: generic id/prefix and content are NOT trusted", () => {
+  expect(extractRunIdFromToolResultEvent({ details: { id: "job-1" } })).toBe(null);
+  expect(extractRunIdFromToolResultEvent({ details: { prefix: "abc" } })).toBe(null);
+  // worker output (even JSON) must never misclassify a blocking run as async
+  expect(extractRunIdFromToolResultEvent({ details: {}, content: [{ text: JSON.stringify({ asyncId: "run-x", results: [] }) }] })).toBe(null);
+  expect(extractRunIdFromToolResultEvent({ details: undefined })).toBe(null);
 });

--- a/packages/chorus-pi/test/lib.test.ts
+++ b/packages/chorus-pi/test/lib.test.ts
@@ -5,6 +5,8 @@ import {
   WORKER_AGENT_NAMES,
   subagentTaskItems,
   sessionWorkflow,
+  hasSessionMarker,
+  extractRunIdFromToolResultEvent,
   detectOpenSpec,
   buildSessionBanner,
   parseMaxCodeReviewRounds,
@@ -531,4 +533,30 @@ test("resolveChorusConfigFromMcpJson: all candidates partial → empty (no compl
   const readFile = (p: string) => files[p as keyof typeof files];
   expect(resolveChorusConfigFromMcpJson(["/proj/.mcp.json", "/home/.pi/agent/mcp.json"], fs, readFile))
     .toEqual({ url: "", apiKey: "" });
+});
+
+// ─── hasSessionMarker / extractRunIdFromToolResultEvent ──────────────
+
+test("hasSessionMarker: matches injected block header at line start only", () => {
+  expect(hasSessionMarker("do work\n--- Chorus session (auto-injected by the chorus-pi extension) ---\nSession UUID: x")).toBe(true);
+  expect(hasSessionMarker("--- Chorus session (managed by main agent) ---")).toBe(true);
+  expect(hasSessionMarker("plain implementation task, no chorus")).toBe(false);
+  // prose that merely mentions the phrase must NOT suppress injection
+  expect(hasSessionMarker("this task is about the Chorus session lifecycle")).toBe(false);
+  expect(hasSessionMarker("")).toBe(false);
+});
+
+test("extractRunIdFromToolResultEvent: asyncId/runId from details or JSON content", () => {
+  expect(extractRunIdFromToolResultEvent({ details: { asyncId: "run-1" }, content: [] })).toBe("run-1");
+  expect(extractRunIdFromToolResultEvent({ details: { runId: "run-2" }, content: [] })).toBe("run-2");
+  expect(extractRunIdFromToolResultEvent({ details: {}, content: [{ text: JSON.stringify({ asyncId: "run-3" }) }] })).toBe("run-3");
+  expect(extractRunIdFromToolResultEvent({ details: {}, content: [{ text: JSON.stringify({ runId: "run-4" }) }] })).toBe("run-4");
+});
+
+test("extractRunIdFromToolResultEvent: generic id/prefix are NOT trusted run ids", () => {
+  expect(extractRunIdFromToolResultEvent({ details: { id: "job-1" }, content: [] })).toBe(null);
+  expect(extractRunIdFromToolResultEvent({ details: { prefix: "abc" }, content: [] })).toBe(null);
+  expect(extractRunIdFromToolResultEvent({ details: {}, content: [{ text: JSON.stringify({ id: "job-1", results: [] }) }] })).toBe(null);
+  expect(extractRunIdFromToolResultEvent({ details: {}, content: [{ text: "plain text" }] })).toBe(null);
+  expect(extractRunIdFromToolResultEvent({ details: {}, content: [] })).toBe(null);
 });

--- a/packages/chorus-pi/test/static.sh
+++ b/packages/chorus-pi/test/static.sh
@@ -27,8 +27,8 @@ echo "═══ A1b. no undefined module-scope variables (catches the callSessio
 # A transpile (bun build) does NOT catch references to undeclared variables because
 # TS strips types and bun's transpiler is lenient. So grep for the known module-scope
 # consts and assert every reference is preceded by a declaration.
-for v in callSessions injectedOnce checkinContext mcpSessionId; do
-  decls=$(grep -cE "^const $v\b|^let $v\b" extensions/chorus.ts)
+for v in callSessions injectedOnce checkinContext mcpSessionId runIdToSid inflightCloses; do
+  decls=$(grep -cE "^[[:space:]]*const $v\\b|^[[:space:]]*let $v\\b" extensions/chorus.ts)
   uses=$(grep -cE "\b$v\b" extensions/chorus.ts)
   if [ "$decls" -ge 1 ]; then ok "$v declared ($decls×) and used ($uses×)"; else no "$v used ($uses×) but NEVER declared — runtime ReferenceError"; fi
 done


### PR DESCRIPTION
## Summary

`packages/chorus-pi`'s Chorus session lifecycle assumed the `subagent` tool
runs **blocking** (session opens on `tool_call`, closes on `tool_result`).
The nicobailon `pi-subagents` package is the de-facto subagent implementation
for many users, and it launches **async (detached)** by default: `tool_result`
returns immediately with `details.asyncId`, completion arrives later on the pi
event bus. With this PR the extension's session lifecycle supports both:

- **Async completion**: `tool_result` with `details.asyncId`/`details.runId`
  defers session close to `subagent:async-complete` / `subagent:process-terminal`
  events, with a `session_shutdown` sweep as final guard.
- **No double-injection**: tasks that already carry an injected
  `--- Chorus session` block (main-agent wave templates) are never re-injected.
- **Contract-locked extraction**: the run id comes **only** from
  `details.asyncId`/`details.runId` (verified against pi-subagents source);
  a blocking run's worker output or a generic `id`/`prefix` can never
  misclassify it as async (no session leak).
- **Bundled agents tuned for nicobailon**: `agents/*.md` gain
  `async: false` (reviewer verdict + chorus-worker stay foreground),
  reviewers gain `mcpScript` in `tools` and the nicobailon
  `acceptance: { level: "none" }` marker; `package.json` declares
  `pi.subagents.agents: ["./agents"]` so nicobailon discovers them from the
  installed package (no user-level copy).
- **Coexistence documented**: both implementations register a tool named
  `subagent`; pi rejects a duplicate registration, so the README now documents
  the `settings.packages` package-filter exclude
  (`"extensions": ["!extensions/subagent/**"]`) as the deterministic,
  zero-conflict way to keep nicobailon active while retaining chorus.ts session
  hooks and the packaged agents.

The bundled blocking subagent is **unchanged** (it is the default when no
external implementation is installed); only the async path is added.

## Testing

- `test/all.sh` — offline layers all green (static A: 39 checks; unit B +
  extension-event tests, incl. new deferred-close / process-terminal /
  duplicate-event / marker-suppression / close-failure-retry cases).
- Real-environment verification (pi 0.84.4 + pi-subagents 0.64):
  `subagent({ action: "list" })` shows nicobailon agents, `chorus-worker`
  runs foreground with project context inherited and the Chorus session
  workflow injected.

## Notes

- Two reviewer passes completed; final verdict PASS (one non-blocking P2 note
  on external-contract verification — the nicobailon/pi contract points are
  documented with source line references in `lib/lib.ts`).
