### PR TITLE
feat(daemon): server-paginate the daemon session/conversation list

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1593,6 +1593,7 @@
     "agentSessionCount": "{count, plural, one {# conversation} other {# conversations}}",
     "listHeader": "CONVERSATIONS",
     "loadMore": "Load more",
+    "loadingMore": "Loading more…",
     "loadEarlier": "Load earlier messages",
     "loadingEarlier": "Loading earlier…",
     "transcriptLoading": "Loading transcript…",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1593,6 +1593,7 @@
     "agentSessionCount": "{count} 件の会話",
     "listHeader": "会話",
     "loadMore": "さらに読み込む",
+    "loadingMore": "読み込み中…",
     "loadEarlier": "以前のメッセージを読み込む",
     "loadingEarlier": "以前のメッセージを読み込み中…",
     "transcriptLoading": "トランスクリプトを読み込み中…",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1593,6 +1593,7 @@
     "agentSessionCount": "대화 {count}개",
     "listHeader": "대화",
     "loadMore": "더 보기",
+    "loadingMore": "더 불러오는 중…",
     "loadEarlier": "이전 메시지 불러오기",
     "loadingEarlier": "이전 메시지를 불러오는 중…",
     "transcriptLoading": "대화 기록을 불러오는 중…",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1593,6 +1593,7 @@
     "agentSessionCount": "{count, plural, other {# 个对话}}",
     "listHeader": "对话",
     "loadMore": "加载更多",
+    "loadingMore": "加载中…",
     "loadEarlier": "加载更早的消息",
     "loadingEarlier": "正在加载更早…",
     "transcriptLoading": "正在加载记录…",

--- a/openspec/changes/archive/2026-09-05-paginate-daemon-session-list/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-05-paginate-daemon-session-list/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/archive/2026-09-05-paginate-daemon-session-list/README.md
+++ b/openspec/changes/archive/2026-09-05-paginate-daemon-session-list/README.md
@@ -1,0 +1,3 @@
+# paginate-daemon-session-list
+
+Server-side pagination for the daemon session/conversation list endpoint

--- a/openspec/changes/archive/2026-09-05-paginate-daemon-session-list/design.md
+++ b/openspec/changes/archive/2026-09-05-paginate-daemon-session-list/design.md
@@ -1,0 +1,132 @@
+# Design — Paginate the daemon session/conversation list
+
+## Context
+
+`GET /api/daemon-sessions` → `getVisibleSessionsWithOrigin(auth)` →
+`getVisibleSessions(auth)`:
+
+```ts
+// daemon-session.service.ts
+const rows = await prisma.daemonSession.findMany({
+  where: { companyUuid, ...ownerScope(auth) },
+  orderBy: { lastTurnAt: "desc" },        // NO take/limit — full history
+});
+await reconcileOrphanTurnsForSessions(companyUuid, rows);  // over ALL rows
+return rows.map(toSessionView);
+```
+
+`getVisibleSessionsWithOrigin` then batches three enrichment queries (connection
+liveness, `getFirstInstructionBySessionUuid`, idea titles) over that full set.
+
+The chat client (`daemon-chat.tsx`) is **agent-first**: it derives the agent Select from
+`connections ∪ sessions`, default-selects the most-recent agent, filters `sessions` to the
+selected agent, sorts by `lastTurnAt` desc, and slices to `visibleCount` (12, +12 per
+"Load more"). It fetches the full list on mount and every 15s.
+
+## Goals
+
+- The chat modal never loads more session rows than it shows.
+- Enrichment + reconcile cost scales with a page (≤ limit), not total history.
+- No behavior change for non-chat callers (`connections-view` tests, send box).
+- Preserve the agent-first UX: the Select still lists every agent with history, the default
+  agent is still the most-recent, older conversations still reachable via "Load more".
+
+## Decisions
+
+### D1 — Paginate per agent, not globally
+
+The UI shows exactly one agent's conversations at a time. A global newest-first cursor
+would return a page mixing agents, so selecting agent X could show zero of X's rows until
+many pages load. Pagination is therefore **scoped by `agentUuid`**, matching the render
+model 1:1.
+
+### D2 — Agent index is a separate cheap mode
+
+The Select and default-agent selection need the set of agents that have history and which
+is most recent — a global fact the per-agent page cannot provide. A dedicated
+`?view=agents` mode answers it with a single `GROUP BY agentUuid` (`_count`, `max(lastTurnAt)`),
+owner/company-scoped, with **no** enrichment and **no** reconcile. Cost is O(distinct agents),
+independent of total session count.
+
+Agents currently connected but with no history still appear in the Select because the client
+already unions the agent index with the live `connections` list — the index only needs to
+contribute agents that have **history** (possibly disconnected).
+
+### D3 — Keyset cursor on `(lastTurnAt desc, uuid desc)`
+
+`lastTurnAt` is not unique, so the cursor is the composite `(lastTurnAt, uuid)`. We mirror
+the existing `comment.service.ts` pattern: `orderBy: [{ lastTurnAt: "desc" }, { uuid: "desc" }]`,
+`cursor: { uuid: <before> }, skip: 1`, `take: limit + 1` (the extra row is the `hasMore`
+sentinel — no count query). `nextCursor` is the last returned row's `uuid`.
+
+- Prisma `cursor` seeks to the row with that `uuid`, then applies the compound `orderBy`, so
+  the `(lastTurnAt, uuid)` ordering is stable across pages even with tied timestamps.
+- `limit` defaults to `DEFAULT_SESSION_PAGE = 12` (matches the client `PAGE_SIZE`), clamped to
+  `1..100`.
+- Empty/absent `before` → first page.
+
+### D4 — Enrich + reconcile only the page
+
+`getVisibleSessionsWithOrigin` gains a paginated variant that, given the page rows, runs the
+same three enrichment queries + `reconcileOrphanTurnsForSessions` scoped to those ≤ limit
+rows. The full-history path is retained unchanged for the legacy no-param mode.
+
+### D5 — Route contract (additive, backward-compatible)
+
+`GET /api/daemon-sessions`:
+
+| Query | Response | Notes |
+|---|---|---|
+| _(none)_ | `{ sessions: SessionTargetView[] }` | **Unchanged** — full list, enriched, legacy. |
+| `?view=agents` | `{ agents: { agentUuid, lastTurnAt, sessionCount }[] }` | Cheap GROUP BY; no enrichment/reconcile. |
+| `?agentUuid=&limit=&before=` | `{ sessions: SessionTargetView[], nextCursor: string \| null, hasMore: boolean }` | Per-agent page, newest-first, enriched over the page. |
+
+- `agentUuid` is validated under the caller's owner/self scope (reuse the existing
+  `callerOwnsAgent` fence in `daemon-instruction.service.ts`); an agent the caller may not see
+  yields an empty page (non-disclosure), never another owner's rows.
+- Mode is chosen by params: `view=agents` wins; else `agentUuid` present → page mode; else
+  legacy. Invalid `limit`/`before` are clamped/ignored, not errors.
+
+### D6 — Client data layer (chat modal only)
+
+`daemon-chat.tsx`:
+
+- **Agent axis:** on mount + 15s poll, fetch `?view=agents`; merge with `connections` for the
+  Select; `mostRecentAgentUuid` = the index's max-`lastTurnAt` agent (fallback to
+  `connections`/first agent as today).
+- **Rows:** on selected-agent resolve/change, fetch `?agentUuid=&limit=12` → the page becomes
+  the row source (replacing the client-side per-agent filter + slice). Track `nextCursor`/`hasMore`.
+- **Load more:** fetch `?agentUuid=&before=<nextCursor>&limit=12`, append (dedup by `uuid`).
+- **Poll:** refetch the selected agent's first page (resettles `originOnline`, surfaces new
+  conversations at the top) — bounded, not the whole history.
+- **Live merges:** `handleSessionStarted` (prepend/patch) and the SSE transcript subscription
+  are unchanged — they mutate the loaded page array. A started conversation for the selected
+  agent prepends; the agent index refreshes on the next poll so a brand-new agent's entry
+  appears.
+- `conversation-list.tsx`: `onLoadMore` now triggers a server page fetch; `hasMore` comes from
+  the server. `visibleCount` client slice is removed for the chat path.
+
+### D7 — Non-chat callers untouched
+
+`connections-view.tsx` (referenced only by tests now) and `send-instruction-box` receive the
+`sessions` array via the no-param default, whose shape/bytes are unchanged. No edits there.
+
+## Risks / Trade-offs
+
+- **More round-trips on open** (agent-index + first page) vs one big fetch — but each is small
+  and bounded; net latency drops at the user's scale, and both can run in parallel.
+- **Agent index staleness** between polls — acceptable; the Select is coarse and the 15s poll
+  reconverges, same cadence as today.
+- **Cursor correctness with live inserts** — a conversation whose `lastTurnAt` advances mid-paging
+  could shift pages; dedup-by-`uuid` on append prevents duplicates, and "Load more" is
+  best-effort history, so a rare re-order is harmless (matches the transcript pager's stance).
+
+## Test Plan
+
+- Service: agent-index aggregation (counts, max lastTurnAt, owner scope); per-agent page
+  (ordering, `limit` clamp, cursor `before`, `hasMore` sentinel, empty page, cross-owner
+  non-disclosure); enrichment/reconcile scoped to the page; legacy no-param path unchanged.
+- Route: mode selection by params; legacy default byte-shape; agent scope validation.
+- Client: agent-index → Select + default agent; per-agent first page; "Load more" appends via
+  server cursor; poll refetches first page; live prepend/SSE still merge; existing
+  loading-skeleton behavior (`deriveChatBodyState`) preserved.

--- a/openspec/changes/archive/2026-09-05-paginate-daemon-session-list/proposal.md
+++ b/openspec/changes/archive/2026-09-05-paginate-daemon-session-list/proposal.md
@@ -1,0 +1,73 @@
+# Paginate the daemon session/conversation list
+
+## Why
+
+Opening the daemon chat modal is slow, and the slowness grows with the number of
+conversations. The user confirmed (idea 460ea0d5 elaboration) that the pain is the
+**load time of the conversation-history list**, not front-end rendering — "只有网络问题，没有性能问题".
+
+The root cause is that `GET /api/daemon-sessions` returns **every** visible session at
+once, with no `take`/`limit`:
+
+- `getVisibleSessions` runs `prisma.daemonSession.findMany({ orderBy: lastTurnAt desc })`
+  over the caller's whole history, then a read-time orphan-turn reconcile pass over that
+  full set.
+- `getVisibleSessionsWithOrigin` then enriches **every** row: one connection-liveness
+  query, one earliest-`human_instruction`-per-session query, and one idea-title query —
+  all scaling with total session count.
+- The chat client fetches this full payload on open **and re-fetches it every 15s**, then
+  throws most of it away (it slices to 12 rows for the one selected agent).
+
+At 20–100 conversations (the user's range) this is a large, latency-heavy payload the
+UI does not need. The front-end already paginates client-side; the fix is to stop
+sending the whole list over the wire.
+
+## What Changes
+
+Add **opt-in, backward-compatible** server-side pagination to `GET /api/daemon-sessions`,
+matched to the client's existing agent-first UI (one agent's conversations shown at a
+time, newest-first):
+
+1. **Agent-index mode** (`?view=agents`) — a cheap `GROUP BY agentUuid` returning, per
+   agent that has session history, its `agentUuid`, most-recent `lastTurnAt`, and
+   `sessionCount`. No transcript, no per-row enrichment, no reconcile. Drives the left-pane
+   agent Select and the default-agent selection without loading any conversation rows.
+
+2. **Per-agent page mode** (`?agentUuid=<uuid>&limit=<n>&before=<cursor>`) — one page of
+   that agent's conversations, newest-first, keyset-paginated by a stable `(lastTurnAt, uuid)`
+   cursor, returning `{ sessions, nextCursor, hasMore }`. Origin-online + naming enrichment
+   and the orphan-turn reconcile run **only over the returned page**, not the whole history.
+
+3. **Legacy full-list mode** (no query params) — response is **byte-identical** to today
+   (`{ sessions: [...all] }`), so `connections-view` and the send box's targeting picker are
+   unaffected. Pagination is purely additive.
+
+4. **Client rewire** (daemon chat modal only) — the modal fetches the agent index for its
+   Select + default agent, then fetches per-agent pages on selection and on "Load more"
+   (server-driven cursor instead of a client-side slice). The 15s poll refetches only the
+   selected agent's first page. Live merges (`handleSessionStarted`, SSE transcript events)
+   operate on the loaded page as before.
+
+## Capabilities
+
+- `daemon-session-conversation` — ADDED: server-paginated visible-session list (agent-index
+  mode, per-agent cursor page mode, legacy full-list preservation).
+
+## Out of Scope (explicitly, per elaboration Q4/Q5)
+
+- Front-end virtualization / windowing of the list or transcript.
+- `React.memo` / render-pipeline changes, deferred Shiki/Mermaid highlighting.
+- Transcript pagination — already message-paginated (20/page cursor + "load earlier");
+  unchanged.
+
+## Impact
+
+- **Endpoint:** `GET /api/daemon-sessions` gains two opt-in query modes; default response
+  unchanged.
+- **Service:** `daemon-session.service.ts` (new paginated read + agent-index read),
+  `daemon-instruction.service.ts` (`getVisibleSessionsWithOrigin` gains a paginated variant
+  enriching only a page).
+- **Client:** `daemon-chat.tsx` data layer + `conversation-list.tsx` "Load more" wiring.
+- **Compat:** `connections-view` (test-only now) and the send box are unaffected — they use
+  the no-param default.
+- **Risk:** low — additive endpoint modes; existing callers keep the legacy shape.

--- a/openspec/changes/archive/2026-09-05-paginate-daemon-session-list/specs/daemon-session-conversation/spec.md
+++ b/openspec/changes/archive/2026-09-05-paginate-daemon-session-list/specs/daemon-session-conversation/spec.md
@@ -1,0 +1,82 @@
+# daemon-session-conversation — delta
+
+## ADDED Requirements
+
+### Requirement: Server-paginated visible session list
+
+The `GET /api/daemon-sessions` endpoint SHALL support opt-in, backward-compatible
+server-side pagination of the caller's visible daemon sessions, matched to the
+agent-first chat UI. The endpoint SHALL expose three modes selected by query parameters,
+and every mode SHALL enforce the same owner/self + company visibility fence as the
+existing unpaginated read (an agent key sees only its own sessions; a user/super_admin sees
+only sessions of agents they own; never cross-owner or cross-company).
+
+#### Scenario: Legacy full-list mode is unchanged
+
+- **WHEN** the endpoint is called with no pagination query parameters
+- **THEN** it SHALL return `{ sessions }` containing every visible session, enriched with
+  `originOnline` and naming fields, ordered by `lastTurnAt` descending — byte-identical in
+  shape to the pre-change response
+- **AND** non-chat callers (the connections view, the send-instruction targeting picker)
+  SHALL continue to work without modification
+
+#### Scenario: Agent-index mode
+
+- **WHEN** the endpoint is called with `view=agents`
+- **THEN** it SHALL return, for each agent that has at least one visible session, an entry
+  carrying `agentUuid`, the agent's most recent session `lastTurnAt`, and its visible
+  `sessionCount`
+- **AND** it SHALL compute this with a single grouped aggregate, performing NO per-session
+  origin/naming enrichment and NO orphan-turn reconcile
+- **AND** the cost SHALL scale with the number of distinct agents, not the total session count
+
+#### Scenario: Per-agent cursor page mode
+
+- **WHEN** the endpoint is called with `agentUuid=<uuid>` and optional `limit` and `before`
+- **THEN** it SHALL return `{ sessions, nextCursor, hasMore }` where `sessions` is one page of
+  that agent's visible conversations ordered by `lastTurnAt` descending (ties broken by a
+  stable secondary key), `nextCursor` is the cursor to pass as `before` for the next page (or
+  `null` when none remain), and `hasMore` indicates whether older conversations exist
+- **AND** `limit` SHALL default to the client page size and be clamped to a bounded range
+- **AND** origin-online enrichment, naming enrichment, and the orphan-turn reconcile SHALL run
+  only over the returned page, not the full history
+
+#### Scenario: Per-agent page enforces visibility scope
+
+- **WHEN** a caller requests `agentUuid` for an agent it may not see (an agent it does not own,
+  or in another company)
+- **THEN** the endpoint SHALL return an empty page rather than another owner's sessions, without
+  disclosing whether that agent exists
+
+### Requirement: Chat modal consumes the paginated session list
+
+The daemon chat modal SHALL load its conversation list through the paginated endpoint so the
+payload it fetches is bounded by what it displays, while preserving its agent-first behavior.
+
+#### Scenario: Agent axis from the index
+
+- **WHEN** the chat modal opens
+- **THEN** it SHALL populate its agent Select and choose a default agent using the agent-index
+  mode (unioned with the live connection list for currently-connected agents), without fetching
+  any conversation rows for non-selected agents
+
+#### Scenario: Per-agent page load and load-more
+
+- **WHEN** an agent is selected in the chat modal
+- **THEN** the modal SHALL fetch the first page of that agent's conversations from the per-agent
+  page mode and render them newest-first
+- **AND** the "Load more" control SHALL fetch the next page via the server cursor and append it,
+  de-duplicated by session uuid, rather than slicing a fully-fetched client-side array
+
+#### Scenario: Bounded background refresh
+
+- **WHEN** the chat modal's periodic refresh runs
+- **THEN** it SHALL refetch only the selected agent's first page (resettling online status and
+  surfacing newly-started conversations at the top), not the caller's entire session history
+
+#### Scenario: Live updates still merge
+
+- **WHEN** a conversation is started or re-pointed, or a live transcript event arrives, while the
+  chat modal is open
+- **THEN** the modal SHALL merge it into the currently loaded page (prepend/patch/append) exactly
+  as before, without requiring a full-list refetch

--- a/openspec/specs/daemon-session-conversation/spec.md
+++ b/openspec/specs/daemon-session-conversation/spec.md
@@ -504,3 +504,82 @@ A load failure with no cached conversations SHALL continue to show the distinct 
 - **THEN** it MUST render the distinct load-error card
 - **AND** it MUST NOT render the "no conversations" empty state or the loading affordance
 
+### Requirement: Server-paginated visible session list
+
+The `GET /api/daemon-sessions` endpoint SHALL support opt-in, backward-compatible
+server-side pagination of the caller's visible daemon sessions, matched to the
+agent-first chat UI. The endpoint SHALL expose three modes selected by query parameters,
+and every mode SHALL enforce the same owner/self + company visibility fence as the
+existing unpaginated read (an agent key sees only its own sessions; a user/super_admin sees
+only sessions of agents they own; never cross-owner or cross-company).
+
+#### Scenario: Legacy full-list mode is unchanged
+
+- **WHEN** the endpoint is called with no pagination query parameters
+- **THEN** it SHALL return `{ sessions }` containing every visible session, enriched with
+  `originOnline` and naming fields, ordered by `lastTurnAt` descending — byte-identical in
+  shape to the pre-change response
+- **AND** non-chat callers (the connections view, the send-instruction targeting picker)
+  SHALL continue to work without modification
+
+#### Scenario: Agent-index mode
+
+- **WHEN** the endpoint is called with `view=agents`
+- **THEN** it SHALL return, for each agent that has at least one visible session, an entry
+  carrying `agentUuid`, the agent's most recent session `lastTurnAt`, and its visible
+  `sessionCount`
+- **AND** it SHALL compute this with a single grouped aggregate, performing NO per-session
+  origin/naming enrichment and NO orphan-turn reconcile
+- **AND** the cost SHALL scale with the number of distinct agents, not the total session count
+
+#### Scenario: Per-agent cursor page mode
+
+- **WHEN** the endpoint is called with `agentUuid=<uuid>` and optional `limit` and `before`
+- **THEN** it SHALL return `{ sessions, nextCursor, hasMore }` where `sessions` is one page of
+  that agent's visible conversations ordered by `lastTurnAt` descending (ties broken by a
+  stable secondary key), `nextCursor` is the cursor to pass as `before` for the next page (or
+  `null` when none remain), and `hasMore` indicates whether older conversations exist
+- **AND** `limit` SHALL default to the client page size and be clamped to a bounded range
+- **AND** origin-online enrichment, naming enrichment, and the orphan-turn reconcile SHALL run
+  only over the returned page, not the full history
+
+#### Scenario: Per-agent page enforces visibility scope
+
+- **WHEN** a caller requests `agentUuid` for an agent it may not see (an agent it does not own,
+  or in another company)
+- **THEN** the endpoint SHALL return an empty page rather than another owner's sessions, without
+  disclosing whether that agent exists
+
+### Requirement: Chat modal consumes the paginated session list
+
+The daemon chat modal SHALL load its conversation list through the paginated endpoint so the
+payload it fetches is bounded by what it displays, while preserving its agent-first behavior.
+
+#### Scenario: Agent axis from the index
+
+- **WHEN** the chat modal opens
+- **THEN** it SHALL populate its agent Select and choose a default agent using the agent-index
+  mode (unioned with the live connection list for currently-connected agents), without fetching
+  any conversation rows for non-selected agents
+
+#### Scenario: Per-agent page load and load-more
+
+- **WHEN** an agent is selected in the chat modal
+- **THEN** the modal SHALL fetch the first page of that agent's conversations from the per-agent
+  page mode and render them newest-first
+- **AND** the "Load more" control SHALL fetch the next page via the server cursor and append it,
+  de-duplicated by session uuid, rather than slicing a fully-fetched client-side array
+
+#### Scenario: Bounded background refresh
+
+- **WHEN** the chat modal's periodic refresh runs
+- **THEN** it SHALL refetch only the selected agent's first page (resettling online status and
+  surfacing newly-started conversations at the top), not the caller's entire session history
+
+#### Scenario: Live updates still merge
+
+- **WHEN** a conversation is started or re-pointed, or a live transcript event arrives, while the
+  chat modal is open
+- **THEN** the modal SHALL merge it into the currently loaded page (prepend/patch/append) exactly
+  as before, without requiring a full-list refetch
+

--- a/src/app/api/daemon-sessions/__tests__/route.test.ts
+++ b/src/app/api/daemon-sessions/__tests__/route.test.ts
@@ -4,6 +4,8 @@ import { NextRequest } from "next/server";
 // ===== Mocks =====
 const mockGetAuthContext = vi.fn();
 const mockGetVisibleSessionsWithOrigin = vi.fn();
+const mockGetVisibleSessionsPageWithOrigin = vi.fn();
+const mockGetVisibleAgentIndex = vi.fn();
 
 vi.mock("@/lib/auth", () => ({
   getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
@@ -11,6 +13,11 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("@/services/daemon-instruction.service", () => ({
   getVisibleSessionsWithOrigin: (...args: unknown[]) => mockGetVisibleSessionsWithOrigin(...args),
+  getVisibleSessionsPageWithOrigin: (...args: unknown[]) => mockGetVisibleSessionsPageWithOrigin(...args),
+}));
+
+vi.mock("@/services/daemon-session.service", () => ({
+  getVisibleAgentIndex: (...args: unknown[]) => mockGetVisibleAgentIndex(...args),
 }));
 
 import { GET } from "@/app/api/daemon-sessions/route";
@@ -40,14 +47,22 @@ const sessions = [
   },
 ];
 
-function getRequest(): NextRequest {
-  return new NextRequest(new URL("http://localhost:3000/api/daemon-sessions"));
+function getRequest(query = ""): NextRequest {
+  return new NextRequest(new URL(`http://localhost:3000/api/daemon-sessions${query}`));
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetAuthContext.mockResolvedValue(userAuth);
   mockGetVisibleSessionsWithOrigin.mockResolvedValue(sessions);
+  mockGetVisibleSessionsPageWithOrigin.mockResolvedValue({
+    sessions,
+    nextCursor: "s1",
+    hasMore: true,
+  });
+  mockGetVisibleAgentIndex.mockResolvedValue([
+    { agentUuid, lastTurnAt: "2026-06-19T03:00:00.000Z", sessionCount: 1 },
+  ]);
 });
 
 describe("GET /api/daemon-sessions", () => {
@@ -83,5 +98,54 @@ describe("GET /api/daemon-sessions", () => {
     const body = await res.json();
     expect(res.status).toBe(200);
     expect(body.data.sessions).toEqual([]);
+  });
+
+  it("LEGACY no-param mode does NOT touch the paginated/agent-index paths", async () => {
+    await GET(getRequest(), emptyCtx);
+    expect(mockGetVisibleSessionsWithOrigin).toHaveBeenCalledTimes(1);
+    expect(mockGetVisibleSessionsPageWithOrigin).not.toHaveBeenCalled();
+    expect(mockGetVisibleAgentIndex).not.toHaveBeenCalled();
+  });
+
+  it("?view=agents → agent-index mode (no full list, no page)", async () => {
+    const res = await GET(getRequest("?view=agents"), emptyCtx);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.data).toEqual({
+      agents: [{ agentUuid, lastTurnAt: "2026-06-19T03:00:00.000Z", sessionCount: 1 }],
+    });
+    expect(mockGetVisibleAgentIndex).toHaveBeenCalledTimes(1);
+    expect(mockGetVisibleAgentIndex.mock.calls[0][0]).toBe(userAuth);
+    expect(mockGetVisibleSessionsWithOrigin).not.toHaveBeenCalled();
+    expect(mockGetVisibleSessionsPageWithOrigin).not.toHaveBeenCalled();
+  });
+
+  it("?agentUuid=&limit=&before= → per-agent page mode with parsed opts", async () => {
+    const res = await GET(
+      getRequest(`?agentUuid=${agentUuid}&limit=5&before=cursor-1`),
+      emptyCtx,
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.data).toEqual({ sessions, nextCursor: "s1", hasMore: true });
+    expect(mockGetVisibleSessionsPageWithOrigin).toHaveBeenCalledTimes(1);
+    const [auth, passedAgent, opts] = mockGetVisibleSessionsPageWithOrigin.mock.calls[0];
+    expect(auth).toBe(userAuth);
+    expect(passedAgent).toBe(agentUuid);
+    expect(opts).toEqual({ limit: 5, before: "cursor-1" });
+    expect(mockGetVisibleSessionsWithOrigin).not.toHaveBeenCalled();
+  });
+
+  it("per-agent page mode with no limit/before passes undefined limit + null before", async () => {
+    await GET(getRequest(`?agentUuid=${agentUuid}`), emptyCtx);
+    expect(mockGetVisibleSessionsPageWithOrigin.mock.calls[0][2]).toEqual({
+      limit: undefined,
+      before: null,
+    });
+  });
+
+  it("per-agent page mode ignores a non-numeric limit (passes undefined, service clamps)", async () => {
+    await GET(getRequest(`?agentUuid=${agentUuid}&limit=abc`), emptyCtx);
+    expect(mockGetVisibleSessionsPageWithOrigin.mock.calls[0][2].limit).toBeUndefined();
   });
 });

--- a/src/app/api/daemon-sessions/route.ts
+++ b/src/app/api/daemon-sessions/route.ts
@@ -6,6 +6,15 @@
 // renders an enabled/disabled send box per session without a second call. Returns NO
 // turn/transcript bodies — transcript rendering is the separate 子3 capability.
 //
+// Three modes, selected by query params (paginate-daemon-session-list) — pagination is
+// OPT-IN and backward-compatible; the no-param response is unchanged:
+//   - `?view=agents`               → { agents } : the agent index (cheap grouped aggregate,
+//                                     no enrichment/reconcile) for the chat modal's Select.
+//   - `?agentUuid=&limit=&before=` → { sessions, nextCursor, hasMore } : one keyset page of
+//                                     that agent's conversations, enriched over the page only.
+//   - (no params)                  → { sessions } : the full enriched list (LEGACY, unchanged) —
+//                                     used by the connections view + the send box targeting.
+//
 // Auth posture mirrors /api/agent-connections and the daemon read routes: any valid auth
 // context (agent API key → its own sessions; user/super_admin → sessions of agents they
 // own), no MCP tool, no new permission bit. Visibility is enforced by the service's
@@ -15,7 +24,11 @@ import { NextRequest } from "next/server";
 import { withErrorHandler } from "@/lib/api-handler";
 import { success, errors } from "@/lib/api-response";
 import { getAuthContext } from "@/lib/auth";
-import { getVisibleSessionsWithOrigin } from "@/services/daemon-instruction.service";
+import { getVisibleAgentIndex } from "@/services/daemon-session.service";
+import {
+  getVisibleSessionsWithOrigin,
+  getVisibleSessionsPageWithOrigin,
+} from "@/services/daemon-instruction.service";
 
 // GET /api/daemon-sessions — list the caller's daemon sessions with originOnline.
 export const GET = withErrorHandler(async (request: NextRequest) => {
@@ -24,6 +37,29 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     return errors.unauthorized();
   }
 
+  const { searchParams } = new URL(request.url);
+
+  // Agent-index mode — the left-pane Select + default-agent selection, no rows.
+  if (searchParams.get("view") === "agents") {
+    const agents = await getVisibleAgentIndex(auth);
+    return success({ agents });
+  }
+
+  // Per-agent page mode — one keyset page of a single agent's conversations. Invalid
+  // `limit` / `before` are clamped/ignored by the service, never an error.
+  const agentUuid = searchParams.get("agentUuid");
+  if (agentUuid) {
+    const limitParam = searchParams.get("limit");
+    const limit = limitParam !== null ? Number(limitParam) : undefined;
+    const before = searchParams.get("before");
+    const page = await getVisibleSessionsPageWithOrigin(auth, agentUuid, {
+      limit: limit !== undefined && Number.isFinite(limit) ? limit : undefined,
+      before: before || null,
+    });
+    return success(page);
+  }
+
+  // Legacy full-list mode — unchanged shape for the connections view + send box.
   const sessions = await getVisibleSessionsWithOrigin(auth);
   return success({ sessions });
 });

--- a/src/components/agent-presence/__tests__/apply-transcript-event.test.ts
+++ b/src/components/agent-presence/__tests__/apply-transcript-event.test.ts
@@ -12,7 +12,9 @@ import { describe, expect, it } from "vitest";
 import {
   applyTranscriptEvent,
   mergeTurnPage,
+  mergeSessionsById,
 } from "@/components/agent-presence/chat/daemon-chat";
+import type { SessionTarget } from "@/components/agent-presence/send-instruction-box";
 import { groupMergedTurns } from "@/components/agent-presence/chat/transcript-view";
 import type {
   TranscriptMessageView,
@@ -454,5 +456,60 @@ describe("live-convergence seam: turn_status_changed(merged) → apply → group
     expect(groups).toHaveLength(1);
     expect(groups[0].absorbing.uuid).toBe("a");
     expect(groups[0].merged.map((t) => t.uuid)).toEqual(["m1"]);
+  });
+});
+
+// ===== mergeSessionsById — the paginated-list union helper =====
+function sess(uuid: string, lastTurnAt: string, extra: Partial<SessionTarget> = {}): SessionTarget {
+  return {
+    uuid,
+    agentUuid: "agent-1",
+    sessionId: uuid,
+    directIdeaUuid: null,
+    originConnectionUuid: "conn-1",
+    status: "active",
+    title: null,
+    lastTurnAt,
+    originOnline: false,
+    firstInstruction: null,
+    ideaTitle: null,
+    ...extra,
+  };
+}
+
+describe("mergeSessionsById", () => {
+  it("appends an older 'Load more' page and sorts newest-first by lastTurnAt", () => {
+    const existing = [sess("a", "2026-06-19T05:00:00.000Z"), sess("b", "2026-06-19T04:00:00.000Z")];
+    const older = [sess("c", "2026-06-19T03:00:00.000Z"), sess("d", "2026-06-19T02:00:00.000Z")];
+    const out = mergeSessionsById(existing, older);
+    expect(out.map((s) => s.uuid)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("de-dupes by uuid — the INCOMING (fresher) copy wins", () => {
+    const existing = [sess("a", "2026-06-19T05:00:00.000Z", { originOnline: false })];
+    const incoming = [sess("a", "2026-06-19T06:00:00.000Z", { originOnline: true })];
+    // incoming is the first arg → its copy wins.
+    const out = mergeSessionsById(incoming, existing);
+    expect(out).toHaveLength(1);
+    expect(out[0].originOnline).toBe(true);
+    expect(out[0].lastTurnAt).toBe("2026-06-19T06:00:00.000Z");
+  });
+
+  it("preserves an optimistic row absent from the incoming page (fresh first-page load)", () => {
+    const optimistic = [sess("new", "2026-06-19T07:00:00.000Z")];
+    const serverPage = [sess("a", "2026-06-19T05:00:00.000Z")];
+    // fresh load: mergeSessionsById(page, existing-for-agent) — the optimistic row survives.
+    const out = mergeSessionsById(serverPage, optimistic);
+    expect(out.map((s) => s.uuid)).toEqual(["new", "a"]);
+  });
+
+  it("returns a new array and does not mutate its inputs", () => {
+    const a = [sess("a", "2026-06-19T05:00:00.000Z")];
+    const b = [sess("b", "2026-06-19T04:00:00.000Z")];
+    const out = mergeSessionsById(a, b);
+    expect(out).not.toBe(a);
+    expect(out).not.toBe(b);
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
   });
 });

--- a/src/components/agent-presence/__tests__/connections-modal.test.tsx
+++ b/src/components/agent-presence/__tests__/connections-modal.test.tsx
@@ -255,10 +255,49 @@ function respondWith(opts: {
           json: async () => ({ success: true, data: detail }),
         });
       }
-      if (url.startsWith("/api/daemon-sessions")) {
+      // Agent-index mode (?view=agents): derive the index from the fixture sessions
+      // (group by agentUuid → sessionCount + max lastTurnAt), newest agent first — the
+      // shape the paginated endpoint returns for the chat modal's Select + default agent.
+      if (url.includes("view=agents")) {
+        const byAgent = new Map<
+          string,
+          { agentUuid: string; lastTurnAt: string; sessionCount: number }
+        >();
+        for (const s of sessions) {
+          const cur = byAgent.get(s.agentUuid);
+          if (!cur) {
+            byAgent.set(s.agentUuid, {
+              agentUuid: s.agentUuid,
+              lastTurnAt: s.lastTurnAt,
+              sessionCount: 1,
+            });
+          } else {
+            cur.sessionCount += 1;
+            if (s.lastTurnAt > cur.lastTurnAt) cur.lastTurnAt = s.lastTurnAt;
+          }
+        }
+        const agents = [...byAgent.values()].sort((a, b) =>
+          a.lastTurnAt < b.lastTurnAt ? 1 : -1,
+        );
         return Promise.resolve({
           ok: sessionsOk,
-          json: async () => ({ success: sessionsOk, data: { sessions } }),
+          json: async () => ({ success: sessionsOk, data: { agents } }),
+        });
+      }
+      // Per-agent page mode (?agentUuid=X): filter the fixture sessions to that agent
+      // and return the paginated envelope. The fixtures fit in one page (hasMore false).
+      if (url.startsWith("/api/daemon-sessions")) {
+        const m = url.match(/[?&]agentUuid=([^&]+)/);
+        const agentUuid = m ? decodeURIComponent(m[1]) : null;
+        const pageSessions = agentUuid
+          ? sessions.filter((s) => s.agentUuid === agentUuid)
+          : sessions;
+        return Promise.resolve({
+          ok: sessionsOk,
+          json: async () => ({
+            success: sessionsOk,
+            data: { sessions: pageSessions, nextCursor: null, hasMore: false },
+          }),
         });
       }
     }

--- a/src/components/agent-presence/chat/__tests__/conversation-list.test.tsx
+++ b/src/components/agent-presence/chat/__tests__/conversation-list.test.tsx
@@ -81,7 +81,7 @@ function renderList(overrides: Partial<React.ComponentProps<typeof ConversationL
       selectedSessionUuid={null}
       onSelectSession={() => {}}
       onNewConversation={() => {}}
-      visibleCount={12}
+      hasMore={false}
       onLoadMore={() => {}}
       {...overrides}
     />,
@@ -129,5 +129,42 @@ describe("ConversationList body state", () => {
     renderList({ loading: true, rows: [makeRow("s-1", "Stale row")] });
     expect(screen.getByTestId("conversation-list-skeleton")).toBeTruthy();
     expect(screen.queryByText("Stale row")).toBeNull();
+  });
+
+  it("renders ALL loaded rows (no client-side slice) — pagination is server-driven", () => {
+    const rows = Array.from({ length: 20 }, (_, i) => makeRow(`s-${i}`, `Conversation ${i}`));
+    renderList({ loading: false, rows });
+    // Every loaded row is rendered — there is no visibleCount cap anymore.
+    expect(screen.getByText("Conversation 0")).toBeTruthy();
+    expect(screen.getByText("Conversation 19")).toBeTruthy();
+  });
+
+  it("shows 'Load more' only when the server reports hasMore, and calls onLoadMore on click", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const onLoadMore = vi.fn();
+
+    // hasMore=false → no control.
+    renderList({ loading: false, rows: [makeRow("s-1", "Only")], hasMore: false, onLoadMore });
+    expect(screen.queryByText("Load more")).toBeNull();
+    cleanup();
+
+    // hasMore=true → control present and wired.
+    renderList({ loading: false, rows: [makeRow("s-1", "Only")], hasMore: true, onLoadMore });
+    const btn = screen.getByText("Load more");
+    await user.click(btn);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("loadingMore disables the control and shows the loading label", () => {
+    renderList({
+      loading: false,
+      rows: [makeRow("s-1", "Only")],
+      hasMore: true,
+      loadingMore: true,
+    });
+    expect(screen.queryByText("Load more")).toBeNull();
+    const loading = screen.getByText("Loading more…");
+    expect(loading.closest("button")?.disabled).toBe(true);
   });
 });

--- a/src/components/agent-presence/chat/__tests__/daemon-chat-pagination.test.tsx
+++ b/src/components/agent-presence/chat/__tests__/daemon-chat-pagination.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+//
+// DaemonChat data-layer pagination (paginate-daemon-session-list). Asserts the chat modal
+// consumes the SERVER-PAGINATED /api/daemon-sessions endpoint rather than fetching the whole
+// history: on open it reads the agent INDEX (`?view=agents`) — never the bare full list — and
+// then the SELECTED agent's first PAGE (`?agentUuid=&limit=12`); the 15s poll refetches only
+// that first page. ConversationList/TranscriptView/etc are stubbed so this focuses purely on
+// the fetch orchestration.
+
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAuthFetch = vi.fn();
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+vi.mock("@/lib/auth-client", () => ({
+  authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+}));
+vi.mock("@/lib/logger-client", () => ({
+  clientLogger: { error: vi.fn() },
+}));
+
+// One online connection for agent-1 so the agent axis + default selection resolve.
+vi.mock("@/contexts/agent-presence-context", () => ({
+  useAgentPresence: () => ({
+    status: "ok",
+    connections: [
+      {
+        uuid: "conn-1",
+        agentUuid: "agent-1",
+        agentName: "Admin Claude",
+        effectiveStatus: "online",
+        host: "",
+      },
+    ],
+    executionsByConnection: new Map(),
+    setOpenSession: vi.fn(),
+    subscribeTranscript: vi.fn(() => vi.fn()),
+    focusTarget: null,
+    clearChatFocusTarget: vi.fn(),
+  }),
+}));
+
+vi.mock("../conversation-list", () => ({ ConversationList: () => <div /> }));
+vi.mock("../transcript-view", () => ({ TranscriptView: () => <div /> }));
+vi.mock("../new-conversation-pane", () => ({ NewConversationPane: () => <div /> }));
+vi.mock("../../daemon-connect-cta", () => ({ DaemonConnectCta: () => <div /> }));
+
+import { DaemonChat } from "../daemon-chat";
+
+const isIndex = (u: unknown) => String(u).includes("view=agents");
+const isPage = (u: unknown) => String(u).includes("agentUuid=");
+// The removed legacy behavior: a bare list fetch with NO query params.
+const isBareFullList = (u: unknown) => String(u) === "/api/daemon-sessions";
+
+function indexResp() {
+  return {
+    ok: true,
+    json: async () => ({
+      success: true,
+      data: {
+        agents: [
+          { agentUuid: "agent-1", lastTurnAt: "2026-08-30T12:00:00.000Z", sessionCount: 25 },
+        ],
+      },
+    }),
+  };
+}
+function pageResp() {
+  return {
+    ok: true,
+    json: async () => ({
+      success: true,
+      data: { sessions: [], nextCursor: null, hasMore: true },
+    }),
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  mockAuthFetch.mockImplementation((url: string) => {
+    if (isIndex(url)) return Promise.resolve(indexResp());
+    if (isPage(url)) return Promise.resolve(pageResp());
+    return Promise.resolve({ ok: true, json: async () => ({ success: true, data: {} }) });
+  });
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe("DaemonChat server-paginated list", () => {
+  it("on open reads the agent index and the selected agent's first page — never the bare full list", async () => {
+    const view = render(<DaemonChat />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const urls = mockAuthFetch.mock.calls.map(([u]) => String(u));
+    // Agent index fetched; bare full-list NEVER fetched.
+    expect(urls.some(isIndex)).toBe(true);
+    expect(urls.some(isBareFullList)).toBe(false);
+    // The default (most-recent) agent's FIRST page is fetched, bounded by limit=12.
+    const firstPage = urls.find(isPage);
+    expect(firstPage).toContain("agentUuid=agent-1");
+    expect(firstPage).toContain("limit=12");
+    // First page carries no cursor.
+    expect(firstPage).not.toContain("before=");
+
+    view.unmount();
+  });
+
+  it("the 15s poll refetches only the selected agent's first page (bounded, not the whole history)", async () => {
+    const view = render(<DaemonChat />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    const pageCallsAfterMount = mockAuthFetch.mock.calls.filter(([u]) => isPage(u)).length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+
+    const pageCallsAfterPoll = mockAuthFetch.mock.calls.filter(([u]) => isPage(u)).length;
+    expect(pageCallsAfterPoll).toBeGreaterThan(pageCallsAfterMount);
+    // Every page fetch is the bounded first page for the selected agent — never a full list.
+    for (const [u] of mockAuthFetch.mock.calls.filter(([x]) => isPage(x))) {
+      expect(String(u)).toContain("limit=12");
+    }
+    expect(mockAuthFetch.mock.calls.some(([u]) => isBareFullList(u))).toBe(false);
+
+    view.unmount();
+  });
+});

--- a/src/components/agent-presence/chat/__tests__/daemon-chat-request-coalescing.test.tsx
+++ b/src/components/agent-presence/chat/__tests__/daemon-chat-request-coalescing.test.tsx
@@ -72,14 +72,47 @@ vi.mock("../../daemon-connect-cta", () => ({
 
 import { DaemonChat } from "../daemon-chat";
 
-function successfulListResponse() {
+function agentIndexResponse() {
   return {
     ok: true,
-    json: async () => ({ success: true, data: { sessions: [] } }),
+    json: async () => ({
+      success: true,
+      data: {
+        agents: [
+          { agentUuid: "agent-1", lastTurnAt: "2026-08-30T12:00:00.000Z", sessionCount: 1 },
+        ],
+      },
+    }),
+  };
+}
+function pageResponse() {
+  return {
+    ok: true,
+    json: async () => ({
+      success: true,
+      data: { sessions: [], nextCursor: null, hasMore: false },
+    }),
+  };
+}
+function detailResponse() {
+  return {
+    ok: true,
+    json: async () => ({
+      success: true,
+      data: {
+        session: sessionSeed,
+        turns: [],
+        hasMore: false,
+        oldestTurnSeq: null,
+        oldestMsgSeq: null,
+      },
+    }),
   };
 }
 
-describe("DaemonChat session-list request coalescing", () => {
+const isIndexUrl = (u: unknown) => String(u).includes("view=agents");
+
+describe("DaemonChat agent-index request coalescing", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
@@ -98,55 +131,40 @@ describe("DaemonChat session-list request coalescing", () => {
     vi.useRealTimers();
   });
 
-  it("shares the mount/focus request, then allows a fresh 15-second refresh", async () => {
-    let resolveInitialList!: (value: ReturnType<typeof successfulListResponse>) => void;
-    const initialList = new Promise<ReturnType<typeof successfulListResponse>>((resolve) => {
-      resolveInitialList = resolve;
+  it("shares the mount/focus agent-index request, then allows a fresh 15-second refresh", async () => {
+    let resolveInitialIndex!: (value: ReturnType<typeof agentIndexResponse>) => void;
+    const initialIndex = new Promise<ReturnType<typeof agentIndexResponse>>((resolve) => {
+      resolveInitialIndex = resolve;
     });
 
     mockAuthFetch.mockImplementation((url: string) => {
-      if (url === "/api/daemon-sessions") {
-        const listCallCount = mockAuthFetch.mock.calls.filter(
-          ([calledUrl]) => calledUrl === "/api/daemon-sessions",
-        ).length;
-        return listCallCount === 1
-          ? initialList
-          : Promise.resolve(successfulListResponse());
+      if (isIndexUrl(url)) {
+        // The mount fetch + the focus-driven re-sync both call fetchAgentIndex; the second
+        // must COALESCE into the first in-flight request (one network call).
+        const indexCallCount = mockAuthFetch.mock.calls.filter(([u]) => isIndexUrl(u)).length;
+        return indexCallCount === 1 ? initialIndex : Promise.resolve(agentIndexResponse());
       }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({
-          success: true,
-          data: {
-            session: sessionSeed,
-            turns: [],
-            hasMore: false,
-            oldestTurnSeq: null,
-            oldestMsgSeq: null,
-          },
-        }),
-      });
+      if (String(url).includes("agentUuid=")) return Promise.resolve(pageResponse());
+      return Promise.resolve(detailResponse()); // /api/daemon-sessions/<uuid>
     });
 
     const view = render(<DaemonChat />);
 
     expect(mockClearChatFocusTarget).toHaveBeenCalledOnce();
-    expect(
-      mockAuthFetch.mock.calls.filter(([url]) => url === "/api/daemon-sessions"),
-    ).toHaveLength(1);
+    // Mount + focus-driven agent-index reads coalesced into a single network call.
+    expect(mockAuthFetch.mock.calls.filter(([url]) => isIndexUrl(url))).toHaveLength(1);
 
     await act(async () => {
-      resolveInitialList(successfulListResponse());
-      await initialList;
+      resolveInitialIndex(agentIndexResponse());
+      await initialIndex;
     });
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(15_000);
     });
 
-    expect(
-      mockAuthFetch.mock.calls.filter(([url]) => url === "/api/daemon-sessions"),
-    ).toHaveLength(2);
+    // The 15s poll issues a fresh agent-index read (coalescing cleared after settlement).
+    expect(mockAuthFetch.mock.calls.filter(([url]) => isIndexUrl(url))).toHaveLength(2);
 
     view.unmount();
   });

--- a/src/components/agent-presence/chat/conversation-list.tsx
+++ b/src/components/agent-presence/chat/conversation-list.tsx
@@ -188,7 +188,8 @@ export function ConversationList({
   selectedSessionUuid,
   onSelectSession,
   onNewConversation,
-  visibleCount,
+  hasMore,
+  loadingMore = false,
   onLoadMore,
   loading = false,
 }: {
@@ -204,9 +205,12 @@ export function ConversationList({
   // composer. Always offered (chat-app convention) so the user is never one-click
   // away from talking to the agent.
   onNewConversation: () => void;
-  // How many rows are currently revealed (the container owns the count + page size
-  // so it survives a re-render); "Load more" grows it.
-  visibleCount: number;
+  // Whether the server reports MORE (older) conversations beyond the loaded rows — drives
+  // the "Load more" control. The container owns the keyset cursor + page fetching; this
+  // pane just renders the already-loaded `rows` and asks for the next page on click.
+  hasMore: boolean;
+  // True while the next page is being fetched — disables the control + shows a loading label.
+  loadingMore?: boolean;
   onLoadMore: () => void;
   // True while the session list is still loading (first load / no data yet). Renders
   // skeleton placeholder rows INSTEAD of the empty state, so an in-flight load is never
@@ -218,8 +222,6 @@ export function ConversationList({
   const t = useTranslations("daemonChat");
   const nowMs = useNowTick();
 
-  const visibleRows = rows.slice(0, visibleCount);
-  const hasMore = rows.length > visibleCount;
   // The "New conversation" affordance is active only when an agent is selected and
   // nothing is selected yet (so the right pane is already the composer) — but it
   // remains visible always, just visually marked when it's the current view.
@@ -322,7 +324,7 @@ export function ConversationList({
           </div>
         ) : (
           <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-            {visibleRows.map((row, idx) => (
+            {rows.map((row, idx) => (
               <div key={row.session.uuid}>
                 <Row
                   row={row}
@@ -330,7 +332,7 @@ export function ConversationList({
                   onSelect={() => onSelectSession(row.session.uuid)}
                   nowMs={nowMs}
                 />
-                {idx < visibleRows.length - 1 && (
+                {idx < rows.length - 1 && (
                   <div className="h-px w-full bg-[#F2EEE7] dark:bg-[#201e1a]" />
                 )}
               </div>
@@ -341,9 +343,10 @@ export function ConversationList({
                   variant="ghost"
                   size="sm"
                   onClick={onLoadMore}
+                  disabled={loadingMore}
                   className="h-8 w-full rounded-lg text-[12px] font-medium text-primary hover:bg-[#FBF4EF] dark:hover:bg-[#26241f] hover:text-primary"
                 >
-                  {t("loadMore")}
+                  {loadingMore ? t("loadingMore") : t("loadMore")}
                 </Button>
               </div>
             )}

--- a/src/components/agent-presence/chat/daemon-chat.tsx
+++ b/src/components/agent-presence/chat/daemon-chat.tsx
@@ -40,6 +40,7 @@ import { useAgentPresence } from "@/contexts/agent-presence-context";
 import type { ExecutionView } from "../types";
 import type { SessionTarget } from "../send-instruction-box";
 import type {
+  AgentSessionIndexEntry,
   SessionDetailView,
   SessionView,
   TranscriptMessageView,
@@ -126,6 +127,23 @@ export function mergeTurnPage(
   return [...byUuid.values()].sort((a, b) => a.seq - b.seq);
 }
 
+// Union two conversation-row lists by session uuid, then sort newest-first by `lastTurnAt`.
+// Used to (a) preserve an optimistically-prepended (just-started) conversation when a fresh
+// server page for its agent lands, (b) fold the 15s poll's refreshed first page into the
+// already-loaded rows WITHOUT dropping older pages a user pulled via "Load more" (the
+// proposal-review note), and (c) append an older "Load more" page. When the same conversation
+// appears on both sides the INCOMING copy wins (it is fresher — newer originOnline / status /
+// lastTurnAt). Returns a NEW array.
+export function mergeSessionsById(
+  incoming: SessionTarget[],
+  existing: SessionTarget[],
+): SessionTarget[] {
+  const byUuid = new Map<string, SessionTarget>();
+  for (const s of existing) byUuid.set(s.uuid, s);
+  for (const s of incoming) byUuid.set(s.uuid, s); // incoming (fresher) wins on a uuid clash
+  return [...byUuid.values()].sort((a, b) => (a.lastTurnAt < b.lastTurnAt ? 1 : -1));
+}
+
 export function applyTranscriptEvent(
   turns: TurnWithMessagesView[],
   event: {
@@ -190,7 +208,7 @@ export function applyTranscriptEvent(
 // "loading"`) where nothing matched and the list fell through to its empty state, reading
 // as "no conversations" while the fetch was still in flight. Gating on `listStatus` closes
 // that window: during first load `listLoading` is true and the list pane renders its
-// skeleton. `fetchSessions` only ever sets `listStatus` to `"ok"` / `"error"` (never back
+// skeleton. `fetchAgentIndex` only ever sets `listStatus` to `"ok"` / `"error"` (never back
 // to `"loading"`), so the 15s background poll never re-raises the skeleton after first load.
 //
 // Precedence (unchanged from before, minus the removed top-level loading text branch):
@@ -231,50 +249,121 @@ export function DaemonChat() {
     clearChatFocusTarget,
   } = useAgentPresence();
 
-  // ===== Conversation list (GET /api/daemon-sessions) =====
+  // ===== Conversation list (server-paginated GET /api/daemon-sessions) =====
+  // The list is paginated per agent (the UI shows one agent at a time). Two reads back it:
+  //   - `?view=agents`  → the AGENT INDEX (cheap grouped aggregate) for the Select + default
+  //     agent. Fetched on mount + a 15s refresh; NO conversation rows.
+  //   - `?agentUuid=&limit=&before=` → one PAGE of the SELECTED agent's conversations. So we
+  //     never fetch more rows than we show (the fix: opening the modal no longer pulls the
+  //     caller's whole history).
+  // `sessions` therefore holds ONLY the SELECTED agent's loaded page(s) (+ live/optimistic
+  // rows), not every session.
+  const [agentIndex, setAgentIndex] = useState<AgentSessionIndexEntry[]>([]);
   const [sessions, setSessions] = useState<SessionTarget[]>([]);
+  // `listStatus` gates the first-load skeleton on the AGENT-INDEX fetch (the modal's first
+  // paint); `pageStatus` covers the selected agent's first PAGE fetch so switching agents
+  // shows a skeleton instead of an empty flash.
   const [listStatus, setListStatus] = useState<"loading" | "ok" | "error">(
     "loading",
   );
-  // Mount, seeded-focus, and timer refreshes can race. Keep one request per mounted chat
-  // in flight; clear it after settlement so the next 15s tick still reads fresh data.
-  const sessionsRequestRef = useRef<Promise<void> | null>(null);
-  const fetchSessions = useCallback((): Promise<void> => {
-    if (sessionsRequestRef.current) return sessionsRequestRef.current;
+  const [pageStatus, setPageStatus] = useState<"idle" | "loading" | "ok" | "error">(
+    "idle",
+  );
+  // The server keyset cursor for the SELECTED agent's next (older) page + whether more exist.
+  const [listCursor, setListCursor] = useState<string | null>(null);
+  const [listHasMore, setListHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
 
+  // Agent-index fetch — coalesced (one in flight per mounted chat) + refreshed every 15s, the
+  // same cadence/coalescing the old full-list fetch used.
+  const agentIndexRequestRef = useRef<Promise<void> | null>(null);
+  const fetchAgentIndex = useCallback((): Promise<void> => {
+    if (agentIndexRequestRef.current) return agentIndexRequestRef.current;
     const request = (async () => {
       try {
-        const res = await authFetch("/api/daemon-sessions");
+        const res = await authFetch("/api/daemon-sessions?view=agents");
         if (!res.ok) {
           setListStatus("error");
           return;
         }
         const json = await res.json();
         if (json.success) {
-          setSessions(json.data.sessions ?? []);
+          setAgentIndex(json.data.agents ?? []);
           setListStatus("ok");
         } else {
           setListStatus("error");
         }
       } catch (error) {
-        clientLogger.error("Failed to fetch daemon sessions:", error);
+        clientLogger.error("Failed to fetch daemon agent index:", error);
         setListStatus("error");
       }
     })();
-
-    sessionsRequestRef.current = request;
+    agentIndexRequestRef.current = request;
     void request.finally(() => {
-      if (sessionsRequestRef.current === request) {
-        sessionsRequestRef.current = null;
+      if (agentIndexRequestRef.current === request) {
+        agentIndexRequestRef.current = null;
       }
     });
     return request;
   }, []);
   useEffect(() => {
-    fetchSessions();
-    const id = setInterval(fetchSessions, 15_000);
+    fetchAgentIndex();
+    const id = setInterval(fetchAgentIndex, 15_000);
     return () => clearInterval(id);
-  }, [fetchSessions]);
+  }, [fetchAgentIndex]);
+
+  // Fetch the SELECTED agent's first page. A selection change bumps `pageReqRef` so a stale
+  // response can't overwrite the new agent's rows; a background merge-refresh (poll) reuses
+  // the current generation so it never invalidates an in-flight "Load more".
+  //  - fresh load (agent switch): MERGE the server page with any existing rows FOR THIS AGENT
+  //    (`prev.filter(agentUuid)`) so a just-started/seeded conversation not yet indexed
+  //    server-side survives, while a genuine switch (prev holds the OTHER agent's rows) is an
+  //    effective replace; reset the cursor to this page's.
+  //  - merge refresh (poll): union the refreshed first page into ALL loaded rows, keeping
+  //    older "Load more" pages, and DO NOT touch the cursor.
+  const pageReqRef = useRef(0);
+  const fetchFirstPage = useCallback(
+    async (agentUuid: string, opts?: { merge?: boolean }): Promise<void> => {
+      const reqId = opts?.merge ? pageReqRef.current : ++pageReqRef.current;
+      if (!opts?.merge) setPageStatus("loading");
+      try {
+        const res = await authFetch(
+          `/api/daemon-sessions?agentUuid=${encodeURIComponent(agentUuid)}&limit=${PAGE_SIZE}`,
+        );
+        if (reqId !== pageReqRef.current) return; // superseded by an agent switch
+        if (!res.ok) {
+          if (!opts?.merge) setPageStatus("error");
+          return;
+        }
+        const json = await res.json();
+        if (reqId !== pageReqRef.current) return;
+        if (json.success) {
+          const data = json.data as {
+            sessions: SessionTarget[];
+            nextCursor: string | null;
+            hasMore: boolean;
+          };
+          const page = data.sessions ?? [];
+          if (opts?.merge) {
+            setSessions((prev) => mergeSessionsById(page, prev));
+          } else {
+            setSessions((prev) =>
+              mergeSessionsById(page, prev.filter((s) => s.agentUuid === agentUuid)),
+            );
+            setListCursor(data.nextCursor);
+            setListHasMore(Boolean(data.hasMore));
+          }
+          setPageStatus("ok");
+        } else if (!opts?.merge) {
+          setPageStatus("error");
+        }
+      } catch (error) {
+        clientLogger.error("Failed to fetch daemon session page:", error);
+        if (!opts?.merge) setPageStatus("error");
+      }
+    },
+    [],
+  );
 
   // ===== Agent axis (agent-first) =====
   // Resolve a display name per agentUuid from the connection list (sessions carry
@@ -289,26 +378,23 @@ export function DaemonChat() {
     }
     const agentUuids = new Set<string>([
       ...connections.map((c) => c.agentUuid),
-      ...sessions.map((s) => s.agentUuid),
+      // Agents with history (possibly disconnected) come from the index, NOT the loaded
+      // per-agent rows — so the Select lists every agent even before its page is fetched.
+      ...agentIndex.map((a) => a.agentUuid),
     ]);
     return [...agentUuids].map((agentUuid) => ({
       agentUuid,
       agentName: names.get(agentUuid) ?? t("roleAgent"),
     }));
-  }, [connections, sessions, t]);
+  }, [connections, agentIndex, t]);
 
   // Default-select the agent with the most recent conversation so the modal never
-  // opens empty. Derived-then-pinned: the explicit selection wins when it still
-  // resolves, otherwise fall back to the most-recent agent.
+  // opens empty. The agent index is server-sorted by max `lastTurnAt` desc, so its first
+  // entry IS the most-recent agent — no row scan needed. Fall back to the first agent
+  // (e.g. a connected agent with no history yet).
   const mostRecentAgentUuid = useMemo(() => {
-    let best: { agentUuid: string; lastTurnAt: string } | null = null;
-    for (const s of sessions) {
-      if (!best || s.lastTurnAt > best.lastTurnAt) {
-        best = { agentUuid: s.agentUuid, lastTurnAt: s.lastTurnAt };
-      }
-    }
-    return best?.agentUuid ?? agents[0]?.agentUuid ?? null;
-  }, [sessions, agents]);
+    return agentIndex[0]?.agentUuid ?? agents[0]?.agentUuid ?? null;
+  }, [agentIndex, agents]);
 
   const [pickedAgentUuid, setPickedAgentUuid] = useState<string | null>(null);
   const selectedAgentUuid =
@@ -394,11 +480,65 @@ export function DaemonChat() {
       }));
   }, [sessions, selectedAgentUuid, executionsByConnection, conversationName]);
 
-  // Client-side pagination — reset to one page when the agent changes.
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  // Load the selected agent's FIRST page whenever the selection changes (server-side
+  // pagination replaces the old client-side slice). Clearing the selection empties the
+  // loaded rows + cursor.
   useEffect(() => {
-    setVisibleCount(PAGE_SIZE);
-  }, [selectedAgentUuid]);
+    if (!selectedAgentUuid) {
+      setSessions([]);
+      setListCursor(null);
+      setListHasMore(false);
+      setPageStatus("idle");
+      return;
+    }
+    fetchFirstPage(selectedAgentUuid);
+  }, [selectedAgentUuid, fetchFirstPage]);
+
+  // Poll ONLY the selected agent's first page every 15s — resettles `originOnline` and
+  // surfaces newly-started conversations at the top, merged (never replacing) so older
+  // "Load more" pages and optimistic rows are preserved. Bounded to one page, never the
+  // whole history.
+  useEffect(() => {
+    if (!selectedAgentUuid) return;
+    const id = setInterval(() => {
+      void fetchFirstPage(selectedAgentUuid, { merge: true });
+    }, 15_000);
+    return () => clearInterval(id);
+  }, [selectedAgentUuid, fetchFirstPage]);
+
+  // "Load more" — fetch the next (older) page via the server `before` cursor and append it,
+  // de-duplicated by uuid. Bound to the current agent generation so an agent switch
+  // mid-flight discards the stale append.
+  const loadMoreSessions = useCallback(async () => {
+    if (!selectedAgentUuid || loadingMore || !listHasMore || !listCursor) return;
+    const reqId = pageReqRef.current;
+    setLoadingMore(true);
+    try {
+      const res = await authFetch(
+        `/api/daemon-sessions?agentUuid=${encodeURIComponent(selectedAgentUuid)}&limit=${PAGE_SIZE}&before=${encodeURIComponent(listCursor)}`,
+      );
+      if (reqId !== pageReqRef.current) return; // agent switched mid-flight
+      if (!res.ok) return; // transient — the control stays available
+      const json = await res.json();
+      if (reqId !== pageReqRef.current) return;
+      if (json.success) {
+        const data = json.data as {
+          sessions: SessionTarget[];
+          nextCursor: string | null;
+          hasMore: boolean;
+        };
+        // Existing rows first (newer), then the older page — mergeSessionsById re-sorts by
+        // lastTurnAt desc and de-dupes by uuid.
+        setSessions((prev) => mergeSessionsById(prev, data.sessions ?? []));
+        setListCursor(data.nextCursor);
+        setListHasMore(Boolean(data.hasMore));
+      }
+    } catch (error) {
+      clientLogger.error("Failed to load more daemon sessions:", error);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [selectedAgentUuid, loadingMore, listHasMore, listCursor]);
 
   // ===== Selected conversation + its transcript (GET /api/daemon-sessions/[uuid]) =====
   const [selectedSessionUuid, setSelectedSessionUuid] = useState<string | null>(
@@ -746,7 +886,7 @@ export function DaemonChat() {
         // The session is pinned to a connection we just verified online (ad-hoc start) or
         // re-pointed to one (T12 re-point) — either way its origin is online right now.
         originOnline: true,
-        // Naming fields settle on the next fetchSessions() re-sync (the just-sent
+        // Naming fields settle on the next first-page re-sync (the just-sent
         // instruction becomes this conversation's firstInstruction server-side).
         firstInstruction: null,
         ideaTitle: null,
@@ -788,10 +928,14 @@ export function DaemonChat() {
           : prev,
       );
       setSelectedSessionUuid(created.uuid);
-      // Re-sync from the server in the background (authoritative ordering + fields).
-      fetchSessions();
+      // Refresh the agent index in the background so a brand-new agent (or a shifted
+      // most-recent) settles into the Select. Authoritative row ordering/fields for the
+      // conversation itself come from the selection-change first-page fetch (this created
+      // session's agent gets pinned right after) and the 15s merge-poll; the optimistic
+      // prepend/patch above already shows it immediately.
+      fetchAgentIndex();
     },
-    [fetchSessions],
+    [fetchAgentIndex],
   );
 
   // Consume a one-shot chat focus target: pin the left rail to the focused agent,
@@ -829,13 +973,23 @@ export function DaemonChat() {
   // helper (see its doc for the loading-vs-empty leak this fixes). The list pane shows a
   // skeleton whenever `listLoading` — gated on the LIST fetch status alone, NOT AND-ed with
   // the independently-settling presence `status`, so the empty state never shows mid-load.
+  // Whether the caller has ANY conversation history at all — the sum of the agent index's
+  // per-agent counts (cheap, from the index, NOT the loaded page). Drives the empty /
+  // no-agents states exactly as the old total-session count did, without loading rows.
+  const totalHistorySessions = useMemo(
+    () => agentIndex.reduce((n, a) => n + a.sessionCount, 0),
+    [agentIndex],
+  );
   const { body: bodyState, listLoading } = deriveChatBodyState({
     listStatus,
-    sessionCount: sessions.length,
+    sessionCount: totalHistorySessions,
     agentCount: agents.length,
   });
   const showListError = bodyState === "error";
   const noAgentsAtAll = bodyState === "no-agents";
+  // The conversation list shows its skeleton during the agent-index first load OR while the
+  // selected agent's first page is loading — so switching agents never flashes the empty state.
+  const conversationListLoading = listLoading || pageStatus === "loading";
 
   // The transcript pane is reused on both breakpoints, differing ONLY in the reply
   // composer's action-row geometry: desktop two-pane keeps it inline (actions on the
@@ -977,9 +1131,10 @@ export function DaemonChat() {
                   setMobileDetailOpen(true);
                 }}
                 onNewConversation={startNewConversation}
-                visibleCount={visibleCount}
-                onLoadMore={() => setVisibleCount((n) => n + PAGE_SIZE)}
-                loading={listLoading}
+                hasMore={listHasMore}
+                loadingMore={loadingMore}
+                onLoadMore={loadMoreSessions}
+                loading={conversationListLoading}
               />
             </div>
 
@@ -997,9 +1152,10 @@ export function DaemonChat() {
                   selectedSessionUuid={selectedSessionUuid}
                   onSelectSession={selectSession}
                   onNewConversation={startNewConversation}
-                  visibleCount={visibleCount}
-                  onLoadMore={() => setVisibleCount((n) => n + PAGE_SIZE)}
-                  loading={listLoading}
+                  hasMore={listHasMore}
+                  loadingMore={loadingMore}
+                  onLoadMore={loadMoreSessions}
+                  loading={conversationListLoading}
                 />
               </div>
 

--- a/src/services/__tests__/daemon-instruction.service.test.ts
+++ b/src/services/__tests__/daemon-instruction.service.test.ts
@@ -30,6 +30,7 @@ vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 const mockResolveOrCreateSession = vi.fn();
 const mockAssertContinuable = vi.fn();
 const mockGetVisibleSessions = vi.fn();
+const mockGetSessionsPageForAgent = vi.fn();
 const mockGetFirstInstruction = vi.fn();
 vi.mock("@/services/daemon-session.service", () => {
   // Defined inside the factory (hoisted with the mock) so the class is initialized
@@ -47,6 +48,7 @@ vi.mock("@/services/daemon-session.service", () => {
     resolveOrCreateSession: (...a: unknown[]) => mockResolveOrCreateSession(...a),
     assertContinuable: (...a: unknown[]) => mockAssertContinuable(...a),
     getVisibleSessions: (...a: unknown[]) => mockGetVisibleSessions(...a),
+    getSessionsPageForAgent: (...a: unknown[]) => mockGetSessionsPageForAgent(...a),
     getFirstInstructionBySessionUuid: (...a: unknown[]) => mockGetFirstInstruction(...a),
     SessionReadOnlyError,
     STALE_THRESHOLD_MS: 90_000,
@@ -98,6 +100,7 @@ import {
   createAdHocSessionWithInstruction,
   repointSessionOriginAndSend,
   getVisibleSessionsWithOrigin,
+  getVisibleSessionsPageWithOrigin,
 } from "@/services/daemon-instruction.service";
 // The mocked SessionReadOnlyError class (defined in the vi.mock factory above), imported
 // so the offline-origin test can construct + assert against the same class the SUT sees.
@@ -191,6 +194,7 @@ beforeEach(() => {
   mockConnectionBelongsToAgent.mockResolvedValue(true);
   mockIsConnectionLive.mockResolvedValue(true);
   mockGetVisibleSessions.mockResolvedValue([]);
+  mockGetSessionsPageForAgent.mockResolvedValue({ sessions: [], nextCursor: null, hasMore: false });
   // Naming enrichment helper defaults to "no opening instruction" unless a test wires it.
   mockGetFirstInstruction.mockResolvedValue(new Map());
 });
@@ -908,5 +912,70 @@ describe("getVisibleSessionsWithOrigin", () => {
     expect(out[0]).toHaveProperty("status");
     expect(out[0]).toHaveProperty("lastTurnAt");
     expect(out[0]).toHaveProperty("originOnline");
+  });
+});
+
+// ===== getVisibleSessionsPageWithOrigin (per-agent paginated + enriched) =====
+describe("getVisibleSessionsPageWithOrigin", () => {
+  it("unauthorized/unknown agent → empty page, WITHOUT paging or disclosing existence", async () => {
+    mockPrisma.agent.count.mockResolvedValue(0); // callerOwnsAgent → false for a user
+    const out = await getVisibleSessionsPageWithOrigin(userAuth, agentUuid, { limit: 12 });
+    expect(out).toEqual({ sessions: [], nextCursor: null, hasMore: false });
+    expect(mockGetSessionsPageForAgent).not.toHaveBeenCalled();
+    expect(mockPrisma.daemonConnection.findMany).not.toHaveBeenCalled();
+  });
+
+  it("authorized agent → enriches ONLY the page rows and passes through the cursor/hasMore", async () => {
+    mockPrisma.agent.count.mockResolvedValue(1); // owns the agent
+    mockGetSessionsPageForAgent.mockResolvedValue({
+      sessions: [
+        sessionView({ uuid: "s1", sessionId: "idea-9", directIdeaUuid: "idea-9" }),
+      ],
+      nextCursor: "s1",
+      hasMore: true,
+    });
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([
+      { uuid: connectionUuid, status: "online", lastSeenAt: new Date() },
+    ]);
+    mockPrisma.idea.findMany.mockResolvedValue([{ uuid: "idea-9", title: "Presence pill" }]);
+
+    const out = await getVisibleSessionsPageWithOrigin(userAuth, agentUuid, {
+      limit: 12,
+      before: "cursor-abc",
+    });
+
+    // The requested agent + pagination opts are forwarded verbatim to the raw pager.
+    expect(mockGetSessionsPageForAgent).toHaveBeenCalledWith(userAuth, agentUuid, {
+      limit: 12,
+      before: "cursor-abc",
+    });
+    expect(out.nextCursor).toBe("s1");
+    expect(out.hasMore).toBe(true);
+    expect(out.sessions).toHaveLength(1);
+    expect(out.sessions[0].originOnline).toBe(true);
+    expect(out.sessions[0].ideaTitle).toBe("Presence pill");
+    // Enrichment ran over the single page row only (one idea query for its one idea).
+    expect(mockPrisma.idea.findMany.mock.calls[0][0].where.uuid.in).toEqual(["idea-9"]);
+  });
+
+  it("empty page still returns the pager's cursor/hasMore, skipping enrichment", async () => {
+    mockPrisma.agent.count.mockResolvedValue(1);
+    mockGetSessionsPageForAgent.mockResolvedValue({ sessions: [], nextCursor: null, hasMore: false });
+    const out = await getVisibleSessionsPageWithOrigin(userAuth, agentUuid);
+    expect(out).toEqual({ sessions: [], nextCursor: null, hasMore: false });
+    // enrichSessions short-circuits on an empty page — no connection query.
+    expect(mockPrisma.daemonConnection.findMany).not.toHaveBeenCalled();
+  });
+
+  it("AGENT-KEY caller owns itself (no agent.count query needed)", async () => {
+    mockGetSessionsPageForAgent.mockResolvedValue({
+      sessions: [sessionView({ uuid: "s1", directIdeaUuid: null })],
+      nextCursor: null,
+      hasMore: false,
+    });
+    mockPrisma.daemonConnection.findMany.mockResolvedValue([]);
+    const out = await getVisibleSessionsPageWithOrigin(agentAuth, agentUuid);
+    expect(out.sessions).toHaveLength(1);
+    expect(mockPrisma.agent.count).not.toHaveBeenCalled(); // self-ownership is a uuid compare
   });
 });

--- a/src/services/__tests__/daemon-session.service.test.ts
+++ b/src/services/__tests__/daemon-session.service.test.ts
@@ -8,6 +8,7 @@ const mockPrisma = vi.hoisted(() => {
     findUnique: vi.fn(),
     findFirst: vi.fn(),
     findMany: vi.fn(),
+    groupBy: vi.fn(),
     update: vi.fn(),
     updateMany: vi.fn(),
     },
@@ -83,6 +84,10 @@ import {
   findReusablePendingInstructionTurn,
   advanceTurn,
   getVisibleSessions,
+  getVisibleAgentIndex,
+  getSessionsPageForAgent,
+  DEFAULT_SESSION_PAGE,
+  MAX_SESSION_PAGE,
   listVisibleRunningSessionActivities,
   getSessionTurns,
   getSessionDetail,
@@ -1004,6 +1009,126 @@ describe("getVisibleSessions", () => {
       getVisibleSessions({ type: "user", companyUuid, actorUuid: ownerUuid }),
     ).rejects.toThrow("db down");
     expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+});
+
+// ===== getVisibleAgentIndex (agent-index mode — grouped aggregate, no enrichment) =====
+const agentUuid2 = "agent-0000-0000-0000-000000000002";
+describe("getVisibleAgentIndex", () => {
+  it("groups by agentUuid with count + max(lastTurnAt), owner+company scoped, newest agent first, no reconcile", async () => {
+    mockPrisma.daemonSession.groupBy.mockResolvedValue([
+      { agentUuid, _count: { _all: 3 }, _max: { lastTurnAt: new Date("2026-06-15T05:00:00.000Z") } },
+      { agentUuid: agentUuid2, _count: { _all: 1 }, _max: { lastTurnAt: new Date("2026-06-15T02:00:00.000Z") } },
+    ]);
+    const result = await getVisibleAgentIndex({ type: "user", companyUuid, actorUuid: ownerUuid });
+    const arg = mockPrisma.daemonSession.groupBy.mock.calls[0][0];
+    expect(arg.by).toEqual(["agentUuid"]);
+    expect(arg.where).toEqual({ companyUuid, agent: { ownerUuid } });
+    expect(arg._count).toEqual({ _all: true });
+    expect(arg._max).toEqual({ lastTurnAt: true });
+    expect(arg.orderBy).toEqual({ _max: { lastTurnAt: "desc" } });
+    expect(result).toEqual([
+      { agentUuid, lastTurnAt: "2026-06-15T05:00:00.000Z", sessionCount: 3 },
+      { agentUuid: agentUuid2, lastTurnAt: "2026-06-15T02:00:00.000Z", sessionCount: 1 },
+    ]);
+    // Agent-index mode does NO orphan-turn reconcile (that probe query never runs).
+    expect(mockPrisma.daemonSessionTurn.findMany).not.toHaveBeenCalled();
+  });
+
+  it("AGENT-KEY caller is self-scoped via agentUuid", async () => {
+    mockPrisma.daemonSession.groupBy.mockResolvedValue([]);
+    await getVisibleAgentIndex({ type: "agent", companyUuid, actorUuid: agentUuid });
+    expect(mockPrisma.daemonSession.groupBy.mock.calls[0][0].where).toEqual({
+      companyUuid,
+      agentUuid,
+    });
+  });
+
+  it("PROPAGATES a query error (read, does NOT swallow)", async () => {
+    mockPrisma.daemonSession.groupBy.mockRejectedValue(new Error("db down"));
+    await expect(
+      getVisibleAgentIndex({ type: "user", companyUuid, actorUuid: ownerUuid }),
+    ).rejects.toThrow("db down");
+  });
+});
+
+// ===== getSessionsPageForAgent (per-agent keyset page) =====
+describe("getSessionsPageForAgent", () => {
+  it("first page (no cursor): default limit, newest-first, take=limit+1, narrowed to the agent + owner scope", async () => {
+    mockPrisma.daemonSession.findMany.mockResolvedValue([sessionRow()]);
+    const page = await getSessionsPageForAgent(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      agentUuid,
+    );
+    const arg = mockPrisma.daemonSession.findMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ companyUuid, agent: { ownerUuid }, agentUuid });
+    expect(arg.orderBy).toEqual([{ lastTurnAt: "desc" }, { uuid: "desc" }]);
+    expect(arg.take).toBe(DEFAULT_SESSION_PAGE + 1);
+    expect(arg.cursor).toBeUndefined();
+    expect(arg.skip).toBeUndefined();
+    expect(page.sessions).toHaveLength(1);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it("hasMore + nextCursor when the +1 sentinel row is returned (page trimmed to limit)", async () => {
+    const rows = Array.from({ length: 3 }, (_, i) =>
+      sessionRow({ uuid: `sess-page-${i}` }),
+    );
+    mockPrisma.daemonSession.findMany.mockResolvedValue(rows);
+    const page = await getSessionsPageForAgent(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      agentUuid,
+      { limit: 2 },
+    );
+    expect(mockPrisma.daemonSession.findMany.mock.calls[0][0].take).toBe(3);
+    expect(page.sessions.map((s) => s.uuid)).toEqual(["sess-page-0", "sess-page-1"]);
+    expect(page.hasMore).toBe(true);
+    expect(page.nextCursor).toBe("sess-page-1"); // last row OF THE PAGE, not the sentinel
+  });
+
+  it("clamps limit to 1..MAX_SESSION_PAGE and floors/ignores garbage", async () => {
+    mockPrisma.daemonSession.findMany.mockResolvedValue([]);
+    const auth = { type: "user", companyUuid, actorUuid: ownerUuid };
+    await getSessionsPageForAgent(auth, agentUuid, { limit: 9999 });
+    expect(mockPrisma.daemonSession.findMany.mock.calls[0][0].take).toBe(MAX_SESSION_PAGE + 1);
+    await getSessionsPageForAgent(auth, agentUuid, { limit: 0 });
+    expect(mockPrisma.daemonSession.findMany.mock.calls[1][0].take).toBe(1 + 1);
+    await getSessionsPageForAgent(auth, agentUuid, { limit: NaN });
+    expect(mockPrisma.daemonSession.findMany.mock.calls[2][0].take).toBe(DEFAULT_SESSION_PAGE + 1);
+  });
+
+  it("passes the keyset cursor (cursor:{uuid} + skip:1) when `before` is set", async () => {
+    mockPrisma.daemonSession.findMany.mockResolvedValue([]);
+    await getSessionsPageForAgent(
+      { type: "user", companyUuid, actorUuid: ownerUuid },
+      agentUuid,
+      { before: "sess-cursor-xyz" },
+    );
+    const arg = mockPrisma.daemonSession.findMany.mock.calls[0][0];
+    expect(arg.cursor).toEqual({ uuid: "sess-cursor-xyz" });
+    expect(arg.skip).toBe(1);
+  });
+
+  it("AGENT-KEY caller paging ANOTHER agent → empty page, NO query (non-disclosure)", async () => {
+    const page = await getSessionsPageForAgent(
+      { type: "agent", companyUuid, actorUuid: agentUuid },
+      agentUuid2,
+    );
+    expect(page).toEqual({ sessions: [], nextCursor: null, hasMore: false });
+    expect(mockPrisma.daemonSession.findMany).not.toHaveBeenCalled();
+  });
+
+  it("AGENT-KEY caller paging ITS OWN agent → self-scoped where (no key collision)", async () => {
+    mockPrisma.daemonSession.findMany.mockResolvedValue([]);
+    await getSessionsPageForAgent(
+      { type: "agent", companyUuid, actorUuid: agentUuid },
+      agentUuid,
+    );
+    expect(mockPrisma.daemonSession.findMany.mock.calls[0][0].where).toEqual({
+      companyUuid,
+      agentUuid,
+    });
   });
 });
 

--- a/src/services/daemon-instruction.service.ts
+++ b/src/services/daemon-instruction.service.ts
@@ -46,6 +46,7 @@ import {
   // that error is caught + mapped to 409 at the route layer, so it is not referenced here.
   assertContinuable,
   getVisibleSessions,
+  getSessionsPageForAgent,
   getFirstInstructionBySessionUuid,
   publishTranscriptEvent,
   STALE_THRESHOLD_MS,
@@ -1132,7 +1133,51 @@ async function callerOwnsAgent(
 export async function getVisibleSessionsWithOrigin(
   auth: { type: string; companyUuid: string; actorUuid: string },
 ): Promise<SessionTargetView[]> {
-  const sessions = await getVisibleSessions(auth);
+  return enrichSessions(auth, await getVisibleSessions(auth));
+}
+
+/**
+ * A page of a single agent's visible conversations, each enriched with `originOnline` +
+ * naming (the SAME shape as {@link getVisibleSessionsWithOrigin}), plus the keyset cursor
+ * (`nextCursor` / `hasMore`). Backs the chat modal's per-agent paginated list.
+ *
+ * The requested `agentUuid` is validated under the caller's scope via the existing
+ * `callerOwnsAgent` fence — an agent the caller may not see (not owned, or in another
+ * company) yields an EMPTY page, never another owner's rows and without disclosing whether
+ * that agent exists. The underlying `getSessionsPageForAgent` re-applies the owner/self
+ * fence in its own query (defense in depth) and reconciles ONLY the returned page, so
+ * enrichment here also runs over just that page — bounded by `limit`, not the full history.
+ */
+export async function getVisibleSessionsPageWithOrigin(
+  auth: { type: string; companyUuid: string; actorUuid: string },
+  agentUuid: string,
+  opts?: { limit?: number; before?: string | null },
+): Promise<{
+  sessions: SessionTargetView[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}> {
+  if (!(await callerOwnsAgent(auth, agentUuid))) {
+    return { sessions: [], nextCursor: null, hasMore: false };
+  }
+  const page = await getSessionsPageForAgent(auth, agentUuid, opts);
+  const sessions = await enrichSessions(auth, page.sessions);
+  return { sessions, nextCursor: page.nextCursor, hasMore: page.hasMore };
+}
+
+/**
+ * Enrich a set of session rows with the derived `originOnline` flag + naming fields
+ * (`firstInstruction`, `ideaTitle`). Extracted so the full-list and per-agent-page reads
+ * share one enrichment path. All lookups are batched (one query each) and the two naming
+ * reads run IN PARALLEL, so the added latency is O(1) round-trips in the SIZE OF THE INPUT
+ * PAGE regardless of total session count. `originOnline` uses the SAME staleness verdict
+ * `assertContinuable` enforces (`status === "online" && now - lastSeenAt <=
+ * STALE_THRESHOLD_MS`), single-sourced via the re-exported `STALE_THRESHOLD_MS`.
+ */
+async function enrichSessions(
+  auth: { type: string; companyUuid: string; actorUuid: string },
+  sessions: SessionView[],
+): Promise<SessionTargetView[]> {
   if (sessions.length === 0) return [];
 
   const connectionUuids = [...new Set(sessions.map((s) => s.originConnectionUuid))];

--- a/src/services/daemon-session.service.ts
+++ b/src/services/daemon-session.service.ts
@@ -1051,6 +1051,110 @@ export async function getVisibleSessions(auth: {
   return rows.map(toSessionView);
 }
 
+// ===== Owner-scoped PAGINATED reads (daemon session list pagination) =====
+//
+// The full-history `getVisibleSessions` above stays as the legacy (no-param) path. The
+// two reads below back the opt-in paginated modes of GET /api/daemon-sessions, so the
+// chat modal never fetches more session rows than it shows. Both keep the exact
+// owner/self + companyUuid fence of `getVisibleSessions`.
+
+// The chat modal's page size — one page of a single agent's conversations. Matches the
+// client's PAGE_SIZE so a first page fills the list exactly once.
+export const DEFAULT_SESSION_PAGE = 12;
+// Hard bound on a caller-supplied `limit`, so a crafted request can't ask for the whole
+// history back (defeating the point) or a pathological page.
+export const MAX_SESSION_PAGE = 100;
+
+function clampSessionLimit(limit: number | undefined): number {
+  if (limit === undefined || !Number.isFinite(limit)) return DEFAULT_SESSION_PAGE;
+  return Math.min(MAX_SESSION_PAGE, Math.max(1, Math.floor(limit)));
+}
+
+/** One entry of the agent index: an agent that has visible session history. */
+export interface AgentSessionIndexEntry {
+  agentUuid: string;
+  // Most recent conversation timestamp for this agent (ISO-8601) — lets the client pick
+  // a default-selected agent without loading any rows.
+  lastTurnAt: string;
+  // How many visible conversations this agent has.
+  sessionCount: number;
+}
+
+/** A page of a single agent's conversations, newest-first, with a keyset cursor. */
+export interface SessionPage {
+  sessions: SessionView[];
+  // Pass as `before` to fetch the next (older) page; null when none remain.
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+/**
+ * The agent axis for the chat modal's Select: every agent that has at least one visible
+ * session, with its most-recent `lastTurnAt` and visible `sessionCount`. A single grouped
+ * aggregate under the SAME owner/self + companyUuid fence as `getVisibleSessions` — NO
+ * per-session origin/naming enrichment and NO orphan-turn reconcile, so its cost scales
+ * with the number of distinct agents, not the total session count. A READ that does NOT
+ * swallow — a query failure propagates.
+ */
+export async function getVisibleAgentIndex(auth: {
+  type: string;
+  companyUuid: string;
+  actorUuid: string;
+}): Promise<AgentSessionIndexEntry[]> {
+  const groups = await prisma.daemonSession.groupBy({
+    by: ["agentUuid"],
+    where: { companyUuid: auth.companyUuid, ...ownerScope(auth) },
+    _count: { _all: true },
+    _max: { lastTurnAt: true },
+    orderBy: { _max: { lastTurnAt: "desc" } },
+  });
+  return groups.map((g) => ({
+    agentUuid: g.agentUuid,
+    // Every grouped agent has ≥1 session, so `_max.lastTurnAt` is always present; guard
+    // defensively rather than assert non-null.
+    lastTurnAt: (g._max.lastTurnAt ?? new Date(0)).toISOString(),
+    sessionCount: g._count._all,
+  }));
+}
+
+/**
+ * One page of a SINGLE agent's visible conversations, newest-first, keyset-paginated by
+ * a stable `(lastTurnAt desc, uuid desc)` order (mirrors `comment.service` cursor paging:
+ * `cursor` + `skip: 1` + `take: limit + 1` for the `hasMore` sentinel, no count query).
+ *
+ * Visibility: an AGENT key may only page ITS OWN sessions — a mismatch yields an empty
+ * page (non-disclosure), never another agent's rows. This explicit guard matters because
+ * for an agent caller `ownerScope` is the scalar `{ agentUuid: actorUuid }`, which the
+ * requested `agentUuid` would otherwise overwrite when merged into the same `where`
+ * object; the guard makes the merge safe (they are equal past this point). A USER /
+ * super_admin caller's `ownerScope` is the relation filter `{ agent: { ownerUuid } }` (a
+ * distinct key), so it AND-composes with `agentUuid` and never cross-owner leaks. A READ
+ * that does NOT swallow.
+ */
+export async function getSessionsPageForAgent(
+  auth: { type: string; companyUuid: string; actorUuid: string },
+  agentUuid: string,
+  opts?: { limit?: number; before?: string | null },
+): Promise<SessionPage> {
+  if (auth.type === "agent" && agentUuid !== auth.actorUuid) {
+    return { sessions: [], nextCursor: null, hasMore: false };
+  }
+  const limit = clampSessionLimit(opts?.limit);
+  const before = opts?.before ?? null;
+  const rows = await prisma.daemonSession.findMany({
+    where: { companyUuid: auth.companyUuid, ...ownerScope(auth), agentUuid },
+    orderBy: [{ lastTurnAt: "desc" }, { uuid: "desc" }],
+    ...(before ? { cursor: { uuid: before }, skip: 1 } : {}),
+    take: limit + 1,
+  });
+  const hasMore = rows.length > limit;
+  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+  const nextCursor = hasMore ? pageRows[pageRows.length - 1].uuid : null;
+  // Reconcile only the PAGE's origin connections — bounded, not the full history.
+  await reconcileOrphanTurnsForSessions(auth.companyUuid, pageRows);
+  return { sessions: pageRows.map(toSessionView), nextCursor, hasMore };
+}
+
 /**
  * Rebuild the caller-visible running activity set for company-stream bootstrap.
  * User subscribers observe every running session in their company and receive


### PR DESCRIPTION
## Summary
Opening the daemon chat modal was slow because `GET /api/daemon-sessions` returned the caller's **entire** session history on open (and re-fetched it every 15s), running per-row origin/naming enrichment + an orphan-turn reconcile over the whole set. This adds opt-in, backward-compatible server-side pagination and rewires the chat modal to use it, so the modal never fetches more session rows than it shows.

Fixes idea `460ea0d5` (Chorus 0.17.3). Scope is intentionally **network/payload only** — the owner's elaboration confirmed it's a load-time problem, not rendering — so virtualization / memoization / deferred markdown are explicitly out of scope. The transcript was already message-paginated.

## What changed
`GET /api/daemon-sessions` gains two opt-in query modes; the no-param response is unchanged:

| Query | Response | Notes |
|---|---|---|
| _(none)_ | `{ sessions }` | **Legacy full list, byte-identical** — connections-view + send box unaffected |
| `?view=agents` | `{ agents: {agentUuid, lastTurnAt, sessionCount}[] }` | Cheap `GROUP BY agentUuid`; no enrichment/reconcile; drives the Select + default agent |
| `?agentUuid=&limit=&before=` | `{ sessions, nextCursor, hasMore }` | Per-agent keyset page (newest-first); enrichment + reconcile scoped to the page |

Client (chat modal): agent index -> default select -> per-agent first page -> "Load more" via server cursor -> 15s poll refetches only the selected agent's first page, **merged** (preserves loaded pages + optimistically-prepended conversations). Live merges (`handleSessionStarted`, SSE) unchanged.

## Changed files
| File | Change |
|------|--------|
| `src/services/daemon-session.service.ts` | `getVisibleAgentIndex` (groupBy) + `getSessionsPageForAgent` (keyset page); `DEFAULT_SESSION_PAGE`/`MAX_SESSION_PAGE` |
| `src/services/daemon-instruction.service.ts` | extracted `enrichSessions`; new `getVisibleSessionsPageWithOrigin` (page-scoped enrichment + `callerOwnsAgent` fence) |
| `src/app/api/daemon-sessions/route.ts` | mode selection by query params |
| `src/components/agent-presence/chat/daemon-chat.tsx` | agent-index + per-agent page fetch, load-more cursor, 15s merge-poll, `mergeSessionsById` |
| `src/components/agent-presence/chat/conversation-list.tsx` | server-driven `hasMore`/`loadingMore`/`onLoadMore` (dropped the client `visibleCount` slice) |
| `messages/{en,zh,ja,ko}.json` | `daemonChat.loadingMore` |
| `openspec/**` | archived change `paginate-daemon-session-list` -> cumulative `daemon-session-conversation` spec |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] New/updated unit + component tests: service (three modes, cursor paging, limit clamp, hasMore sentinel, cross-owner non-disclosure), route (mode selection + legacy isolation), client (agent-index select, first page, load-more append/dedup, poll, `mergeSessionsById`)
- [x] Whole `src/` test suite passes; proposal-reviewer + 2 task-reviewers + code-review gateway all PASS (WITH NOTES)
- [ ] Note: repo has a pre-existing baseline of `cli/__tests__` failures (17) and `pnpm lint` problems, unrelated to this change (identical with `src/` stashed)

Generated with [Claude Code](https://claude.com/claude-code)