### PR TITLE
feat(daemon): wake carries the waker's session anchor (advisory, idea/theme-scoped)

### DIFF
--- a/cli/__tests__/prompts.test.mjs
+++ b/cli/__tests__/prompts.test.mjs
@@ -228,6 +228,53 @@ describe("buildBatchPrompt — human_instruction is NEVER collapsed", () => {
   });
 });
 
+describe("buildBatchPrompt — waker-session advisory anchor (T2, busy-worker batch)", () => {
+  // AC (proposal-reviewer flag): the advisory anchor must ALSO surface in the coalesced
+  // multi-wake path — the busy-worker scenario is exactly a batch. It is actor-scoped, so
+  // it rides each event's own block (not once at the top).
+  const WAKER_X = { agentUuid: "agent-x", agentName: "PeerX", ideaUuid: "idea-X" };
+  const WAKER_Y = { agentUuid: "agent-y", agentName: "PeerY", ideaUuid: "idea-Y" };
+
+  it("surfaces each event's own anchor per block; events without one carry no anchor", () => {
+    const withAnchor = mk({
+      action: "mentioned",
+      entityType: "idea",
+      entityUuid: "idea-X",
+      message: "@agent look",
+      wakerSession: WAKER_X,
+    });
+    const noAnchor = mk({ action: "task_assigned", entityUuid: "task-F", entityTitle: "F" });
+    const p = buildBatchPrompt([withAnchor, noAnchor]);
+
+    // both events render as blocks
+    expect(occurrences(p, "### Event ")).toBe(2);
+    // the anchor rides the block that carries it, naming its own waker
+    expect(p).toContain("@[PeerX](agent:agent-x)");
+    expect(p).toContain("has a live session open on this resource");
+    // exactly one anchor block — the no-anchor event contributes none
+    expect(occurrences(p, "has a live session open on this resource")).toBe(1);
+    // still advisory, not a routing guarantee
+    expect(p).toContain("advisory, not an");
+  });
+
+  it("renders a distinct per-wake anchor for each event that carries one", () => {
+    const a = mk({ action: "task_assigned", entityUuid: "task-A", wakerSession: WAKER_X });
+    const b = mk({
+      action: "mentioned",
+      entityType: "idea",
+      entityUuid: "idea-Y",
+      message: "@agent hi",
+      wakerSession: WAKER_Y,
+    });
+    const p = buildBatchPrompt([a, b]);
+    expect(p).toContain("@[PeerX](agent:agent-x)");
+    expect(p).toContain("@[PeerY](agent:agent-y)");
+    expect(occurrences(p, "has a live session open on this resource")).toBe(2);
+    // each anchor sits with its own event, in arrival order
+    expect(p.indexOf("@[PeerX](agent:agent-x)")).toBeLessThan(p.indexOf("@[PeerY](agent:agent-y)"));
+  });
+});
+
 describe("buildBatchPrompt — null-body events are omitted", () => {
   it("omits empty human_instruction events from a multi-event batch", () => {
     // AC: Events whose body is null (empty human_instruction) are omitted from the batch.

--- a/cli/__tests__/wake-orchestration.test.mjs
+++ b/cli/__tests__/wake-orchestration.test.mjs
@@ -110,6 +110,60 @@ describe("buildPrompt", () => {
     ).toBeNull();
   });
 
+  // --- Waker-session advisory anchor (wake-carry-waker-session-anchor, T2) ---
+  const WAKER = { agentUuid: "agent-waker", agentName: "Peer", ideaUuid: "idea-1" };
+
+  it("appends the waker-session advisory iff wakerSession is present, naming @[name](agent:uuid)", () => {
+    // absent → no anchor block
+    expect(buildPrompt(TASK_NOTIF)).not.toContain("has a live session open on this resource");
+    // present → advisory block naming the waker, with the not-a-route disclaimer
+    const p = buildPrompt({ ...TASK_NOTIF, wakerSession: WAKER });
+    expect(p).toContain("@[Peer](agent:agent-waker)");
+    expect(p).toContain("has a live session open on this resource");
+    // makes NO server-routing claim — states it is advisory, not an enforced route
+    expect(p).toContain("advisory, not an");
+    expect(p).toContain("enforced server route");
+    expect(p).toContain("there is no automatic subscription and nothing is force-delivered");
+  });
+
+  it("renders the anchor and orchestrator blocks independently (both/either/neither)", () => {
+    // both present → both render
+    const both = buildPrompt({
+      ...TASK_NOTIF,
+      orchestrator: { type: "agent", uuid: "agent-orchestrator", name: "Coordinator" },
+      wakerSession: WAKER,
+    });
+    expect(both).toContain("Your orchestrator for this resource is @Coordinator.");
+    expect(both).toContain("@[Peer](agent:agent-waker)");
+
+    // anchor only → orchestrator block absent
+    const anchorOnly = buildPrompt({ ...TASK_NOTIF, wakerSession: WAKER });
+    expect(anchorOnly).toContain("@[Peer](agent:agent-waker)");
+    expect(anchorOnly).not.toContain("Your orchestrator for this resource");
+
+    // orchestrator only → anchor block absent
+    const orchOnly = buildPrompt({
+      ...TASK_NOTIF,
+      orchestrator: { type: "agent", uuid: "agent-orchestrator", name: "Coordinator" },
+    });
+    expect(orchOnly).toContain("Your orchestrator for this resource is @Coordinator.");
+    expect(orchOnly).not.toContain("has a live session open on this resource");
+  });
+
+  it("keeps a null wake body null even when a wakerSession anchor is present (no anchor-only wake)", () => {
+    expect(
+      buildPrompt({ ...TASK_NOTIF, action: "unknown_action", wakerSession: WAKER }),
+    ).toBeNull();
+    expect(
+      buildPrompt({
+        ...TASK_NOTIF,
+        action: "human_instruction",
+        instructionText: "   ",
+        wakerSession: WAKER,
+      }),
+    ).toBeNull();
+  });
+
   it("comment_added does NOT wake (too noisy); only an explicit @mention does", () => {
     // A plain comment to the task's assignee/creator should be ignored...
     expect(buildPrompt({ ...TASK_NOTIF, action: "comment_added", message: "please rebase" })).toBeNull();

--- a/cli/prompts.mjs
+++ b/cli/prompts.mjs
@@ -26,6 +26,13 @@
  * @property {string} actorUuid
  * @property {string} actorName
  * @property {{type: string, uuid: string, name: string} | null} [orchestrator]
+ * @property {{agentUuid: string, agentName: string, ideaUuid: string} | null} [wakerSession]
+ *   Derived, NON-persisted waker-session anchor (wake-carry-waker-session-anchor, T1). Present
+ *   only for an agent-caused wake on an idea/task-anchored resource whose waking agent has a
+ *   live, ONLINE-origin session for that idea — it tells the woken peer that replying on this
+ *   resource reaches the waker's existing live session. A SIBLING of `orchestrator`
+ *   (actor-scoped vs assignment-scoped): either, both, or neither may be present. The server
+ *   supplies it on the `chorus_get_notifications` projection; the router threads it here.
  * @property {string} [instructionText]  Free-text body of a `human_instruction` wake
  *   (子1 — daemon-session-conversation). The server denormalizes the canonical turn
  *   promptText onto the wake notification so the daemon reads it in the
@@ -61,6 +68,37 @@ function orchestratorGuidance(n) {
     `@[${n.orchestrator.name}](agent:${n.orchestrator.uuid}) with the decision needed or completion ` +
     `evidence, then leave any human-gated resource pending and end the turn. Do not @mention the ` +
     `orchestrator for ordinary internal progress.`
+  );
+}
+
+/**
+ * Waker-session advisory, appended to a wake body whenever the notification carries a
+ * `wakerSession` anchor (wake-carry-waker-session-anchor, T2). It tells the woken peer WHERE
+ * the waking agent's live conversation is: replying by commenting on THIS resource lands the
+ * reply back in that agent's existing idea-anchored session, keeping the exchange on one
+ * thread instead of scattering into a fresh one.
+ *
+ * It is deliberately ADVISORY, not routing — the server surfaces the anchor only when it
+ * resolved a live, ONLINE-origin waker session (an offline/missing waker degrades to
+ * notify-only and the field is null); there is no automatic subscription and nothing is
+ * force-delivered. The wording must NOT promise a guaranteed channel.
+ *
+ * A SIBLING of `orchestratorGuidance`: independent, appended alongside it in buildPrompt, so
+ * either/both/neither may render on one wake and they may name different agents. Its OpenClaw
+ * twin is `buildWakerSessionGuidance` in packages/openclaw-plugin/src/event-router.ts —
+ * KEEP THE TWO WORDINGS IN SYNC.
+ * @param {NotificationDetail} n
+ */
+function wakerSessionGuidance(n) {
+  if (!n.wakerSession) return null;
+  const { agentName, agentUuid } = n.wakerSession;
+  return (
+    `@[${agentName}](agent:${agentUuid}) woke you and has a live session open on this ` +
+    `resource. If you reply by commenting on this same resource, your reply reaches that ` +
+    `agent's live session, keeping the exchange on one thread. This is advisory, not an ` +
+    `enforced server route — there is no automatic subscription and nothing is force-delivered; ` +
+    `replying here is simply where a reply lands via the normal return path. Prefer replying ` +
+    `on this resource over opening a new session.`
   );
 }
 
@@ -121,7 +159,12 @@ export function buildPrompt(n) {
   const body = buildPromptBody(n);
   if (body == null) return null;
   const handoff = orchestratorGuidance(n);
-  return `${HEADLESS_PREAMBLE}\n\n${body}${handoff ? `\n\n${handoff}` : ""}`;
+  const anchor = wakerSessionGuidance(n);
+  return (
+    `${HEADLESS_PREAMBLE}\n\n${body}` +
+    (handoff ? `\n\n${handoff}` : "") +
+    (anchor ? `\n\n${anchor}` : "")
+  );
 }
 
 /**
@@ -208,7 +251,14 @@ export function buildBatchPrompt(notifications) {
         ? `\n(${g.count} ${n.action} events on this ${entityType} arrived — showing the newest ` +
           `below; earlier ones are re-derivable via the entity's own chorus_get_* tools.)`
         : "";
-    return `${header}${collapseNote}\n\n${g.body}`;
+    // Per-wake waker-session advisory (wake-carry-waker-session-anchor, T2). The anchor is
+    // ACTOR-scoped, so it belongs to each event individually — different queued wakes may
+    // carry different (or no) waker sessions. Appending it only in buildPrompt would silently
+    // drop it in this coalesced busy-worker batch, the feature's core scenario; so surface it
+    // per block here too, keyed off the collapsed group's newest notification.
+    const anchor = wakerSessionGuidance(n);
+    const anchorBlock = anchor ? `\n\n${anchor}` : "";
+    return `${header}${collapseNote}\n\n${g.body}${anchorBlock}`;
   });
 
   return [HEADLESS_PREAMBLE, backlogPreamble, ...rendered].join("\n\n");

--- a/openspec/changes/archive/2026-09-07-wake-carry-waker-session-anchor/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-07-wake-carry-waker-session-anchor/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/archive/2026-09-07-wake-carry-waker-session-anchor/README.md
+++ b/openspec/changes/archive/2026-09-07-wake-carry-waker-session-anchor/README.md
@@ -1,0 +1,3 @@
+# wake-carry-waker-session-anchor
+
+Agent-originated wakes carry the waker agent's live session anchor so a woken peer can reply back into the waker's existing idea-anchored session instead of opening a new one (advisory, idea/theme-scoped)

--- a/openspec/changes/archive/2026-09-07-wake-carry-waker-session-anchor/design.md
+++ b/openspec/changes/archive/2026-09-07-wake-carry-waker-session-anchor/design.md
@@ -1,0 +1,165 @@
+# Design — wake-carry-waker-session-anchor
+
+## Context
+
+When an agent wakes a peer, the woken agent receives a Notification (read via
+`chorus_get_notifications`, which the daemon already calls) carrying the waker's
+identity (`actorType/actorUuid/actorName`) and — for idea/task resources with an
+agent assigner — a derived `orchestrator` attribution. Neither tells the woken
+agent **where the waker's live conversation is**, so a reply scatters or opens a
+new session. The landing substrate already exists: `DaemonSession` is idea-anchored
+(`sessionId === directIdeaUuid`, `prisma/schema.prisma:665-707`, no 1h auto-close),
+`resolveIdeaSessionOriginTarget` (`notification-turn.ts:676`) already maps
+`(agentUuid, ideaUuid) → online origin connection`, and un-pinned `@mention` returns
+already ride the upgraded `RESIDUAL_CWD_UPGRADE_TRIGGERS` ladder back onto that
+session. The only missing piece is **telling the woken agent the anchor is there**.
+
+## Goals / non-goals
+
+- **Goal:** an agent-originated, idea/task-anchored wake surfaces the waker's live
+  session anchor to the woken agent, advisory-only.
+- **Non-goal:** any new server routing, enforced return-routing, offline
+  queue/replay, ad-hoc (no shared idea) anchoring, or persisted state. All left to
+  sibling theme children.
+
+## Decisions (from elaboration round 1, `1dbbfac0`)
+
+| # | Decision | Realization |
+|---|----------|-------------|
+| 1 | Carry via the orchestrator-attribution mechanism, **no schema column** | Reuse the derived / non-persisted / read-projection / prompt-append machinery. See "Sibling field, not nested" below. |
+| 2 | Stamp on **all agent-originated wakes** | Actor-scoped resolution keyed on `actorType === "agent"`, over the idea/task resource keying the read projection already uses. |
+| 3 | Return path **advisory only** | Prompt wording only; `createTurnAndResolveTarget` routing ladder is untouched; return reply lands via the existing ladder. |
+| 4 | Waker offline → **notify-only** | Anchor is emitted only when the waker's idea-anchored session has an **online** origin connection; otherwise absent, and the prompt makes no live-session claim. |
+
+### Sibling field, not nested — a deliberate refinement of decision #1
+
+The elaboration answer was "extend the `orchestrator` attribution." Grounding shows
+`OrchestratorAttribution` (`orchestrator.service.ts:7` = `{ type:"agent", uuid, name }`)
+is **assignment-scoped** — derived by `resolveResourceOrchestrator` from the
+resource's `assignedByType/assignedByUuid`, and by contract (existing capability
+requirement) it reads only that resource's typed provenance. The waker anchor is
+**actor-scoped**: it must appear for *any* agent waker (e.g. a bare `@mention` with
+no assignment) and must be present even when `orchestrator` is absent, or identify a
+*different* agent than the orchestrator.
+
+So we honor the intent of #1 — reuse the exact derived / non-persisted / read-time /
+prompt-append plumbing, add no DB column — but implement the anchor as a **sibling**
+derived field `wakerSession` on `NotificationResponse`, not a sub-field of
+`OrchestratorAttribution`. `orchestrator` and `wakerSession` are independent: either,
+both, or neither may be present on a wake.
+
+## Data shape (no schema change)
+
+New transport-only type (derived, never persisted), added next to
+`OrchestratorAttribution`:
+
+```ts
+export interface WakerSessionAnchor {
+  agentUuid: string;   // the waking agent (= notification actorUuid)
+  agentName: string;   // resolved current display name (= actorName)
+  ideaUuid: string;    // the idea whose session the reply reaches (DaemonSession.sessionId)
+}
+```
+
+`NotificationResponse` (`notification.service.ts:67-93`) gains:
+
+```ts
+wakerSession: WakerSessionAnchor | null;   // sibling of `orchestrator`
+```
+
+`RawNotification` is unchanged (no new column). The `Notification` model is
+unchanged.
+
+## Resolution — read time, in `formatNotifications`
+
+`formatNotifications` (`notification.service.ts:157-195`) already batch-resolves
+`orchestrator` per idea/task resource. Add a parallel batch resolve for the anchor:
+
+1. **Which notifications qualify:** `actorType === "agent"` **and** the addressed
+   entity resolves to an idea anchor. Reuse the existing idea/task resource keying
+   (`notificationResourceKey`, `notification.service.ts:151-154`): an `idea` entity's
+   anchor is itself; a `task` entity's anchor is the task's own `ideaUuid` (the
+   resource's *direct* containing idea — a single lookup, **not** parent/container
+   lineage traversal). Comment-mention notifications already carry the comment's
+   target kind as `entityType` (`mention.service.ts:445-455`), so a comment-on-idea
+   wake is an `idea` notification and a comment-on-task wake is a `task` notification —
+   both covered. Proposal/document-addressed wakes are **out of V1** (they carry no
+   idea/task key today; matches the orchestrator projection's own scope).
+2. **Resolve the anchor** with a new helper `resolveWakerSessionAnchor(companyUuid,
+   agentUuid, ideaUuid)` modeled on `resolveIdeaSessionOriginTarget`
+   (`notification-turn.ts:676`): find the waker's `DaemonSession` where
+   `sessionId === ideaUuid`, then confirm its `originConnectionUuid` maps to a
+   connection whose `effectiveStatus === "online"` (reusing the connection-registry
+   liveness the target resolver already applies). Return the `WakerSessionAnchor`
+   only when online; else `null`.
+3. **Batch:** group distinct `(agentUuid, ideaUuid)` pairs and resolve in parallel,
+   exactly like the orchestrator map, so a page of notifications adds at most one
+   session lookup + one connection lookup per distinct waker/idea.
+4. **Exclusions:** user-actor wakes → no anchor; a waker with no idea-anchored
+   session or no online origin → no anchor; self-notifications never occur (the
+   notification listener already skips notifying the actor).
+
+No change to `createTurnAndResolveTarget` or the routing ladder — the anchor is a
+read-projection enrichment, identical in spirit to how `orchestrator` is merged.
+
+## Prompt surface — advisory, `cli/prompts.mjs`
+
+`buildPrompt(n)` (`cli/prompts.mjs:120-125`) assembles
+`HEADLESS_PREAMBLE + body + orchestratorGuidance(n)`. Add a sibling
+`wakerSessionGuidance(n)` appended alongside `orchestratorGuidance`:
+
+- Returns `null` unless `n.wakerSession` is present.
+- Emits one advisory block naming `@[${n.wakerSession.agentName}](agent:${n.wakerSession.agentUuid})`
+  and stating that **replying on this resource reaches that agent's live session**
+  rather than opening a new one — with an explicit "this is where a reply lands, not
+  an enforced route" framing (no server-routing claim).
+- Independent of `orchestratorGuidance`: both may render on the same wake; a null
+  action body stays null (anchor guidance never creates a preamble-only wake).
+- Update the `NotificationDetail` typedef (`cli/prompts.mjs:19-34`) with the
+  `wakerSession` field.
+
+**Keep the OpenClaw twin in sync:** `packages/openclaw-plugin/src/event-router.ts`
+carries `buildOrchestratorGuidance` (the OpenClaw port of `orchestratorGuidance`) and
+its own NotificationResponse-equivalent type. Add the matching `wakerSession` field +
+guidance there with identical wording, per the `plugin-maintenance` sync rule.
+
+## Skill contract — `chorus:orchestrate`
+
+Document the "reply-here-reaches-the-waker" semantics and the offline notify-only
+boundary in the orchestrate skill body, across every plugin surface that carries it
+(`public/skill/orchestrate-chorus/SKILL.md`, `public/chorus-plugin/skills/orchestrate/SKILL.md`,
+and the ports kept in sync by `plugin-maintenance`). This is guidance only — it must
+not imply an automatic server subscription or enforced routing.
+
+## Module contracts (cross-task)
+
+- **Anchor type + resolver** (T1) is the shared contract T2 and T4 consume:
+  `WakerSessionAnchor` shape above, `wakerSession: WakerSessionAnchor | null` on
+  `NotificationResponse`, emitted only when the waker's origin is online.
+- **Prompt block** (T2) reads only `n.wakerSession`; it must render the advisory
+  line iff the field is present, with no routing claim, and never on a null body.
+
+## Risks & mitigations
+
+- **Read-time cost:** one extra session + connection lookup per distinct waker/idea
+  in a notifications page. Mitigation: batch by distinct pair, mirroring the existing
+  orchestrator batch; negligible for typical page sizes.
+- **Staleness between read and reply:** the anchor reflects liveness at read time; the
+  waker could go offline before the reply. Acceptable — the return path already
+  degrades to the existing ladder / notify-only; the advisory wording promises a
+  landing, not a guarantee.
+- **CC / OpenClaw prompt drift:** the two guidance builders must stay in sync
+  (existing hazard for `orchestratorGuidance`). Mitigation: T2 updates both and the
+  `plugin-maintenance` skill enforces parity.
+- **Scope creep to ad-hoc / proposal-document wakes:** explicitly deferred; the
+  resolver keys only on the idea/task projection already in place.
+
+## Verification
+
+- **Unit:** anchor resolver (online → anchor, offline/no-session/user-actor → null,
+  no lineage climb) and `formatNotifications` wiring; prompt builder (block iff field,
+  coexists with orchestrator, null body stays null) on both CC and OpenClaw twins.
+- **Integration + live e2e (acceptance gate):** a real agent-originated wake yields a
+  `NotificationResponse` carrying the anchor and a rendered advisory line; a live
+  Claude + Codex daemon run proves a peer wake → reply lands in the original waker
+  session (not a new one), and an offline waker degrades to notify-only.

--- a/openspec/changes/archive/2026-09-07-wake-carry-waker-session-anchor/proposal.md
+++ b/openspec/changes/archive/2026-09-07-wake-carry-waker-session-anchor/proposal.md
@@ -1,0 +1,77 @@
+## Why
+
+When one agent wakes another (an orchestrator dispatching a worker, or any agent
+`@mention`-ing a peer), the wake payload carries the waker's **identity**
+(`actorType/actorUuid/actorName`, plus the derived assignment `orchestrator`) but
+**no pointer to the waker's live session**. Nothing tells the woken agent that
+replying *here* — on this idea/task/resource — lands back in the waker's existing
+conversation. So a woken peer's reply tends to scatter or open a brand-new
+session, and agent-to-agent collaboration loses its anchor. The substrate to land
+a reply back already exists (idea-anchored `DaemonSession` +
+`resolveIdeaSessionOriginTarget` + the `RESIDUAL_CWD_UPGRADE_TRIGGERS` return
+ladder); what is missing is that the woken agent is never *told* the anchor is
+there.
+
+This is the owner's #1 slice of the "multi-agent orchestration reliability" theme
+(`f10eeb04`), deliberately scoped down: **surface the anchor, do not build new
+routing.**
+
+## What Changes
+
+- For **agent-originated** wakes on an **idea/theme-anchored** resource, the wake
+  payload gains a derived, **non-persisted** `wakerSession` anchor: the waker
+  agent's current live session for that idea (its `DaemonSession` + whether its
+  origin connection is online). It is resolved at wake-serialize time from the
+  existing session/connection state — **no schema column, no new DB writes** —
+  reusing the same derivation + serialization + prompt-append machinery that
+  already carries the `orchestrator` attribution.
+- The daemon **wake prompt** gains one advisory line whenever a live
+  `wakerSession` anchor is present: it names the waker (`@[Name](agent:uuid)`) and
+  states that replying on *this* resource reaches the waker's live session rather
+  than opening a new one. This is **advisory only** — it changes no server
+  routing; the return reply still lands via the existing return ladder.
+- When the waker's origin is **offline** at wake time, no live anchor is
+  emitted (notify-only; the prompt makes no stale "live session" claim). This is
+  the accepted V1 boundary.
+- The `chorus:orchestrate` skill documents the "reply-here-reaches-the-waker"
+  semantics so workers know the anchor exists and how it behaves.
+
+Scope is bounded to wakes that share an idea/theme key. **Out of scope (left to
+sibling theme children):** ad-hoc peer anchoring with no shared idea; a durable
+theme-level orchestrator-handle subsystem; enforced return-routing; offline
+queue/replay; single-active-per-theme; the DAG auto-advancer.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+
+- `agent-orchestrator-handoff`: extend wake attribution and the daemon prompt so
+  that, in addition to the assignment-derived `orchestrator`, an **agent-originated,
+  idea/theme-anchored** wake also carries the **waker's live session anchor** and
+  the prompt restates the advisory "reply here reaches the waker's live session"
+  guidance. (The anchor is **actor-scoped** — emitted for any agent waker, not
+  only an assignment orchestrator — so it is a sibling of `orchestrator`, not a
+  sub-field, and it inherits the same "read only the addressed resource, never
+  traverse lineage" discipline.)
+- `multi-agent-orchestration`: the `chorus:orchestrate` skill documents that a
+  worker woken by an agent can reply on the shared resource to reach the waker's
+  live session, and the offline (notify-only) boundary.
+
+## Impact
+
+- **Server** (`src/services/`): the orchestrator/attribution resolver and the
+  wake-serialization path in the notification-turn flow — compute and attach the
+  derived `wakerSession` anchor; the `NotificationResponse` payload type gains an
+  optional `wakerSession` field.
+- **Daemon prompt** (`cli/prompts.mjs`): append the advisory anchor line when a
+  live `wakerSession` is present.
+- **Skill docs**: `chorus:orchestrate` skill body across every plugin surface
+  that carries it.
+- **No** schema/migration, **no** new endpoint, **no** change to return-wake
+  routing precedence.
+- **Verification**: unit + integration coverage of the attribution/prompt path,
+  plus a live Claude + Codex daemon e2e (peer wake → reply lands in the original
+  waker session) as the human acceptance gate.

--- a/openspec/changes/archive/2026-09-07-wake-carry-waker-session-anchor/specs/agent-orchestrator-handoff/spec.md
+++ b/openspec/changes/archive/2026-09-07-wake-carry-waker-session-anchor/specs/agent-orchestrator-handoff/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Agent-originated idea/theme wakes SHALL carry the waker's live session anchor
+
+The server SHALL enrich an **agent**-caused daemon wake for a directly addressed
+Idea or Task with a derived `wakerSession` anchor identifying the waking agent's
+current live session for that Idea, so a woken peer can be told where a reply
+lands. The anchor SHALL be **derived at
+serialization time** from existing session and connection state and SHALL NOT be
+persisted (no schema column, no write). The anchor is **actor-scoped**: it
+identifies the wake's agent actor and MUST be emitted independently of whether the
+resource also has an assignment-derived `orchestrator` (the two are separate
+fields and MAY both be present, absent, or identify different agents). Resolution
+MUST read only the addressed resource's own idea anchor (its `directIdeaUuid`) and
+MUST NOT traverse Idea lineage, parent/container Ideas, Proposals, Documents, or
+root-Idea ancestry. The anchor SHALL be emitted only when the waking agent has a
+live session for that Idea whose origin connection is currently online; otherwise
+it SHALL be absent. A wake caused by a **user** actor SHALL NOT carry a
+`wakerSession` anchor.
+
+#### Scenario: Agent @mention wake carries the waker's live session anchor
+
+- **GIVEN** agent A has a live, online-origin session anchored on Idea I
+- **WHEN** agent A wakes agent B by mentioning B on Idea I (or a task/comment anchored on I)
+- **THEN** the wake payload for B SHALL include a `wakerSession` anchor identifying agent A's live session for Idea I
+- **AND** the notification actor SHALL remain agent A unchanged
+
+#### Scenario: Anchor is emitted without an assignment orchestrator
+
+- **GIVEN** Idea I has no agent assignment provenance, so no `orchestrator` is derived
+- **AND** agent A has a live, online-origin session on Idea I
+- **WHEN** agent A wakes agent B on Idea I
+- **THEN** the wake payload SHALL still include a `wakerSession` anchor for agent A
+- **AND** `orchestrator` SHALL remain absent
+
+#### Scenario: Offline waker origin emits no anchor
+
+- **GIVEN** agent A's session for Idea I has no currently-online origin connection
+- **WHEN** agent A wakes agent B on Idea I
+- **THEN** the wake payload SHALL NOT include a `wakerSession` anchor
+- **AND** delivery SHALL fall back to the existing notify-only behavior
+
+#### Scenario: User-caused wake carries no anchor
+
+- **WHEN** a wake for an Idea or Task is caused by a user actor
+- **THEN** the wake payload SHALL NOT include a `wakerSession` anchor
+
+#### Scenario: Anchor resolution does not traverse lineage
+
+- **GIVEN** a child Idea C with no waker session and a parent Idea P on which the waking agent has a live session
+- **WHEN** an agent wake is built for child Idea C
+- **THEN** no `wakerSession` anchor SHALL be emitted
+- **AND** the server MUST NOT traverse to the parent Idea
+
+### Requirement: The daemon prompt SHALL restate the waker session anchor as advisory return guidance
+
+The daemon prompt builder SHALL append an advisory block whenever a wake payload
+carries a live `wakerSession` anchor. The block SHALL name the waking agent with
+its `@[Name](agent:uuid)` mention and SHALL state that replying on the current
+resource reaches the waker's existing live session rather than opening a new one.
+The block is **advisory**: it SHALL NOT assert any server-enforced routing and the
+return reply SHALL continue to resolve through the existing return path. The block
+SHALL be independent of the existing orchestrator block — either, both, or neither
+MAY appear on the same wake. A null action body MUST remain null (anchor
+enrichment MUST NOT create a preamble-only or anchor-only wake). When no live
+`wakerSession` anchor is present, no anchor block SHALL be appended.
+
+#### Scenario: Wake with a live anchor gets the advisory return line
+
+- **GIVEN** a wake payload for agent B carrying a `wakerSession` anchor for agent A
+- **WHEN** the daemon builds the prompt
+- **THEN** the prompt SHALL include a block naming `@[A](agent:<A uuid>)` and stating that a reply on this resource reaches A's live session
+- **AND** the block SHALL NOT claim any automatic server routing
+
+#### Scenario: Anchor block and orchestrator block coexist
+
+- **GIVEN** a wake payload carrying both an `orchestrator` (agent O) and a `wakerSession` anchor (agent A)
+- **WHEN** the prompt is built
+- **THEN** the orchestrator handoff block for O SHALL be present
+- **AND** the separate waker-session advisory block for A SHALL also be present
+
+#### Scenario: No anchor means no anchor block
+
+- **WHEN** a wake payload has no `wakerSession` anchor (user actor, offline waker, or non-anchored resource)
+- **THEN** no waker-session advisory block SHALL be appended
+
+#### Scenario: Null body remains null
+
+- **WHEN** an unknown action or blank `human_instruction` produces a null body
+- **THEN** waker-session anchor enrichment MUST NOT create a preamble-only or anchor-only wake

--- a/openspec/specs/agent-orchestrator-handoff/spec.md
+++ b/openspec/specs/agent-orchestrator-handoff/spec.md
@@ -159,3 +159,93 @@ automatic server subscription.
 
 - **WHEN** a worker advances an ordinary internal implementation step with no gate or completion
 - **THEN** workflow guidance SHALL NOT require an orchestrator mention
+
+### Requirement: Agent-originated idea/theme wakes SHALL carry the waker's live session anchor
+
+The server SHALL enrich an **agent**-caused daemon wake for a directly addressed
+Idea or Task with a derived `wakerSession` anchor identifying the waking agent's
+current live session for that Idea, so a woken peer can be told where a reply
+lands. The anchor SHALL be **derived at
+serialization time** from existing session and connection state and SHALL NOT be
+persisted (no schema column, no write). The anchor is **actor-scoped**: it
+identifies the wake's agent actor and MUST be emitted independently of whether the
+resource also has an assignment-derived `orchestrator` (the two are separate
+fields and MAY both be present, absent, or identify different agents). Resolution
+MUST read only the addressed resource's own idea anchor (its `directIdeaUuid`) and
+MUST NOT traverse Idea lineage, parent/container Ideas, Proposals, Documents, or
+root-Idea ancestry. The anchor SHALL be emitted only when the waking agent has a
+live session for that Idea whose origin connection is currently online; otherwise
+it SHALL be absent. A wake caused by a **user** actor SHALL NOT carry a
+`wakerSession` anchor.
+
+#### Scenario: Agent @mention wake carries the waker's live session anchor
+
+- **GIVEN** agent A has a live, online-origin session anchored on Idea I
+- **WHEN** agent A wakes agent B by mentioning B on Idea I (or a task/comment anchored on I)
+- **THEN** the wake payload for B SHALL include a `wakerSession` anchor identifying agent A's live session for Idea I
+- **AND** the notification actor SHALL remain agent A unchanged
+
+#### Scenario: Anchor is emitted without an assignment orchestrator
+
+- **GIVEN** Idea I has no agent assignment provenance, so no `orchestrator` is derived
+- **AND** agent A has a live, online-origin session on Idea I
+- **WHEN** agent A wakes agent B on Idea I
+- **THEN** the wake payload SHALL still include a `wakerSession` anchor for agent A
+- **AND** `orchestrator` SHALL remain absent
+
+#### Scenario: Offline waker origin emits no anchor
+
+- **GIVEN** agent A's session for Idea I has no currently-online origin connection
+- **WHEN** agent A wakes agent B on Idea I
+- **THEN** the wake payload SHALL NOT include a `wakerSession` anchor
+- **AND** delivery SHALL fall back to the existing notify-only behavior
+
+#### Scenario: User-caused wake carries no anchor
+
+- **WHEN** a wake for an Idea or Task is caused by a user actor
+- **THEN** the wake payload SHALL NOT include a `wakerSession` anchor
+
+#### Scenario: Anchor resolution does not traverse lineage
+
+- **GIVEN** a child Idea C with no waker session and a parent Idea P on which the waking agent has a live session
+- **WHEN** an agent wake is built for child Idea C
+- **THEN** no `wakerSession` anchor SHALL be emitted
+- **AND** the server MUST NOT traverse to the parent Idea
+
+### Requirement: The daemon prompt SHALL restate the waker session anchor as advisory return guidance
+
+The daemon prompt builder SHALL append an advisory block whenever a wake payload
+carries a live `wakerSession` anchor. The block SHALL name the waking agent with
+its `@[Name](agent:uuid)` mention and SHALL state that replying on the current
+resource reaches the waker's existing live session rather than opening a new one.
+The block is **advisory**: it SHALL NOT assert any server-enforced routing and the
+return reply SHALL continue to resolve through the existing return path. The block
+SHALL be independent of the existing orchestrator block — either, both, or neither
+MAY appear on the same wake. A null action body MUST remain null (anchor
+enrichment MUST NOT create a preamble-only or anchor-only wake). When no live
+`wakerSession` anchor is present, no anchor block SHALL be appended.
+
+#### Scenario: Wake with a live anchor gets the advisory return line
+
+- **GIVEN** a wake payload for agent B carrying a `wakerSession` anchor for agent A
+- **WHEN** the daemon builds the prompt
+- **THEN** the prompt SHALL include a block naming `@[A](agent:<A uuid>)` and stating that a reply on this resource reaches A's live session
+- **AND** the block SHALL NOT claim any automatic server routing
+
+#### Scenario: Anchor block and orchestrator block coexist
+
+- **GIVEN** a wake payload carrying both an `orchestrator` (agent O) and a `wakerSession` anchor (agent A)
+- **WHEN** the prompt is built
+- **THEN** the orchestrator handoff block for O SHALL be present
+- **AND** the separate waker-session advisory block for A SHALL also be present
+
+#### Scenario: No anchor means no anchor block
+
+- **WHEN** a wake payload has no `wakerSession` anchor (user actor, offline waker, or non-anchored resource)
+- **THEN** no waker-session advisory block SHALL be appended
+
+#### Scenario: Null body remains null
+
+- **WHEN** an unknown action or blank `human_instruction` produces a null body
+- **THEN** waker-session anchor enrichment MUST NOT create a preamble-only or anchor-only wake
+

--- a/packages/chorus-dsh/skills/orchestrate-chorus/SKILL.md
+++ b/packages/chorus-dsh/skills/orchestrate-chorus/SKILL.md
@@ -106,6 +106,14 @@ Guidance: start narrow. If a single owner can hold the whole feature in their he
 
 ---
 
+## Replying to the agent who woke you (advisory)
+
+When an agent wakes a peer on a shared idea or task — an orchestrator dispatching a worker, or any agent `@mention`-ing another — the wake surfaces the **waker's live session anchor**: a note naming the waking agent and telling the woken peer that the waker has an open conversation on this idea. If you are the woken peer, **reply on the same idea/task resource** (comment there rather than opening a brand-new session) and your reply lands back in the waker's existing live session, keeping the collaboration on one thread instead of scattering into a fresh one.
+
+This is **advisory, not routing.** There is no automatic server subscription and nothing is force-delivered — replying on the shared resource is simply *where a reply lands* (via the existing return path), not a guaranteed channel. When the waker's origin is **offline** at wake time, no live anchor is surfaced and the exchange degrades to **notify-only**: the reply reaches the waker as an ordinary notification it picks up on its next turn. Only idea/theme-anchored wakes carry this anchor; ad-hoc wakes with no shared idea do not.
+
+---
+
 ## Reversed-Conversation gates (you never auto-ship)
 
 Chorus is **AI proposes, humans verify**. As orchestrator you enforce that, you do not bypass it:

--- a/packages/chorus-pi/skills/orchestrate/SKILL.md
+++ b/packages/chorus-pi/skills/orchestrate/SKILL.md
@@ -104,6 +104,14 @@ Guidance: start narrow. If a single owner can hold the whole feature in their he
 
 ---
 
+## Replying to the agent who woke you (advisory)
+
+When an agent wakes a peer on a shared idea or task — an orchestrator dispatching a worker, or any agent `@mention`-ing another — the wake surfaces the **waker's live session anchor**: a note naming the waking agent and telling the woken peer that the waker has an open conversation on this idea. If you are the woken peer, **reply on the same idea/task resource** (comment there rather than opening a brand-new session) and your reply lands back in the waker's existing live session, keeping the collaboration on one thread instead of scattering into a fresh one.
+
+This is **advisory, not routing.** There is no automatic server subscription and nothing is force-delivered — replying on the shared resource is simply *where a reply lands* (via the existing return path), not a guaranteed channel. When the waker's origin is **offline** at wake time, no live anchor is surfaced and the exchange degrades to **notify-only**: the reply reaches the waker as an ordinary notification it picks up on its next turn. Only idea/theme-anchored wakes carry this anchor; ad-hoc wakes with no shared idea do not.
+
+---
+
 ## Reversed-Conversation gates (you never auto-ship)
 
 Chorus is **AI proposes, humans verify**. As orchestrator you enforce that, you do not bypass it:

--- a/packages/openclaw-plugin/skills/orchestrate/SKILL.md
+++ b/packages/openclaw-plugin/skills/orchestrate/SKILL.md
@@ -106,6 +106,14 @@ Guidance: start narrow. If a single owner can hold the whole feature in their he
 
 ---
 
+## Replying to the agent who woke you (advisory)
+
+When an agent wakes a peer on a shared idea or task — an orchestrator dispatching a worker, or any agent `@mention`-ing another — the wake surfaces the **waker's live session anchor**: a note naming the waking agent and telling the woken peer that the waker has an open conversation on this idea. If you are the woken peer, **reply on the same idea/task resource** (comment there rather than opening a brand-new session) and your reply lands back in the waker's existing live session, keeping the collaboration on one thread instead of scattering into a fresh one.
+
+This is **advisory, not routing.** There is no automatic server subscription and nothing is force-delivered — replying on the shared resource is simply *where a reply lands* (via the existing return path), not a guaranteed channel. When the waker's origin is **offline** at wake time, no live anchor is surfaced and the exchange degrades to **notify-only**: the reply reaches the waker as an ordinary notification it picks up on its next turn. Only idea/theme-anchored wakes carry this anchor; ad-hoc wakes with no shared idea do not.
+
+---
+
 ## Reversed-Conversation gates (you never auto-ship)
 
 Chorus is **AI proposes, humans verify**. As orchestrator you enforce that, you do not bypass it:

--- a/packages/openclaw-plugin/src/__tests__/event-router.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/event-router.test.ts
@@ -317,3 +317,60 @@ describe("ChorusEventRouter — orchestrator handoff (daemon parity)", () => {
     expect(wake.mock.calls[0][0]).not.toContain("Your orchestrator for this resource");
   });
 });
+
+describe("ChorusEventRouter — waker-session advisory anchor (daemon parity)", () => {
+  let wake: ReturnType<typeof vi.fn>;
+  let logger: ReturnType<typeof makeLogger>;
+
+  beforeEach(() => {
+    wake = vi.fn();
+    logger = makeLogger();
+  });
+
+  function build(responses: Record<string, unknown>) {
+    const mcpClient = makeMcpClient(responses) as never;
+    const router = new ChorusEventRouter({ mcpClient, wake, logger });
+    return { router };
+  }
+
+  const orchestrator = { type: "agent", uuid: "agent-orch", name: "Coordinator" };
+  const wakerSession = { agentUuid: "agent-waker", agentName: "Peer", ideaUuid: "idea-1" };
+
+  it("appends the advisory anchor when wakerSession is present, naming @[name](agent:uuid)", async () => {
+    const { router } = build({
+      chorus_get_notifications: { notifications: [makeNotification({ wakerSession })] },
+    });
+    router.dispatch({ type: "new_notification", notificationUuid: "n1" } as SseNotificationEvent);
+    await flush();
+    const msg = wake.mock.calls[0][0] as string;
+    // Mirrors the daemon's wakerSessionGuidance wording (cli/prompts.mjs) — kept in sync.
+    expect(msg).toContain("@[Peer](agent:agent-waker)");
+    expect(msg).toContain("has a live session open on this resource");
+    // advisory, NOT a server-routing guarantee
+    expect(msg).toContain("advisory, not an");
+    expect(msg).toContain("enforced server route");
+    // wrapper only rewrites the message; contextKey threads through unchanged
+    expect(wake.mock.calls[0][1]).toBe("chorus:task_assigned:task-1");
+  });
+
+  it("adds NO anchor when the wake carries no wakerSession", async () => {
+    const { router } = build({ chorus_get_notifications: { notifications: [makeNotification()] } });
+    router.dispatch({ type: "new_notification", notificationUuid: "n1" } as SseNotificationEvent);
+    await flush();
+    expect(wake.mock.calls[0][0]).not.toContain("has a live session open on this resource");
+  });
+
+  it("renders the anchor and orchestrator blocks independently (both may ride one wake)", async () => {
+    const { router } = build({
+      chorus_get_notifications: {
+        notifications: [makeNotification({ orchestrator, wakerSession })],
+      },
+    });
+    router.dispatch({ type: "new_notification", notificationUuid: "n1" } as SseNotificationEvent);
+    await flush();
+    const msg = wake.mock.calls[0][0] as string;
+    expect(msg).toContain("Your orchestrator for this resource is @Coordinator.");
+    expect(msg).toContain("@[Coordinator](agent:agent-orch)");
+    expect(msg).toContain("@[Peer](agent:agent-waker)");
+  });
+});

--- a/packages/openclaw-plugin/src/event-router.ts
+++ b/packages/openclaw-plugin/src/event-router.ts
@@ -71,6 +71,16 @@ interface NotificationDetail {
    * inject the same handback instruction the daemon does.
    */
   orchestrator?: { type: string; uuid: string; name: string } | null;
+  /**
+   * Derived, NON-persisted waker-session anchor (wake-carry-waker-session-anchor, T1).
+   * Present only for an agent-caused wake on an idea/task-anchored resource whose waking
+   * agent has a live, ONLINE-origin session for that idea — it tells the woken peer that
+   * replying on this resource reaches the waker's existing live session. A SIBLING of
+   * `orchestrator` (actor-scoped vs assignment-scoped): either, both, or neither may be
+   * present. Mirrors the daemon's cli/prompts.mjs `wakerSession` field so
+   * buildWakerSessionGuidance can inject the same advisory the daemon does.
+   */
+  wakerSession?: { agentUuid: string; agentName: string; ideaUuid: string } | null;
 }
 
 export class ChorusEventRouter {
@@ -255,11 +265,34 @@ export class ChorusEventRouter {
   }
 
   /**
-   * Append orchestrator-handoff guidance (when the resource has an agent orchestrator)
-   * to a wake message and dispatch it. Every handler routes its wake through this so the
-   * handback instruction rides EVERY action — parity with the daemon, which appends
-   * orchestratorGuidance once in buildPrompt (cli/prompts.mjs). No orchestrator → the
-   * message is dispatched unchanged.
+   * Waker-session advisory for a wake — the OpenClaw twin of the daemon's
+   * wakerSessionGuidance in cli/prompts.mjs. KEEP THE TWO WORDINGS IN SYNC. Returns null
+   * unless the notification carries a `wakerSession` anchor (surfaced by the server only when
+   * the waking agent has a live, ONLINE-origin session for this resource's idea). It tells the
+   * woken peer that replying on this resource reaches the waker's existing live session — an
+   * ADVISORY only, not an enforced server route. A SIBLING of buildOrchestratorGuidance:
+   * independent, so either/both/neither may render on one wake.
+   */
+  private buildWakerSessionGuidance(n: NotificationDetail): string | null {
+    if (!n.wakerSession) return null;
+    const { agentName, agentUuid } = n.wakerSession;
+    return (
+      `@[${agentName}](agent:${agentUuid}) woke you and has a live session open on this ` +
+      `resource. If you reply by commenting on this same resource, your reply reaches that ` +
+      `agent's live session, keeping the exchange on one thread. This is advisory, not an ` +
+      `enforced server route — there is no automatic subscription and nothing is force-delivered; ` +
+      `replying here is simply where a reply lands via the normal return path. Prefer replying ` +
+      `on this resource over opening a new session.`
+    );
+  }
+
+  /**
+   * Append orchestrator-handoff guidance (when the resource has an agent orchestrator) and the
+   * waker-session advisory (when the wake carries an online waker anchor) to a wake message and
+   * dispatch it. Every handler routes its wake through this so both instructions ride EVERY
+   * action — parity with the daemon, which appends orchestratorGuidance + wakerSessionGuidance
+   * in buildPrompt (cli/prompts.mjs). The two blocks are independent: either, both, or neither
+   * may append; with neither the message is dispatched unchanged.
    */
   private wakeWithHandoff(
     message: string,
@@ -268,7 +301,11 @@ export class ChorusEventRouter {
     attr: WakeAttribution,
   ): void {
     const handoff = this.buildOrchestratorGuidance(n);
-    this.wake(handoff ? `${message}\n\n${handoff}` : message, contextKey, attr);
+    const anchor = this.buildWakerSessionGuidance(n);
+    let msg = message;
+    if (handoff) msg += `\n\n${handoff}`;
+    if (anchor) msg += `\n\n${anchor}`;
+    this.wake(msg, contextKey, attr);
   }
 
   private handleTaskAssigned(n: NotificationDetail, attr: WakeAttribution): void {

--- a/plugins/chorus/skills/orchestrate/SKILL.md
+++ b/plugins/chorus/skills/orchestrate/SKILL.md
@@ -104,6 +104,14 @@ Guidance: start narrow. If a single owner can hold the whole feature in their he
 
 ---
 
+## Replying to the agent who woke you (advisory)
+
+When an agent wakes a peer on a shared idea or task — an orchestrator dispatching a worker, or any agent `@mention`-ing another — the wake surfaces the **waker's live session anchor**: a note naming the waking agent and telling the woken peer that the waker has an open conversation on this idea. If you are the woken peer, **reply on the same idea/task resource** (comment there rather than opening a brand-new session) and your reply lands back in the waker's existing live session, keeping the collaboration on one thread instead of scattering into a fresh one.
+
+This is **advisory, not routing.** There is no automatic server subscription and nothing is force-delivered — replying on the shared resource is simply *where a reply lands* (via the existing return path), not a guaranteed channel. When the waker's origin is **offline** at wake time, no live anchor is surfaced and the exchange degrades to **notify-only**: the reply reaches the waker as an ordinary notification it picks up on its next turn. Only idea/theme-anchored wakes carry this anchor; ad-hoc wakes with no shared idea do not.
+
+---
+
 ## Reversed-Conversation gates (you never auto-ship)
 
 Chorus is **AI proposes, humans verify**. As orchestrator you enforce that, you do not bypass it:

--- a/public/chorus-plugin/skills/orchestrate/SKILL.md
+++ b/public/chorus-plugin/skills/orchestrate/SKILL.md
@@ -104,6 +104,14 @@ Guidance: start narrow. If a single owner can hold the whole feature in their he
 
 ---
 
+## Replying to the agent who woke you (advisory)
+
+When an agent wakes a peer on a shared idea or task — an orchestrator dispatching a worker, or any agent `@mention`-ing another — the wake surfaces the **waker's live session anchor**: a note naming the waking agent and telling the woken peer that the waker has an open conversation on this idea. If you are the woken peer, **reply on the same idea/task resource** (comment there rather than opening a brand-new session) and your reply lands back in the waker's existing live session, keeping the collaboration on one thread instead of scattering into a fresh one.
+
+This is **advisory, not routing.** There is no automatic server subscription and nothing is force-delivered — replying on the shared resource is simply *where a reply lands* (via the existing return path), not a guaranteed channel. When the waker's origin is **offline** at wake time, no live anchor is surfaced and the exchange degrades to **notify-only**: the reply reaches the waker as an ordinary notification it picks up on its next turn. Only idea/theme-anchored wakes carry this anchor; ad-hoc wakes with no shared idea do not.
+
+---
+
 ## Reversed-Conversation gates (you never auto-ship)
 
 Chorus is **AI proposes, humans verify**. As orchestrator you enforce that, you do not bypass it:

--- a/public/kiro-plugin/.kiro/skills/chorus-orchestrate/SKILL.md
+++ b/public/kiro-plugin/.kiro/skills/chorus-orchestrate/SKILL.md
@@ -104,6 +104,14 @@ Guidance: start narrow. If a single owner can hold the whole feature in their he
 
 ---
 
+## Replying to the agent who woke you (advisory)
+
+When an agent wakes a peer on a shared idea or task — an orchestrator dispatching a worker, or any agent `@mention`-ing another — the wake surfaces the **waker's live session anchor**: a note naming the waking agent and telling the woken peer that the waker has an open conversation on this idea. If you are the woken peer, **reply on the same idea/task resource** (comment there rather than opening a brand-new session) and your reply lands back in the waker's existing live session, keeping the collaboration on one thread instead of scattering into a fresh one.
+
+This is **advisory, not routing.** There is no automatic server subscription and nothing is force-delivered — replying on the shared resource is simply *where a reply lands* (via the existing return path), not a guaranteed channel. When the waker's origin is **offline** at wake time, no live anchor is surfaced and the exchange degrades to **notify-only**: the reply reaches the waker as an ordinary notification it picks up on its next turn. Only idea/theme-anchored wakes carry this anchor; ad-hoc wakes with no shared idea do not.
+
+---
+
 ## Reversed-Conversation gates (you never auto-ship)
 
 Chorus is **AI proposes, humans verify**. As orchestrator you enforce that, you do not bypass it:

--- a/public/skill/orchestrate-chorus/SKILL.md
+++ b/public/skill/orchestrate-chorus/SKILL.md
@@ -104,6 +104,14 @@ Guidance: start narrow. If a single owner can hold the whole feature in their he
 
 ---
 
+## Replying to the agent who woke you (advisory)
+
+When an agent wakes a peer on a shared idea or task — an orchestrator dispatching a worker, or any agent `@mention`-ing another — the wake surfaces the **waker's live session anchor**: a note naming the waking agent and telling the woken peer that the waker has an open conversation on this idea. If you are the woken peer, **reply on the same idea/task resource** (comment there rather than opening a brand-new session) and your reply lands back in the waker's existing live session, keeping the collaboration on one thread instead of scattering into a fresh one.
+
+This is **advisory, not routing.** There is no automatic server subscription and nothing is force-delivered — replying on the shared resource is simply *where a reply lands* (via the existing return path), not a guaranteed channel. When the waker's origin is **offline** at wake time, no live anchor is surfaced and the exchange degrades to **notify-only**: the reply reaches the waker as an ordinary notification it picks up on its next turn. Only idea/theme-anchored wakes carry this anchor; ad-hoc wakes with no shared idea do not.
+
+---
+
 ## Reversed-Conversation gates (you never auto-ship)
 
 Chorus is **AI proposes, humans verify**. As orchestrator you enforce that, you do not bypass it:

--- a/src/services/__tests__/cwd-pin-chain.integration.test.ts
+++ b/src/services/__tests__/cwd-pin-chain.integration.test.ts
@@ -392,7 +392,13 @@ vi.mock("@/lib/logger", () => ({ default: mockLogger, createRequestLogger: () =>
 
 // Lineage: a task / idea under IDEA resolves to that direct idea; everything else → null.
 const mockResolveRootIdea = vi.hoisted(() => vi.fn());
-vi.mock("@/services/lineage.service", () => ({ resolveRootIdea: mockResolveRootIdea }));
+vi.mock("@/services/lineage.service", () => ({
+  resolveRootIdea: mockResolveRootIdea,
+  // daemon-session.service re-exports resolveDirectIdeaUuid from here; keep it consistent
+  // with the mocked resolveRootIdea's directIdeaUuid (the value the old path returned).
+  resolveDirectIdeaUuid: async (...args: unknown[]) =>
+    (await mockResolveRootIdea(...args))?.directIdeaUuid ?? null,
+}));
 
 // Connection registry: the wake bridge AND the mention picker ask for the agent's
 // connections. Keep STALE_THRESHOLD_MS REAL (the session service re-exports it) — only

--- a/src/services/__tests__/daemon-instruction-injection.integration.test.ts
+++ b/src/services/__tests__/daemon-instruction-injection.integration.test.ts
@@ -364,6 +364,10 @@ vi.mock("@/lib/logger", () => ({
 const mockResolveRootIdea = vi.hoisted(() => vi.fn());
 vi.mock("@/services/lineage.service", () => ({
   resolveRootIdea: mockResolveRootIdea,
+  // daemon-session.service re-exports resolveDirectIdeaUuid from here; keep it consistent
+  // with the mocked resolveRootIdea's directIdeaUuid (the value the old path returned).
+  resolveDirectIdeaUuid: async (...args: unknown[]) =>
+    (await mockResolveRootIdea(...args))?.directIdeaUuid ?? null,
 }));
 
 // Connection registry: the chokepoint asks for the agent's online connections to pin an

--- a/src/services/__tests__/daemon-session-conversation.integration.test.ts
+++ b/src/services/__tests__/daemon-session-conversation.integration.test.ts
@@ -405,6 +405,10 @@ vi.mock("@/lib/logger", () => ({
 const mockResolveRootIdea = vi.hoisted(() => vi.fn());
 vi.mock("@/services/lineage.service", () => ({
   resolveRootIdea: mockResolveRootIdea,
+  // daemon-session.service re-exports resolveDirectIdeaUuid from here; keep it consistent
+  // with the mocked resolveRootIdea's directIdeaUuid (the value the old path returned).
+  resolveDirectIdeaUuid: async (...args: unknown[]) =>
+    (await mockResolveRootIdea(...args))?.directIdeaUuid ?? null,
 }));
 
 // Connection registry: the chokepoint asks for the agent's online connections to pin an

--- a/src/services/__tests__/daemon-session.service.test.ts
+++ b/src/services/__tests__/daemon-session.service.test.ts
@@ -56,11 +56,11 @@ vi.mock("@/lib/logger", () => ({ default: mockLogger }));
 const mockEventBus = vi.hoisted(() => ({ emit: vi.fn() }));
 vi.mock("@/lib/event-bus", () => ({ eventBus: mockEventBus }));
 
-// Mock lineage.service so resolveDirectIdeaUuid's reuse is asserted in isolation
-// (no idea/task DB walk).
-const mockResolveRootIdea = vi.hoisted(() => vi.fn());
+// daemon-session.service re-exports the canonical DIRECT-idea primitive from
+// lineage.service; mock it so the re-export is asserted in isolation (no DB walk).
+const mockResolveDirectIdeaUuid = vi.hoisted(() => vi.fn());
 vi.mock("@/services/lineage.service", () => ({
-  resolveRootIdea: mockResolveRootIdea,
+  resolveDirectIdeaUuid: mockResolveDirectIdeaUuid,
 }));
 
 // Mock the connection registry module so importing STALE_THRESHOLD_MS does not pull
@@ -191,7 +191,7 @@ beforeEach(() => {
   mockPrisma.daemonTranscriptMessage.deleteMany.mockResolvedValue({ count: 0 });
   mockPrisma.daemonConnection.findFirst.mockResolvedValue(null);
   transcriptSeqCounter = 0;
-  mockResolveRootIdea.mockResolvedValue({ rootIdeaUuid: null, directIdeaUuid: null, lineage: [], resolvedVia: "not_found" });
+  mockResolveDirectIdeaUuid.mockResolvedValue(null);
 });
 
 // ===== Constants =====
@@ -359,32 +359,24 @@ describe("resolveOrCreateSession", () => {
   });
 });
 
-// ===== resolveDirectIdeaUuid (lineage reuse) =====
-describe("resolveDirectIdeaUuid", () => {
-  it("delegates to lineage.service.resolveRootIdea and returns its directIdeaUuid", async () => {
-    mockResolveRootIdea.mockResolvedValue({
-      rootIdeaUuid: "root-i",
-      directIdeaUuid: "direct-i",
-      lineage: [],
-      resolvedVia: "via_proposal",
-    });
+// ===== resolveDirectIdeaUuid (re-export of the canonical lineage primitive) =====
+// The no-ancestry-climb behavior itself is verified against the REAL resolver in
+// lineage.service.test.ts; here we only assert the re-export forwards faithfully.
+describe("resolveDirectIdeaUuid (re-export)", () => {
+  it("forwards to lineage.service.resolveDirectIdeaUuid and returns its result", async () => {
+    mockResolveDirectIdeaUuid.mockResolvedValue("direct-i");
     const result = await resolveDirectIdeaUuid(companyUuid, "task", "task-1");
-    expect(mockResolveRootIdea).toHaveBeenCalledWith(companyUuid, "task", "task-1");
+    expect(mockResolveDirectIdeaUuid).toHaveBeenCalledWith(companyUuid, "task", "task-1");
     expect(result).toBe("direct-i");
   });
 
-  it("returns null when the entity has no idea ancestor (a success, not an error)", async () => {
-    mockResolveRootIdea.mockResolvedValue({
-      rootIdeaUuid: null,
-      directIdeaUuid: null,
-      lineage: [],
-      resolvedVia: "no_proposal",
-    });
+  it("returns null when the entity has no idea anchor (a success, not an error)", async () => {
+    mockResolveDirectIdeaUuid.mockResolvedValue(null);
     await expect(resolveDirectIdeaUuid(companyUuid, "task", "task-1")).resolves.toBeNull();
   });
 
   it("PROPAGATES a lineage query failure", async () => {
-    mockResolveRootIdea.mockRejectedValue(new Error("db down"));
+    mockResolveDirectIdeaUuid.mockRejectedValue(new Error("db down"));
     await expect(resolveDirectIdeaUuid(companyUuid, "task", "task-1")).rejects.toThrow("db down");
   });
 });

--- a/src/services/__tests__/lineage.service.test.ts
+++ b/src/services/__tests__/lineage.service.test.ts
@@ -17,7 +17,11 @@ vi.mock("@/services/proposal.service", () => ({ getProposalByUuid: mockGetPropos
 vi.mock("@/services/document.service", () => ({ getDocumentByUuid: mockGetDocumentByUuid }));
 vi.mock("@/services/idea.service", () => ({ getIdeaByUuid: mockGetIdeaByUuid }));
 
-import { resolveRootIdea, MAX_PARENT_HOPS } from "@/services/lineage.service";
+import {
+  resolveRootIdea,
+  resolveDirectIdeaUuid,
+  MAX_PARENT_HOPS,
+} from "@/services/lineage.service";
 
 const COMPANY = "company-1111";
 const OTHER_COMPANY = "company-9999";
@@ -527,5 +531,168 @@ describe("lineage.service / resolveRootIdea", () => {
     const res = await resolveRootIdea(COMPANY, "comment", "c1");
     expect(res.rootIdeaUuid).toBeNull();
     expect(res.resolvedVia).toBe("not_found");
+  });
+});
+
+// resolveDirectIdeaUuid is the canonical DIRECT-idea primitive used to key the
+// DaemonSession (`--session-id`) and to derive the waker-session anchor. Spec
+// `agent-orchestrator-handoff` (+ T1 AC) requires it to read ONLY the resource's own
+// idea anchor and MUST NOT climb parent/container idea ancestry. These tests exercise
+// the REAL resolver (only the DB getters are mocked) and assert the parent Idea is
+// never read — the constraint boundary the resolveRootIdea path could not cover.
+describe("lineage.service / resolveDirectIdeaUuid (shallow, no-climb)", () => {
+  it("task → its DIRECT idea, WITHOUT reading the parent/container idea", async () => {
+    installGraph({
+      ideas: [
+        { uuid: "i-root", title: "Root", parentUuid: null },
+        { uuid: "i-child", title: "Child", parentUuid: "i-root" },
+      ],
+      proposals: [{ uuid: "p1", title: "P1", inputType: "idea", inputUuids: ["i-child"] }],
+      tasks: [{ uuid: "t1", title: "T1", proposalUuid: "p1" }],
+    });
+
+    const direct = await resolveDirectIdeaUuid(COMPANY, "task", "t1");
+
+    expect(direct).toBe("i-child");
+    // The direct idea WAS read (existence check); the parent/root idea was NOT.
+    const readIdeaUuids = mockGetIdeaByUuid.mock.calls.map((c) => c[1]);
+    expect(readIdeaUuids).toContain("i-child");
+    expect(readIdeaUuids).not.toContain("i-root");
+  });
+
+  it("value-identical to resolveRootIdea().directIdeaUuid but reads fewer ideas", async () => {
+    installGraph({
+      ideas: [
+        { uuid: "i-root", title: "Root", parentUuid: null },
+        { uuid: "i-mid", title: "Mid", parentUuid: "i-root" },
+        { uuid: "i-leaf", title: "Leaf", parentUuid: "i-mid" },
+      ],
+      proposals: [{ uuid: "p1", title: "P1", inputType: "idea", inputUuids: ["i-leaf"] }],
+      tasks: [{ uuid: "t1", title: "T1", proposalUuid: "p1" }],
+    });
+
+    const shallow = await resolveDirectIdeaUuid(COMPANY, "task", "t1");
+    const shallowIdeaReads = mockGetIdeaByUuid.mock.calls.length;
+    vi.clearAllMocks();
+    installGraph({
+      ideas: [
+        { uuid: "i-root", title: "Root", parentUuid: null },
+        { uuid: "i-mid", title: "Mid", parentUuid: "i-root" },
+        { uuid: "i-leaf", title: "Leaf", parentUuid: "i-mid" },
+      ],
+      proposals: [{ uuid: "p1", title: "P1", inputType: "idea", inputUuids: ["i-leaf"] }],
+      tasks: [{ uuid: "t1", title: "T1", proposalUuid: "p1" }],
+    });
+    const deep = await resolveRootIdea(COMPANY, "task", "t1");
+
+    expect(shallow).toBe(deep.directIdeaUuid); // same value
+    expect(shallow).toBe("i-leaf");
+    expect(shallowIdeaReads).toBe(1); // only the direct idea; root path reads i-leaf+i-mid+i-root
+  });
+
+  it("idea entity → itself (existence-checked), no parent read", async () => {
+    installGraph({
+      ideas: [
+        { uuid: "i-root", title: "Root", parentUuid: null },
+        { uuid: "i-leaf", title: "Leaf", parentUuid: "i-root" },
+      ],
+    });
+
+    const direct = await resolveDirectIdeaUuid(COMPANY, "idea", "i-leaf");
+
+    expect(direct).toBe("i-leaf");
+    expect(mockGetIdeaByUuid.mock.calls.map((c) => c[1])).not.toContain("i-root");
+  });
+
+  it("document → its proposal's direct input idea, no parent read", async () => {
+    installGraph({
+      ideas: [
+        { uuid: "i-root", title: "Root", parentUuid: null },
+        { uuid: "i-child", title: "Child", parentUuid: "i-root" },
+      ],
+      proposals: [{ uuid: "p1", title: "P1", inputType: "idea", inputUuids: ["i-child"] }],
+      documents: [{ uuid: "d1", title: "Spec", proposalUuid: "p1" }],
+    });
+
+    const direct = await resolveDirectIdeaUuid(COMPANY, "document", "d1");
+
+    expect(direct).toBe("i-child");
+    expect(mockGetIdeaByUuid.mock.calls.map((c) => c[1])).not.toContain("i-root");
+  });
+
+  it("proposal entity → inputUuids[0]'s idea", async () => {
+    installGraph({
+      ideas: [{ uuid: "i-a", title: "A", parentUuid: null }],
+      proposals: [{ uuid: "p1", title: "P1", inputType: "idea", inputUuids: ["i-a"] }],
+    });
+
+    await expect(resolveDirectIdeaUuid(COMPANY, "proposal", "p1")).resolves.toBe("i-a");
+  });
+
+  it("multi-idea proposal → inputUuids[0] only (no other input read, no climb)", async () => {
+    installGraph({
+      ideas: [
+        { uuid: "i-root-a", title: "RootA", parentUuid: null },
+        { uuid: "i-a", title: "A", parentUuid: "i-root-a" },
+        { uuid: "i-b", title: "B", parentUuid: null },
+      ],
+      proposals: [
+        { uuid: "p-merge", title: "Merge", inputType: "idea", inputUuids: ["i-a", "i-b"] },
+      ],
+      tasks: [{ uuid: "t1", title: "T1", proposalUuid: "p-merge" }],
+    });
+
+    const direct = await resolveDirectIdeaUuid(COMPANY, "task", "t1");
+
+    expect(direct).toBe("i-a");
+    const readIdeaUuids = mockGetIdeaByUuid.mock.calls.map((c) => c[1]);
+    expect(readIdeaUuids).not.toContain("i-root-a"); // no climb
+    expect(readIdeaUuids).not.toContain("i-b"); // secondary input not needed for the anchor
+  });
+
+  it.each([
+    ["quick task, no proposal", "task", "t-quick"],
+    ["standalone document", "document", "d-solo"],
+    ["missing task", "task", "t-ghost"],
+  ] as const)("null (no idea anchor): %s", async (_label, type, uuid) => {
+    installGraph({
+      tasks: [{ uuid: "t-quick", title: "Quick", proposalUuid: null }],
+      documents: [{ uuid: "d-solo", title: "Note", proposalUuid: null }],
+    });
+
+    await expect(resolveDirectIdeaUuid(COMPANY, type, uuid)).resolves.toBeNull();
+  });
+
+  it("proposal whose input is a document (not an idea) → null", async () => {
+    installGraph({
+      proposals: [{ uuid: "p-doc", title: "PDoc", inputType: "document", inputUuids: ["d-src"] }],
+    });
+
+    await expect(resolveDirectIdeaUuid(COMPANY, "proposal", "p-doc")).resolves.toBeNull();
+  });
+
+  it("task whose proposal input idea is a ghost (missing) → null", async () => {
+    installGraph({
+      proposals: [{ uuid: "p1", title: "P1", inputType: "idea", inputUuids: ["i-ghost"] }],
+      tasks: [{ uuid: "t1", title: "T1", proposalUuid: "p1" }],
+    });
+
+    await expect(resolveDirectIdeaUuid(COMPANY, "task", "t1")).resolves.toBeNull();
+  });
+
+  it("cross-company entity → null (getters are company-scoped)", async () => {
+    installGraph({
+      ideas: [{ uuid: "i-a", title: "A", parentUuid: null }],
+      proposals: [{ uuid: "p1", title: "P1", inputType: "idea", inputUuids: ["i-a"] }],
+      tasks: [{ uuid: "t1", title: "T1", proposalUuid: "p1" }],
+    });
+
+    await expect(resolveDirectIdeaUuid(OTHER_COMPANY, "task", "t1")).resolves.toBeNull();
+  });
+
+  it("unknown entityType → null (no throw)", async () => {
+    installGraph({});
+    // @ts-expect-error — exercising the runtime default branch
+    await expect(resolveDirectIdeaUuid(COMPANY, "comment", "c1")).resolves.toBeNull();
   });
 });

--- a/src/services/__tests__/lineage.service.test.ts
+++ b/src/services/__tests__/lineage.service.test.ts
@@ -680,6 +680,40 @@ describe("lineage.service / resolveDirectIdeaUuid (shallow, no-climb)", () => {
     await expect(resolveDirectIdeaUuid(COMPANY, "task", "t1")).resolves.toBeNull();
   });
 
+  // Value-identity is the invariant the whole "same-source" safety rests on
+  // (anchor.ideaUuid ≡ DaemonSession.sessionId). Pin it not only on the happy path but on
+  // the NULL/edge branches too, so a future drift in resolveRootIdea's null semantics can
+  // never silently fork the shallow primitive. Both paths are run on the SAME graph.
+  it.each([
+    ["ghost proposal input idea", COMPANY, "task", "t-ghost-input"],
+    ["quick task (no proposal)", COMPANY, "task", "t-quick"],
+    ["non-idea proposal input", COMPANY, "proposal", "p-doc"],
+    ["cross-company task", OTHER_COMPANY, "task", "t-ok"],
+  ] as const)(
+    "value-identity on the null/edge branch: %s (shallow === resolveRootIdea().directIdeaUuid)",
+    async (_label, company, type, uuid) => {
+      installGraph({
+        ideas: [{ uuid: "i-ok", title: "OK", parentUuid: null }],
+        proposals: [
+          { uuid: "p-ghost", title: "PGhost", inputType: "idea", inputUuids: ["i-ghost"] },
+          { uuid: "p-doc", title: "PDoc", inputType: "document", inputUuids: ["d-src"] },
+          { uuid: "p-ok", title: "POk", inputType: "idea", inputUuids: ["i-ok"] },
+        ],
+        tasks: [
+          { uuid: "t-ghost-input", title: "TGhost", proposalUuid: "p-ghost" },
+          { uuid: "t-quick", title: "TQuick", proposalUuid: null },
+          { uuid: "t-ok", title: "TOk", proposalUuid: "p-ok" },
+        ],
+      });
+
+      const shallow = await resolveDirectIdeaUuid(company, type, uuid);
+      const deep = (await resolveRootIdea(company, type, uuid)).directIdeaUuid;
+
+      expect(shallow).toBe(deep);
+      expect(shallow).toBeNull();
+    },
+  );
+
   it("cross-company entity → null (getters are company-scoped)", async () => {
     installGraph({
       ideas: [{ uuid: "i-a", title: "A", parentUuid: null }],

--- a/src/services/__tests__/notification.service.test.ts
+++ b/src/services/__tests__/notification.service.test.ts
@@ -36,9 +36,20 @@ vi.mock("@/services/notification-turn", () => ({
   createTurnAndResolveTarget: mockCreateTurnAndResolveTarget,
 }));
 
+// formatNotifications resolves a TASK wake's direct containing idea via the shared lineage
+// resolver (a Task has no `ideaUuid` column; the direct idea is the FIRST idea node, which is
+// also the idea-anchored DaemonSession's business key). Mocked so this suite stays a focused
+// unit test — the resolver itself is covered in daemon-session/lineage suites.
+const mockResolveDirectIdeaUuid = vi.hoisted(() => vi.fn());
+vi.mock("@/services/daemon-session.service", () => ({
+  resolveDirectIdeaUuid: mockResolveDirectIdeaUuid,
+}));
+
 const mockResolveResourceOrchestrator = vi.hoisted(() => vi.fn());
+const mockResolveWakerSessionAnchor = vi.hoisted(() => vi.fn());
 vi.mock("@/services/orchestrator.service", () => ({
   resolveResourceOrchestrator: mockResolveResourceOrchestrator,
+  resolveWakerSessionAnchor: mockResolveWakerSessionAnchor,
 }));
 
 import {
@@ -99,6 +110,11 @@ beforeEach(() => {
     suppressWake: false,
   });
   mockResolveResourceOrchestrator.mockResolvedValue(null);
+  // The waker-session anchor resolver is exercised via its own suite; here default it to no
+  // anchor and to a task→idea resolution that resolves, so the wiring path runs without
+  // asserting an anchor unless a test opts in.
+  mockResolveWakerSessionAnchor.mockResolvedValue(null);
+  mockResolveDirectIdeaUuid.mockResolvedValue("idea-from-task");
 });
 
 // ===== create =====
@@ -440,6 +456,144 @@ describe("createBatch", () => {
       expect.objectContaining({
         data: expect.objectContaining({ instructionText: "do the thing" }),
       })
+    );
+  });
+});
+
+// ===== waker-session anchor wiring (wake-carry-waker-session-anchor, T1) =====
+describe("wakerSession anchor wiring", () => {
+  const waker = "agent-waker-0000-0000-000000000001";
+
+  it("emits the waker-session anchor for an agent-caused idea wake (idea → itself)", async () => {
+    const overrides = {
+      entityType: "idea",
+      entityUuid: "idea-1",
+      actorType: "agent",
+      actorUuid: waker,
+    };
+    mockPrisma.notification.create.mockResolvedValue(makeNotifRecord(overrides));
+    mockPrisma.notification.count.mockResolvedValue(0);
+    const anchor = { agentUuid: waker, agentName: "Waker", ideaUuid: "idea-1" };
+    mockResolveWakerSessionAnchor.mockResolvedValue(anchor);
+
+    const result = await create(makeNotifParams(overrides));
+
+    expect(result.wakerSession).toEqual(anchor);
+    expect(mockResolveWakerSessionAnchor).toHaveBeenCalledWith(
+      companyUuid,
+      waker,
+      "idea-1",
+    );
+    // An idea wake anchors on itself — no lineage resolution at all.
+    expect(mockResolveDirectIdeaUuid).not.toHaveBeenCalled();
+  });
+
+  it("resolves a task wake's direct containing idea (first idea node, not the root)", async () => {
+    const overrides = {
+      entityType: "task",
+      entityUuid: "task-9",
+      actorType: "agent",
+      actorUuid: waker,
+    };
+    mockPrisma.notification.create.mockResolvedValue(makeNotifRecord(overrides));
+    mockPrisma.notification.count.mockResolvedValue(0);
+    mockResolveDirectIdeaUuid.mockResolvedValue("idea-of-task");
+    const anchor = { agentUuid: waker, agentName: "Waker", ideaUuid: "idea-of-task" };
+    mockResolveWakerSessionAnchor.mockResolvedValue(anchor);
+
+    const result = await create(makeNotifParams(overrides));
+
+    // The task's DIRECT idea is resolved once, via the shared resolver that returns the first
+    // idea node (never climbing to a parent/container root); the anchor is keyed on it.
+    expect(mockResolveDirectIdeaUuid).toHaveBeenCalledTimes(1);
+    expect(mockResolveDirectIdeaUuid).toHaveBeenCalledWith(
+      companyUuid,
+      "task",
+      "task-9",
+    );
+    expect(mockResolveWakerSessionAnchor).toHaveBeenCalledWith(
+      companyUuid,
+      waker,
+      "idea-of-task",
+    );
+    expect(result.wakerSession).toEqual(anchor);
+  });
+
+  it("does not emit a waker anchor for a user-actor wake", async () => {
+    const overrides = {
+      entityType: "idea",
+      entityUuid: "idea-1",
+      actorType: "user",
+      actorUuid: "user-1",
+    };
+    mockPrisma.notification.create.mockResolvedValue(makeNotifRecord(overrides));
+    mockPrisma.notification.count.mockResolvedValue(0);
+
+    const result = await create(makeNotifParams(overrides));
+
+    expect(result.wakerSession).toBeNull();
+    expect(mockResolveWakerSessionAnchor).not.toHaveBeenCalled();
+  });
+
+  it("does not emit a waker anchor for a proposal-addressed wake (no idea/task key)", async () => {
+    const overrides = {
+      entityType: "proposal",
+      entityUuid: "proposal-1",
+      actorType: "agent",
+      actorUuid: waker,
+    };
+    mockPrisma.notification.create.mockResolvedValue(makeNotifRecord(overrides));
+    mockPrisma.notification.count.mockResolvedValue(0);
+
+    const result = await create(makeNotifParams(overrides));
+
+    expect(result.wakerSession).toBeNull();
+    expect(mockResolveWakerSessionAnchor).not.toHaveBeenCalled();
+    expect(mockResolveDirectIdeaUuid).not.toHaveBeenCalled();
+  });
+
+  it("omits the anchor when the waker session is offline or missing (resolver → null)", async () => {
+    const overrides = {
+      entityType: "idea",
+      entityUuid: "idea-1",
+      actorType: "agent",
+      actorUuid: waker,
+    };
+    mockPrisma.notification.create.mockResolvedValue(makeNotifRecord(overrides));
+    mockPrisma.notification.count.mockResolvedValue(0);
+    mockResolveWakerSessionAnchor.mockResolvedValue(null);
+
+    const result = await create(makeNotifParams(overrides));
+
+    expect(mockResolveWakerSessionAnchor).toHaveBeenCalledWith(
+      companyUuid,
+      waker,
+      "idea-1",
+    );
+    expect(result.wakerSession).toBeNull();
+  });
+
+  it("resolves the waker anchor once per distinct (agent, idea) pair across a batch", async () => {
+    const params = makeNotifParams({
+      recipientType: "agent",
+      entityType: "idea",
+      entityUuid: "idea-1",
+      actorType: "agent",
+      actorUuid: waker,
+    });
+    const record = makeNotifRecord(params);
+    mockPrisma.notification.create
+      .mockResolvedValueOnce(record)
+      .mockResolvedValueOnce({ ...record, uuid: "notif-2" });
+    mockPrisma.notification.count.mockResolvedValue(1);
+
+    await createBatch([params, params]);
+
+    expect(mockResolveWakerSessionAnchor).toHaveBeenCalledTimes(1);
+    expect(mockResolveWakerSessionAnchor).toHaveBeenCalledWith(
+      companyUuid,
+      waker,
+      "idea-1",
     );
   });
 });

--- a/src/services/__tests__/orchestrator.service.test.ts
+++ b/src/services/__tests__/orchestrator.service.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockPrisma = vi.hoisted(() => ({
   idea: { findFirst: vi.fn() },
   task: { findFirst: vi.fn() },
+  daemonSession: { findFirst: vi.fn() },
 }));
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 
@@ -11,7 +12,15 @@ vi.mock("@/lib/uuid-resolver", () => ({
   resolveAssignmentActor: mockResolveAssignmentActor,
 }));
 
-import { resolveResourceOrchestrator } from "@/services/orchestrator.service";
+const mockListConnectionsForAgent = vi.hoisted(() => vi.fn());
+vi.mock("@/services/daemon-connection.service", () => ({
+  listConnectionsForAgent: mockListConnectionsForAgent,
+}));
+
+import {
+  resolveResourceOrchestrator,
+  resolveWakerSessionAnchor,
+} from "@/services/orchestrator.service";
 
 describe("resolveResourceOrchestrator", () => {
   beforeEach(() => {
@@ -105,4 +114,87 @@ describe("resolveResourceOrchestrator", () => {
       expect(mockResolveAssignmentActor).not.toHaveBeenCalled();
     },
   );
+});
+
+describe("resolveWakerSessionAnchor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the anchor when the waker's idea session has an online origin", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({
+      originConnectionUuid: "conn-1",
+    });
+    mockListConnectionsForAgent.mockResolvedValue([
+      { uuid: "conn-0", agentName: "Waker", effectiveStatus: "offline" },
+      { uuid: "conn-1", agentName: "Waker", effectiveStatus: "online" },
+    ]);
+
+    await expect(
+      resolveWakerSessionAnchor("company-1", "agent-1", "idea-1"),
+    ).resolves.toEqual({
+      agentUuid: "agent-1",
+      agentName: "Waker",
+      ideaUuid: "idea-1",
+    });
+    // The session business key is the idea (sessionId === ideaUuid), scoped by company+agent.
+    expect(mockPrisma.daemonSession.findFirst).toHaveBeenCalledWith({
+      where: { companyUuid: "company-1", agentUuid: "agent-1", sessionId: "idea-1" },
+      select: { originConnectionUuid: true },
+    });
+    expect(mockListConnectionsForAgent).toHaveBeenCalledWith("company-1", "agent-1");
+  });
+
+  it("returns null when the waker has no session for the idea (no connection lookup)", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue(null);
+
+    await expect(
+      resolveWakerSessionAnchor("company-1", "agent-1", "idea-1"),
+    ).resolves.toBeNull();
+    expect(mockListConnectionsForAgent).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the session's origin connection is offline", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({
+      originConnectionUuid: "conn-1",
+    });
+    mockListConnectionsForAgent.mockResolvedValue([
+      { uuid: "conn-1", agentName: "Waker", effectiveStatus: "offline" },
+    ]);
+
+    await expect(
+      resolveWakerSessionAnchor("company-1", "agent-1", "idea-1"),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when the session's origin connection is not among the agent's connections", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({
+      originConnectionUuid: "conn-gone",
+    });
+    // Another connection is online, but it is NOT the session's origin — no anchor.
+    mockListConnectionsForAgent.mockResolvedValue([
+      { uuid: "conn-other", agentName: "Waker", effectiveStatus: "online" },
+    ]);
+
+    await expect(
+      resolveWakerSessionAnchor("company-1", "agent-1", "idea-1"),
+    ).resolves.toBeNull();
+  });
+
+  it("falls back to an empty agentName when the online connection has no joined name", async () => {
+    mockPrisma.daemonSession.findFirst.mockResolvedValue({
+      originConnectionUuid: "conn-1",
+    });
+    mockListConnectionsForAgent.mockResolvedValue([
+      { uuid: "conn-1", agentName: null, effectiveStatus: "online" },
+    ]);
+
+    await expect(
+      resolveWakerSessionAnchor("company-1", "agent-1", "idea-1"),
+    ).resolves.toEqual({
+      agentUuid: "agent-1",
+      agentName: "",
+      ideaUuid: "idea-1",
+    });
+  });
 });

--- a/src/services/__tests__/wake-carry-waker-session-anchor.integration.test.ts
+++ b/src/services/__tests__/wake-carry-waker-session-anchor.integration.test.ts
@@ -1,0 +1,307 @@
+// src/services/__tests__/wake-carry-waker-session-anchor.integration.test.ts
+//
+// INTEGRATION CHECKPOINT for the wake-carry-waker-session-anchor feature (T1 server +
+// T2 daemon prompt, combined). Each end is already pinned in isolation by a per-task suite:
+//   - orchestrator.service.test.ts        → resolveWakerSessionAnchor online/offline/absent
+//   - notification.service.test.ts        → formatNotifications wires the anchor into the
+//                                            NotificationResponse projection (mocking the resolver)
+//   - cli/prompts.test.mjs                → wakerSessionGuidance renders / omits the line
+//
+// What no single unit test proves is the SEAM the per-task reviews could not see: that a
+// real agent-caused idea/task wake, run through the REAL server projection with the REAL
+// anchor resolver, yields a NotificationResponse whose `wakerSession` then drives the REAL
+// daemon prompt builder to emit the advisory line — and that an offline waker collapses the
+// whole chain to notify-only (null anchor → no line). The per-task suites each mock the hop
+// on the other side of their own boundary, so a drift between the server field shape and the
+// prompt builder's read of it would stay green there but fail HERE.
+//
+// This test imports the ACTUAL modules together and walks ONE flow across the server→daemon
+// boundary:
+//   list() → formatNotifications() → resolveWakerSessionAnchor()  [server, TS]
+//         → NotificationResponse.wakerSession
+//         → buildPrompt / buildBatchPrompt                        [daemon client, cli/*.mjs]
+//
+// Only the leaf dependencies are stubbed (prisma rows, the live connection registry, the
+// task→idea lineage resolver, and the wake-turn bridge that list() never calls). The anchor
+// resolver (orchestrator.service) and the notification projection (notification.service) run
+// for real, as does the daemon prompt builder.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ===== Prisma mock (leaf rows only) =====
+// resolveWakerSessionAnchor reads daemonSession.findFirst; resolveResourceOrchestrator reads
+// idea/task.findFirst; list() reads notification.findMany + count. Everything else is real.
+const mockPrisma = vi.hoisted(() => ({
+  notification: {
+    findMany: vi.fn(),
+    count: vi.fn(),
+  },
+  daemonSession: {
+    findFirst: vi.fn(),
+  },
+  idea: {
+    findFirst: vi.fn(),
+  },
+  task: {
+    findFirst: vi.fn(),
+  },
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// list() never emits, but notification.service imports the bus at module top.
+vi.mock("@/lib/event-bus", () => ({ eventBus: { emit: vi.fn(), emitChange: vi.fn() } }));
+
+// The wake-turn bridge is imported by notification.service but NOT reached on the list()
+// read path — stub it so importing the service does not drag in the daemon turn stack.
+vi.mock("@/services/notification-turn", () => ({
+  createTurnAndResolveTarget: vi.fn().mockResolvedValue({
+    turn: null,
+    targetConnectionUuid: null,
+    suppressWake: false,
+  }),
+}));
+
+// A Task has no `ideaUuid` column; formatNotifications resolves a TASK wake's DIRECT
+// containing idea through this shared resolver. Stubbed so the lineage walk itself (covered
+// elsewhere) is out of scope — we only need it to hand back the task's direct idea uuid.
+const mockResolveDirectIdeaUuid = vi.hoisted(() => vi.fn());
+vi.mock("@/services/daemon-session.service", () => ({
+  resolveDirectIdeaUuid: mockResolveDirectIdeaUuid,
+}));
+
+// The live connection registry read that resolveWakerSessionAnchor uses to confirm the
+// waker's session origin is ONLINE. This is the ONLY dependency of the real anchor resolver
+// we stub — the resolver's own logic (session lookup + online-origin match) runs for real.
+const mockListConnectionsForAgent = vi.hoisted(() => vi.fn());
+vi.mock("@/services/daemon-connection.service", () => ({
+  listConnectionsForAgent: mockListConnectionsForAgent,
+}));
+
+// NOTE: @/services/orchestrator.service is intentionally NOT mocked — resolveWakerSessionAnchor
+// runs for real. That is the whole point of this integration checkpoint.
+
+import { list, type NotificationResponse } from "@/services/notification.service";
+// The daemon client lives in cli/ as plain .mjs; Vitest imports it directly (the existing
+// elaboration-verify-wake.integration.test.ts proves the module is importable from a TS test).
+import { buildPrompt, buildBatchPrompt } from "../../../cli/prompts.mjs";
+
+// ===== Fixtures =====
+const companyUuid = "company-0000-0000-0000-000000000001";
+const recipientAgentUuid = "agent-woken-0000-0000-000000000001"; // the peer being woken
+const wakerAgentUuid = "agent-waker-0000-0000-000000000001"; // the actor who woke it
+const ONLINE_IDEA = "idea-online-0000-0000-000000000001";
+const OFFLINE_IDEA = "idea-offline-0000-0000-000000000001";
+const TASK_UUID = "task-0000-0000-0000-000000000001";
+
+// The waker's live-connection display name is DELIBERATELY different from the notification's
+// denormalized actorName below. resolveWakerSessionAnchor sources the anchor's agentName from
+// the connection registry, so seeing "Waker Agent" (not the actorName) in the rendered line
+// proves the name flowed through the real resolver, not a copy of the event actor.
+const CONNECTION_AGENT_NAME = "Waker Agent";
+const ACTOR_NAME = "PM Agent";
+
+// The exact opening of wakerSessionGuidance (cli/prompts.mjs) — unique to the advisory line,
+// so it never collides with the per-action @mention markup (which also names the agent).
+const advisoryLine = (agentName: string, agentUuid: string) =>
+  `@[${agentName}](agent:${agentUuid}) woke you and has a live session open on this resource.`;
+
+const ADVISORY_ONLINE = advisoryLine(CONNECTION_AGENT_NAME, wakerAgentUuid);
+
+type RawRecord = ReturnType<typeof makeRecord>;
+function makeRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    companyUuid,
+    uuid: "notif-0000-0000-0000-000000000001",
+    projectUuid: "project-0000-0000-0000-000000000001",
+    projectName: "Test Project",
+    recipientType: "agent",
+    recipientUuid: recipientAgentUuid,
+    entityType: "idea",
+    entityUuid: ONLINE_IDEA,
+    entityTitle: "Shared idea",
+    action: "mentioned",
+    message: "take a look",
+    actorType: "agent",
+    actorUuid: wakerAgentUuid,
+    actorName: ACTOR_NAME,
+    readAt: null as Date | null,
+    archivedAt: null as Date | null,
+    createdAt: new Date("2026-09-07T00:00:00Z"),
+    instructionText: null as string | null,
+    ...overrides,
+  };
+}
+
+// Run the crafted raw rows through the REAL read projection (list → formatNotifications →
+// resolveWakerSessionAnchor) and return the formatted NotificationResponses.
+async function project(records: RawRecord[]): Promise<NotificationResponse[]> {
+  mockPrisma.notification.findMany.mockResolvedValue(records);
+  const { notifications } = await list({
+    companyUuid,
+    recipientType: "agent",
+    recipientUuid: recipientAgentUuid,
+  });
+  return notifications;
+}
+
+// Mirror the daemon event-router seam: thread the projection fields (including the derived
+// `wakerSession`) into the prompt builder's input shape.
+function toWakeInput(r: NotificationResponse) {
+  return {
+    uuid: r.uuid,
+    projectUuid: r.projectUuid,
+    entityType: r.entityType,
+    entityUuid: r.entityUuid,
+    entityTitle: r.entityTitle,
+    action: r.action,
+    message: r.message,
+    actorType: r.actorType,
+    actorUuid: r.actorUuid,
+    actorName: r.actorName,
+    orchestrator: r.orchestrator,
+    wakerSession: r.wakerSession,
+    instructionText: r.instructionText ?? undefined,
+  };
+}
+
+function occurrences(haystack: string, needle: string): number {
+  let count = 0;
+  let i = haystack.indexOf(needle);
+  while (i !== -1) {
+    count += 1;
+    i = haystack.indexOf(needle, i + needle.length);
+  }
+  return count;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Two counts per list() call (total + unread) — a constant is fine.
+  mockPrisma.notification.count.mockResolvedValue(1);
+  // No assignment provenance → resolveResourceOrchestrator returns null (orchestrator is a
+  // separate sibling; this test isolates the waker anchor).
+  mockPrisma.idea.findFirst.mockResolvedValue(null);
+  mockPrisma.task.findFirst.mockResolvedValue(null);
+  // Idea-anchored DaemonSession lookup, keyed by the idea business key (sessionId === ideaUuid):
+  //   ONLINE_IDEA  → session whose origin connection is online
+  //   OFFLINE_IDEA → session exists but its origin connection is offline (the realistic
+  //                  "waker went offline" case → notify-only)
+  mockPrisma.daemonSession.findFirst.mockImplementation(
+    async (args: { where: { sessionId: string } }) => {
+      const sessionId = args.where.sessionId;
+      if (sessionId === ONLINE_IDEA) return { originConnectionUuid: "conn-online" };
+      if (sessionId === OFFLINE_IDEA) return { originConnectionUuid: "conn-offline" };
+      return null;
+    },
+  );
+  // The live connection registry: one online, one offline connection for the waker.
+  mockListConnectionsForAgent.mockResolvedValue([
+    { uuid: "conn-online", effectiveStatus: "online", agentName: CONNECTION_AGENT_NAME },
+    { uuid: "conn-offline", effectiveStatus: "offline", agentName: CONNECTION_AGENT_NAME },
+  ]);
+  // Default task→idea resolution (only reached by the TASK-entity case).
+  mockResolveDirectIdeaUuid.mockResolvedValue(ONLINE_IDEA);
+});
+
+describe("wake-carry-waker-session-anchor — server projection → daemon prompt (AC1)", () => {
+  it("agent-caused idea wake with an ONLINE waker → NotificationResponse.wakerSession → advisory line", async () => {
+    const [resp] = await project([makeRecord()]);
+
+    // (a) The REAL resolver derived the anchor from the session + online connection, and the
+    //     REAL projection carried it — agentName came from the connection registry, NOT actorName.
+    expect(resp.wakerSession).toEqual({
+      agentUuid: wakerAgentUuid,
+      agentName: CONNECTION_AGENT_NAME,
+      ideaUuid: ONLINE_IDEA,
+    });
+    expect(resp.actorName).toBe(ACTOR_NAME); // still the event actor's own denormalized name
+
+    // (b) The REAL daemon prompt builder, fed that projection, renders the advisory line
+    //     naming @[name](agent:uuid).
+    const prompt = buildPrompt(toWakeInput(resp));
+    expect(prompt).not.toBeNull();
+    expect(prompt).toContain(ADVISORY_ONLINE);
+    // The advisory names the waker via the connection-sourced name (proves the anchor drove it,
+    // not the actor @mention which uses the actorName).
+    expect(prompt).toContain(`@[${CONNECTION_AGENT_NAME}](agent:${wakerAgentUuid})`);
+  });
+
+  it("agent-caused TASK wake resolves its direct idea, then renders the same advisory line", async () => {
+    const [resp] = await project([
+      makeRecord({ entityType: "task", entityUuid: TASK_UUID }),
+    ]);
+
+    // The task's DIRECT containing idea was resolved and used as the anchor's ideaUuid.
+    expect(mockResolveDirectIdeaUuid).toHaveBeenCalledWith(companyUuid, "task", TASK_UUID);
+    expect(resp.wakerSession).toEqual({
+      agentUuid: wakerAgentUuid,
+      agentName: CONNECTION_AGENT_NAME,
+      ideaUuid: ONLINE_IDEA,
+    });
+
+    const prompt = buildPrompt(toWakeInput(resp));
+    expect(prompt).toContain(ADVISORY_ONLINE);
+  });
+
+  it("OFFLINE waker → NotificationResponse.wakerSession is null → NO advisory line (notify-only)", async () => {
+    const [resp] = await project([makeRecord({ entityUuid: OFFLINE_IDEA })]);
+
+    // The session exists but its origin connection is offline → the resolver returns null and
+    // the projection carries no anchor.
+    expect(resp.wakerSession).toBeNull();
+
+    const prompt = buildPrompt(toWakeInput(resp));
+    expect(prompt).not.toBeNull();
+    // The unique advisory sentence is absent. (The per-action @mention markup may still name
+    // the actor — that is NOT the anchor line, so we assert on the advisory's unique wording.)
+    expect(prompt).not.toContain("woke you and has a live session open on this resource");
+  });
+
+  it("user-actor wake never resolves an anchor (no waker session, no line)", async () => {
+    const [resp] = await project([
+      makeRecord({ actorType: "user", actorUuid: "user-1", actorName: "Alice" }),
+    ]);
+
+    expect(resp.wakerSession).toBeNull();
+    expect(mockPrisma.daemonSession.findFirst).not.toHaveBeenCalled();
+    const prompt = buildPrompt(toWakeInput(resp));
+    expect(prompt).not.toContain("woke you and has a live session");
+  });
+});
+
+describe("wake-carry-waker-session-anchor — coalesced batch prompt (AC1, buildBatchPrompt)", () => {
+  it("mixed batch: the ONLINE event's block carries the advisory line, the OFFLINE event's block does not", async () => {
+    // Two agent-caused wakes on two DIFFERENT ideas (so buildBatchPrompt keeps them as two
+    // blocks): one online waker, one offline. This is the feature's target scenario — a busy
+    // worker draining a backlog — and the reviewer's expansion of T2 into buildBatchPrompt.
+    const responses = await project([
+      makeRecord({ uuid: "notif-online", entityUuid: ONLINE_IDEA }),
+      makeRecord({ uuid: "notif-offline", entityUuid: OFFLINE_IDEA }),
+    ]);
+    const [online, offline] = responses;
+    expect(online.wakerSession).not.toBeNull();
+    expect(offline.wakerSession).toBeNull();
+
+    const batch = buildBatchPrompt(responses.map(toWakeInput));
+    expect(batch).not.toBeNull();
+
+    // Multi-event path (size > 1): the backlog preamble and two labeled event blocks appear.
+    expect(batch).toContain("queued Chorus events");
+    expect(batch).toContain("### Event 1");
+    expect(batch).toContain("### Event 2");
+
+    // The advisory line appears EXACTLY ONCE — only in the online waker's block; the offline
+    // event contributes no anchor line.
+    expect(occurrences(batch as string, ADVISORY_ONLINE)).toBe(1);
+    expect(occurrences(batch as string, "woke you and has a live session open on this resource")).toBe(1);
+  });
+
+  it("size-1 renderable batch is byte-identical to buildPrompt and still carries the anchor", async () => {
+    const [resp] = await project([makeRecord()]);
+    const single = buildPrompt(toWakeInput(resp));
+    const batch = buildBatchPrompt([toWakeInput(resp)]);
+    // buildBatchPrompt delegates a lone renderable event to buildPrompt verbatim.
+    expect(batch).toBe(single);
+    expect(batch).toContain(ADVISORY_ONLINE);
+  });
+});

--- a/src/services/daemon-session.service.ts
+++ b/src/services/daemon-session.service.ts
@@ -15,7 +15,8 @@
 // no turn/session business logic lives in routes (service-layer convention).
 //
 // It reuses, never re-models:
-//   - `lineage.service.resolveRootIdea` for `directIdeaUuid` resolution, and
+//   - `lineage.service.resolveDirectIdeaUuid` (re-exported below) for a session's
+//     idea anchor — the shallow, no-ancestry-climb direct-idea primitive, and
 //   - the connection registry's exported `STALE_THRESHOLD_MS` for the single
 //     offline/staleness verdict used by `assertContinuable` (no second constant).
 //
@@ -28,7 +29,9 @@
 import { Prisma } from "@/generated/prisma/client";
 import { prisma } from "@/lib/prisma";
 import { eventBus } from "@/lib/event-bus";
-import { resolveRootIdea, type LineageEntityType } from "@/services/lineage.service";
+// Re-export the canonical DIRECT-idea primitive so the notification chokepoint and the
+// waker-session anchor resolve a session's idea anchor from ONE source (no ancestry climb).
+export { resolveDirectIdeaUuid } from "@/services/lineage.service";
 // The single offline/staleness verdict lives in the connection registry. Import it
 // here (rather than restate the number) so producer (the SSE heartbeat that bumps
 // lastSeenAt) and this consumer can never drift — exactly as the execution service
@@ -480,23 +483,6 @@ export async function resolveOrCreateSession(params: {
     },
   });
   return toSessionView(row);
-}
-
-/**
- * Resolve the `directIdeaUuid` for an entity via the shared lineage resolver, so the
- * notification chokepoint can derive a session's idea anchor without re-implementing
- * the multi-hop walk. Returns the direct idea uuid (the FIRST idea node on the
- * lineage), or null when the entity has no idea ancestor (a success, not an error —
- * the session is then ad-hoc and keyed on a server-generated uuid by the caller).
- * companyUuid-scoped via the lineage getters; a query failure propagates.
- */
-export async function resolveDirectIdeaUuid(
-  companyUuid: string,
-  entityType: LineageEntityType,
-  entityUuid: string,
-): Promise<string | null> {
-  const result = await resolveRootIdea(companyUuid, entityType, entityUuid);
-  return result.directIdeaUuid;
 }
 
 // ===== Turn lifecycle =====

--- a/src/services/lineage.service.ts
+++ b/src/services/lineage.service.ts
@@ -96,6 +96,73 @@ export async function resolveRootIdea(
 }
 
 /**
+ * Resolve an entity's DIRECT idea anchor — the first idea node of its lineage — WITHOUT
+ * walking parent/container idea ancestry. This is the canonical direct-idea primitive:
+ * it keys the `DaemonSession` (`--session-id`, via notification-turn) AND derives the
+ * waker-session anchor (via notification.service), so both stay same-source by
+ * construction.
+ *
+ * Per spec `agent-orchestrator-handoff` (and task T1's acceptance criteria) this
+ * resolution MUST read ONLY the resource's own idea anchor and MUST NOT climb
+ * parent/container idea ancestry. It therefore reads at most one idea (the direct one,
+ * for an existence check) and never a `parentUuid`:
+ *   - `idea`      → itself (existence-checked)
+ *   - `task`      → `task.proposalUuid` → the proposal's `inputUuids[0]` idea
+ *   - `document`  → `doc.proposalUuid`  → the proposal's `inputUuids[0]` idea
+ *   - `proposal`  → its own `inputUuids[0]` idea
+ *
+ * Returns null on any broken link (quick task / standalone document with no proposal,
+ * a non-idea proposal input, an empty input list, a missing/cross-company entity) — the
+ * same "no idea ancestor" successful-null outcome as `resolveRootIdea().directIdeaUuid`,
+ * to which this is VALUE-identical while reading strictly fewer rows (no ancestry).
+ * companyUuid-scoped via the same raw getters; a query failure propagates.
+ */
+export async function resolveDirectIdeaUuid(
+  companyUuid: string,
+  entityType: LineageEntityType,
+  entityUuid: string
+): Promise<string | null> {
+  switch (entityType) {
+    case "idea": {
+      const idea = await getIdeaByUuid(companyUuid, entityUuid);
+      return idea ? idea.uuid : null;
+    }
+    case "task": {
+      const task = await getTaskByUuid(companyUuid, entityUuid);
+      if (!task?.proposalUuid) return null;
+      return directIdeaOfProposal(companyUuid, task.proposalUuid);
+    }
+    case "document": {
+      const doc = await getDocumentByUuid(companyUuid, entityUuid);
+      if (!doc?.proposalUuid) return null;
+      return directIdeaOfProposal(companyUuid, doc.proposalUuid);
+    }
+    case "proposal":
+      return directIdeaOfProposal(companyUuid, entityUuid);
+    default:
+      // Unreachable for typed callers; defensive for runtime (e.g. MCP input).
+      return null;
+  }
+}
+
+/**
+ * The direct input idea of a proposal: `inputUuids[0]` when the proposal is idea-derived
+ * and that idea exists in this company. Never reads the idea's ancestry (no `parentUuid`
+ * hop) — mirrors `resolveFromProposal`'s FIRST idea node without the `walkToRoot` climb.
+ */
+async function directIdeaOfProposal(
+  companyUuid: string,
+  proposalUuid: string
+): Promise<string | null> {
+  const proposal = await getProposalByUuid(companyUuid, proposalUuid);
+  if (!proposal || proposal.inputType !== "idea") return null;
+  const inputUuids = normalizeUuidArray(proposal.inputUuids);
+  if (inputUuids.length === 0) return null;
+  const idea = await getIdeaByUuid(companyUuid, inputUuids[0]);
+  return idea ? idea.uuid : null;
+}
+
+/**
  * Inner resolver: produces every field of ResolveRootIdeaResult EXCEPT directIdeaUuid,
  * which the public wrapper derives from `lineage`. Returns the field typed as optional so
  * the branches need not set it; the wrapper always fills it in.

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -206,12 +206,12 @@ async function formatNotifications(
   //   - idea entity  → the idea itself (`entityUuid`, no lookup, no traversal).
   //   - task entity  → the task's DIRECT containing idea. A Task has no `ideaUuid` column;
   //                    it links to its idea via `proposalUuid` → Proposal.inputUuids[0].
-  //                    `resolveDirectIdeaUuid` returns exactly that FIRST idea node — the
-  //                    resource's own direct idea, NOT the lineage/parent root — which is also
-  //                    the business key the idea-anchored `DaemonSession` is stored under
-  //                    (`sessionId === directIdeaUuid`), so the anchor lookup can match a real
-  //                    session. This reads the direct anchor only; it never resolves to a
-  //                    parent/container idea (the AC's no-ancestry-climb rule).
+  //                    `resolveDirectIdeaUuid` (the shallow canonical primitive) reads exactly
+  //                    that — task → proposal → inputUuids[0] — and NEVER hops a `parentUuid`,
+  //                    honoring the AC's no-ancestry-climb rule. It is the SAME primitive that
+  //                    keys the idea-anchored `DaemonSession` (`sessionId === directIdeaUuid`,
+  //                    via notification-turn), so the anchor lookup matches a real session by
+  //                    construction — same source, no parent/container/root idea ever read.
   // User-actor wakes and proposal/document-addressed wakes never qualify.
 
   // (a) Batch-resolve the direct idea for each distinct agent-caused TASK wake (one resolve

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -5,10 +5,15 @@
 import { prisma } from "@/lib/prisma";
 import { eventBus } from "@/lib/event-bus";
 import { createTurnAndResolveTarget } from "@/services/notification-turn";
-import type { TurnView } from "@/services/daemon-session.service";
+import {
+  resolveDirectIdeaUuid,
+  type TurnView,
+} from "@/services/daemon-session.service";
 import {
   resolveResourceOrchestrator,
+  resolveWakerSessionAnchor,
   type OrchestratorAttribution,
+  type WakerSessionAnchor,
 } from "@/services/orchestrator.service";
 
 // ===== Type Definitions =====
@@ -90,6 +95,15 @@ export interface NotificationResponse {
   // it into the wake prompt.
   instructionText: string | null;
   orchestrator: OrchestratorAttribution | null;
+  // Derived, NON-persisted waker-session anchor (wake-carry-waker-session-anchor, T1). Present
+  // (non-null) ONLY for an agent-caused wake on an idea/task-anchored resource whose waking
+  // agent has a live, ONLINE-origin session for that idea — it tells a woken peer that replying
+  // on this resource reaches the waker's existing live session. A SIBLING of `orchestrator`
+  // (actor-scoped vs assignment-scoped): either, both, or neither may be present, and they may
+  // name different agents. Null for user-actor wakes, an offline/missing waker session, and
+  // proposal/document-addressed wakes (no idea/task key). Derived at read time from existing
+  // session + connection state — no schema column, no write.
+  wakerSession: WakerSessionAnchor | null;
 }
 
 export interface NotificationPreferenceFields {
@@ -185,11 +199,98 @@ async function formatNotifications(
     }),
   );
 
-  return notifications.map((notification) => {
+  // ===== Waker-session anchor (wake-carry-waker-session-anchor, T1) =====
+  // For an AGENT-caused wake on an idea/task-anchored resource, resolve the waking agent's
+  // live session anchor so the woken peer can be told where a reply lands. The waker is the
+  // notification's actor (`actorUuid`). Two idea anchors:
+  //   - idea entity  → the idea itself (`entityUuid`, no lookup, no traversal).
+  //   - task entity  → the task's DIRECT containing idea. A Task has no `ideaUuid` column;
+  //                    it links to its idea via `proposalUuid` → Proposal.inputUuids[0].
+  //                    `resolveDirectIdeaUuid` returns exactly that FIRST idea node — the
+  //                    resource's own direct idea, NOT the lineage/parent root — which is also
+  //                    the business key the idea-anchored `DaemonSession` is stored under
+  //                    (`sessionId === directIdeaUuid`), so the anchor lookup can match a real
+  //                    session. This reads the direct anchor only; it never resolves to a
+  //                    parent/container idea (the AC's no-ancestry-climb rule).
+  // User-actor wakes and proposal/document-addressed wakes never qualify.
+
+  // (a) Batch-resolve the direct idea for each distinct agent-caused TASK wake (one resolve
+  //     per distinct task; the direct idea node, never the ancestry root).
+  const wakerTasks = new Map<string, { companyUuid: string; taskUuid: string }>();
+  for (const n of notifications) {
+    if (n.actorType === "agent" && n.actorUuid && n.entityType === "task") {
+      const key = `${n.companyUuid}:${n.entityUuid}`;
+      if (!wakerTasks.has(key)) {
+        wakerTasks.set(key, { companyUuid: n.companyUuid, taskUuid: n.entityUuid });
+      }
+    }
+  }
+  const taskIdeaUuids = new Map<string, string | null>();
+  await Promise.all(
+    [...wakerTasks.entries()].map(async ([key, { companyUuid, taskUuid }]) => {
+      taskIdeaUuids.set(
+        key,
+        await resolveDirectIdeaUuid(companyUuid, "task", taskUuid),
+      );
+    }),
+  );
+
+  // (b) Per-notification anchor key `(companyUuid, agentUuid, ideaUuid)`, or null when the
+  //     notification does not qualify. Computed once and reused for both the batch-resolve
+  //     target set and the final projection.
+  const wakerKeys = notifications.map((n) => {
+    if (n.actorType !== "agent" || !n.actorUuid) return null;
+    let ideaUuid: string | null = null;
+    if (n.entityType === "idea") {
+      ideaUuid = n.entityUuid;
+    } else if (n.entityType === "task") {
+      ideaUuid = taskIdeaUuids.get(`${n.companyUuid}:${n.entityUuid}`) ?? null;
+    }
+    if (!ideaUuid) return null;
+    return {
+      key: `${n.companyUuid}:${n.actorUuid}:${ideaUuid}`,
+      companyUuid: n.companyUuid,
+      agentUuid: n.actorUuid,
+      ideaUuid,
+    };
+  });
+
+  // (c) Batch-resolve distinct `(agentUuid, ideaUuid)` pairs in parallel, mirroring the
+  //     orchestrator map — at most one session + one connection lookup per distinct pair.
+  const wakerResolveTargets = new Map<
+    string,
+    { companyUuid: string; agentUuid: string; ideaUuid: string }
+  >();
+  for (const parts of wakerKeys) {
+    if (parts && !wakerResolveTargets.has(parts.key)) {
+      wakerResolveTargets.set(parts.key, {
+        companyUuid: parts.companyUuid,
+        agentUuid: parts.agentUuid,
+        ideaUuid: parts.ideaUuid,
+      });
+    }
+  }
+  const wakerAnchors = new Map<string, WakerSessionAnchor | null>();
+  await Promise.all(
+    [...wakerResolveTargets.entries()].map(async ([key, target]) => {
+      wakerAnchors.set(
+        key,
+        await resolveWakerSessionAnchor(
+          target.companyUuid,
+          target.agentUuid,
+          target.ideaUuid,
+        ),
+      );
+    }),
+  );
+
+  return notifications.map((notification, index) => {
     const key = notificationResourceKey(notification);
+    const wakerParts = wakerKeys[index];
     return formatNotification(
       notification,
       key ? orchestrators.get(key) ?? null : null,
+      wakerParts ? wakerAnchors.get(wakerParts.key) ?? null : null,
     );
   });
 }
@@ -197,6 +298,7 @@ async function formatNotifications(
 function formatNotification(
   n: RawNotification,
   orchestrator: OrchestratorAttribution | null,
+  wakerSession: WakerSessionAnchor | null,
 ): NotificationResponse {
   return {
     uuid: n.uuid,
@@ -218,6 +320,9 @@ function formatNotification(
     // Denormalized human_instruction body (子1) — null for every non-instruction action.
     instructionText: n.instructionText ?? null,
     orchestrator,
+    // Derived waker-session anchor (T1) — sibling of `orchestrator`, null unless the waking
+    // agent has a live, online-origin session for this resource's idea.
+    wakerSession,
   };
 }
 

--- a/src/services/orchestrator.service.ts
+++ b/src/services/orchestrator.service.ts
@@ -3,8 +3,70 @@ import {
   resolveAssignmentActor,
   type AssignmentActorInfo,
 } from "@/lib/uuid-resolver";
+import { listConnectionsForAgent } from "@/services/daemon-connection.service";
 
 export type OrchestratorAttribution = AssignmentActorInfo & { type: "agent" };
+
+/**
+ * The waker's live session anchor (wake-carry-waker-session-anchor, T1). A derived,
+ * NEVER-persisted pointer telling a woken peer WHERE the waking agent's live conversation
+ * is, so a reply on this resource lands back in the waker's existing idea-anchored session
+ * instead of scattering into a new one.
+ *
+ * It is a SIBLING of `OrchestratorAttribution`, not a sub-field: `orchestrator` is
+ * ASSIGNMENT-scoped (the resource's `assignedBy*` provenance), whereas this anchor is
+ * ACTOR-scoped (the wake's agent actor). Either, both, or neither may be present on a wake,
+ * and they may identify different agents.
+ *
+ *  - `agentUuid` — the waking agent (= the notification's `actorUuid`).
+ *  - `agentName` — the waking agent's current display name (= the notification's `actorName`;
+ *    sourced here from the live connection registry so the resolver stays self-contained).
+ *  - `ideaUuid` — the idea whose session a reply reaches (`DaemonSession.sessionId`).
+ */
+export interface WakerSessionAnchor {
+  agentUuid: string;
+  agentName: string;
+  ideaUuid: string;
+}
+
+/**
+ * Resolve the waker's live session anchor for an idea-anchored wake — modeled on
+ * `resolveIdeaSessionOriginTarget` (notification-turn.ts): find the waking agent's
+ * `DaemonSession` whose business key is the idea (`sessionId === ideaUuid`), and confirm its
+ * `originConnectionUuid` maps to a connection whose `effectiveStatus === "online"`. The anchor
+ * is returned ONLY when that origin is currently online (the reply has a live place to land);
+ * a missing session or an offline origin yields null (notify-only — the accepted V1 boundary).
+ *
+ * DISCIPLINE (spec `agent-orchestrator-handoff`): resolution reads ONLY the passed idea anchor
+ * — the caller supplies the resource's OWN direct idea (an idea entity is its own anchor; a
+ * task's anchor is its direct `ideaUuid`). This helper never traverses parent/container idea
+ * ancestry, proposals, or documents.
+ *
+ * Cost: at most one `DaemonSession` lookup plus one connection-registry read per distinct
+ * `(agentUuid, ideaUuid)` — the caller batches by that pair, mirroring the orchestrator map.
+ * `agentName` is taken from the matched online connection's joined `agentName` (no extra
+ * query); it is the same `Agent.name` the notification denormalized as `actorName`.
+ */
+export async function resolveWakerSessionAnchor(
+  companyUuid: string,
+  agentUuid: string,
+  ideaUuid: string,
+): Promise<WakerSessionAnchor | null> {
+  const session = await prisma.daemonSession.findFirst({
+    where: { companyUuid, agentUuid, sessionId: ideaUuid },
+    select: { originConnectionUuid: true },
+  });
+  if (!session) return null;
+
+  const connections = await listConnectionsForAgent(companyUuid, agentUuid);
+  const origin = connections.find(
+    (c) =>
+      c.uuid === session.originConnectionUuid && c.effectiveStatus === "online",
+  );
+  if (!origin) return null;
+
+  return { agentUuid, agentName: origin.agentName ?? "", ideaUuid };
+}
 
 /**
  * Resolve the latest explicit agent assigner for the directly addressed resource.


### PR DESCRIPTION
## What

Agent-originated idea/task wakes now surface the **waker agent's live session anchor** to the woken peer, so a reply on the shared resource lands back in the waker's existing session instead of opening a new one. Advisory only — no routing change.

Idea `3027f71a` (theme `f10eeb04` — multi-agent orchestration reliability) · Proposal `7e0d1a05` · OpenSpec `2026-09-07-wake-carry-waker-session-anchor`.

## Changes

- **Server** (`src/services/orchestrator.service.ts`, `src/services/notification.service.ts`): derived, non-persisted `wakerSession` `{agentUuid, agentName, ideaUuid}` as a **sibling** of `orchestrator` on `NotificationResponse`, resolved at read time in `formatNotifications` via `resolveWakerSessionAnchor` (online-origin-gated; idea→itself, task→direct containing idea via `resolveDirectIdeaUuid`, no ancestry climb). **No schema column, no routing change.**
- **Daemon prompt** (`cli/prompts.mjs` + OpenClaw twin `packages/openclaw-plugin/src/event-router.ts`): advisory `wakerSessionGuidance` in `buildPrompt` **and per-block in `buildBatchPrompt`** (the coalesced busy-worker path); byte-identical across the two twins; explicitly advisory, no server-routing claim.
- **Orchestrate skill docs**: the "reply-here-reaches-the-waker" semantics + offline notify-only boundary, across all plugin surfaces.
- **Tests**: unit (server + both prompt twins) + a real end-to-end integration test; OpenSpec archived (`agent-orchestrator-handoff` +2 requirements).

## Design note

The elaboration answer was "extend the orchestrator attribution (no schema column)". Grounding showed `OrchestratorAttribution` is assignment-scoped, but the anchor must be **actor-scoped** (present even with no orchestrator), so it's an independent read-time field reusing the same derivation/prompt-append plumbing — honoring the intent (no DB state) while staying correct.

## Scope boundary

Idea/task-anchored only; advisory-only; notify-only when the waker is offline. Out of scope (sibling theme children): ad-hoc peer anchoring, enforced return-routing, offline queue/replay, single-active-per-theme, DAG auto-advancer.

## Verification

- Independent proposal review, per-task reviews, and the ship-time code-review gateway all PASS (round 1).
- Full suite 5658 pass / 17 **pre-existing** unrelated cli spawner-daemon failures.
- **Live Claude+Codex e2e** on the deployed server: real peer-wake round-trip — the woken peer's return notifications carried the populated `wakerSession`; user-actor and proposal-entity notifications correctly `null`. The daemon-rendered prompt line is integration-test-covered (the live daemon had cached the pre-change `cli/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)