### PR TITLE
test(cli): isolate the CLI suite from the real ~/.chorus state

### DIFF
--- a/cli/__tests__/codex-backend-integration.test.mjs
+++ b/cli/__tests__/codex-backend-integration.test.mjs
@@ -11,15 +11,20 @@
 //      CodexSpawner; driving its wake() through a fake spawn yields the expected
 //      `codex exec --json` (new) and `codex exec resume <id>` (known anchor) argv,
 //      prompt on stdin, daemon URL/key in the child env (never argv).
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 import { EventEmitter } from "node:events";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildDaemon } from "../daemon.mjs";
 import { ClaudeSpawner } from "../claude-spawner.mjs";
 import { CodexSpawner } from "../codex-spawner.mjs";
 import { getThreadId, setThreadId } from "../codex-session-map.mjs";
+import {
+  codexUsageMapPath,
+  getCodexUsageSnapshot,
+  setCodexUsageSnapshot,
+} from "../codex-usage-map.mjs";
 import { Waker } from "../waker.mjs";
 import { createTranscriptUploadHooks } from "../upload-hooks.mjs";
 import { killProcessTree } from "../process-killer.mjs";
@@ -28,6 +33,30 @@ const CREDS = { url: "https://chorus.test", apiKey: "cho_daemonkey" };
 const ANCHOR = "11111111-1111-4111-8111-111111111111";
 const TID = "019f091a-844e-7b43-8c31-6b04ffa38149";
 const silent = { info() {}, warn() {}, error() {} };
+
+// ===== Test hygiene: never write the DEVELOPER's real usage map ===============
+// The Codex usage map's default path is ~/.chorus/codex-usage.json. Tests that
+// exercise the real capture path (rather than stubbing it) must point it at a temp
+// file, and this file asserts at the end that nothing wrote the real one. The
+// developer's file may legitimately exist, so the guard compares CONTENT (before vs
+// after) instead of asserting absence — only an actual write fails it.
+const REAL_USAGE_MAP = codexUsageMapPath();
+const readRealUsageMap = () =>
+  existsSync(REAL_USAGE_MAP) ? readFileSync(REAL_USAGE_MAP, "utf8") : null;
+let realUsageMapBefore = null;
+beforeAll(() => {
+  realUsageMapBefore = readRealUsageMap();
+});
+afterAll(() => {
+  expect(readRealUsageMap()).toBe(realUsageMapBefore);
+});
+
+// Temp usage-map file for tests that keep the real capture/normalize logic.
+const USAGE_DIR = mkdtempSync(join(tmpdir(), "chorus-codex-usage-"));
+const USAGE_PATH = join(USAGE_DIR, "codex-usage.json");
+afterAll(() => {
+  rmSync(USAGE_DIR, { recursive: true, force: true });
+});
 
 // Real codex-cli 0.145.0 turn.completed usage frame (verified live + against
 // ../codex/codex-rs/exec/src/exec_events.rs Usage struct).
@@ -174,6 +203,7 @@ describe("codex backend end-to-end argv (via the daemon-selected spawner)", () =
   it("resumes an interrupted first turn from persisted state in a fresh spawner", async () => {
     const dir = mkdtempSync(join(tmpdir(), "chorus-codex-interrupt-"));
     const path = join(dir, "codex-sessions.json");
+    const usagePath = join(dir, "codex-usage.json");
     const children = [];
     const calls = [];
     const makeSpawner = () =>
@@ -185,6 +215,11 @@ describe("codex backend end-to-end argv (via the daemon-selected spawner)", () =
         logger: silent,
         getThreadIdFn: (anchor) => getThreadId(anchor, { path, logger: silent }),
         setThreadIdFn: (anchor, threadId) => setThreadId(anchor, threadId, { path, logger: silent }),
+        // Isolated usage map — the default would write ~/.chorus/codex-usage.json.
+        getUsageSnapshotFn: (anchor, threadId) =>
+          getCodexUsageSnapshot(anchor, threadId, { path: usagePath, logger: silent }),
+        setUsageSnapshotFn: (anchor, threadId, usage) =>
+          setCodexUsageSnapshot(anchor, threadId, usage, { path: usagePath, logger: silent }),
         spawnImpl: (_command, argv) => {
           calls.push(argv);
           const child = makeFakeChild();
@@ -213,6 +248,7 @@ describe("codex backend end-to-end argv (via the daemon-selected spawner)", () =
   it("keeps resuming the same known thread after an interrupted resumed wake", async () => {
     const dir = mkdtempSync(join(tmpdir(), "chorus-codex-reinterrupt-"));
     const path = join(dir, "codex-sessions.json");
+    const usagePath = join(dir, "codex-usage.json");
     setThreadId(ANCHOR, TID, { path, logger: silent });
     const calls = [];
     const children = [];
@@ -225,6 +261,11 @@ describe("codex backend end-to-end argv (via the daemon-selected spawner)", () =
         logger: silent,
         getThreadIdFn: (anchor) => getThreadId(anchor, { path, logger: silent }),
         setThreadIdFn: (anchor, threadId) => setThreadId(anchor, threadId, { path, logger: silent }),
+        // Isolated usage map — the default would write ~/.chorus/codex-usage.json.
+        getUsageSnapshotFn: (anchor, threadId) =>
+          getCodexUsageSnapshot(anchor, threadId, { path: usagePath, logger: silent }),
+        setUsageSnapshotFn: (anchor, threadId, usage) =>
+          setCodexUsageSnapshot(anchor, threadId, usage, { path: usagePath, logger: silent }),
         spawnImpl: (_command, argv) => {
           calls.push(argv);
           const child = makeFakeChild();
@@ -276,7 +317,8 @@ describe("codex token usage end-to-end (daemon-token-usage): real CodexSpawner �
    * Build a Waker driven by the REAL CodexSpawner (fake child process) and the REAL
    * transcript upload hooks, capturing every advanceTurn payload. The stream frames the
    * fake codex child emits on stdout are the test's input. This exercises capture →
-   * onSessionEnd → waker #advanceTurn (terminal edge) together — no mocked usage.
+   * onSessionEnd → waker #advanceTurn (terminal edge) together — no mocked usage, but
+   * pointed at an ISOLATED usage file so the developer's real map stays untouched.
    */
   function makeCodexWaker({ streamFrames, exitCode = 0, batchDelayMs = 0 } = {}) {
     const child = makeFakeChild();
@@ -288,6 +330,10 @@ describe("codex token usage end-to-end (daemon-token-usage): real CodexSpawner �
       logger: silent,
       getThreadIdFn: () => null,
       setThreadIdFn: () => {},
+      getUsageSnapshotFn: (anchor, threadId) =>
+        getCodexUsageSnapshot(anchor, threadId, { path: USAGE_PATH, logger: silent }),
+      setUsageSnapshotFn: (anchor, threadId, usage) =>
+        setCodexUsageSnapshot(anchor, threadId, usage, { path: USAGE_PATH, logger: silent }),
       // Emit the stream frames + close AFTER the spawner has attached its stdout/close
       // listeners. spawnImpl returns synchronously and the listeners are wired right after;
       // queueMicrotask defers the emission just past that synchronous wiring so `close`

--- a/cli/__tests__/daemon-claude-notfound-warning.test.mjs
+++ b/cli/__tests__/daemon-claude-notfound-warning.test.mjs
@@ -1,9 +1,26 @@
 // cli/__tests__/daemon-claude-notfound-warning.test.mjs
 // Covers daemon-startup-output spec: a missing `claude` emits exactly one loud ⚠
 // stderr warning at startup, while the daemon STILL subscribes (non-fatal).
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runDaemon } from "../daemon.mjs";
 import { agentNotFoundWarningLine, claudeNotFoundWarningLine } from "../daemon-banner.mjs";
+
+// Isolate from the DEVELOPER's real ~/.chorus state: runDaemon's config readers
+// (credentials, cwds, sigint timeout, daemon.json agents) resolve paths through
+// homedir(), so a machine that actually runs a configured daemon would otherwise
+// change this file's behavior. HOME points at a temp dir for this file only.
+const REAL_HOME = process.env.HOME;
+const TMP_HOME = mkdtempSync(join(tmpdir(), "chorus-notfound-home-"));
+beforeAll(() => {
+  process.env.HOME = TMP_HOME;
+});
+afterAll(() => {
+  process.env.HOME = REAL_HOME;
+  rmSync(TMP_HOME, { recursive: true, force: true });
+});
 
 /** Minimal happy-path deps; per-test overrides merge on top. */
 function baseDeps(over = {}) {

--- a/cli/__tests__/daemon-credential-completion.test.mjs
+++ b/cli/__tests__/daemon-credential-completion.test.mjs
@@ -1,9 +1,25 @@
 // cli/__tests__/daemon-credential-completion.test.mjs
 // Covers cli-auth ADDED requirement: interactive credential completion at
 // daemon start (TTY only); non-TTY preserves the hard error.
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runDaemon } from "../daemon.mjs";
 import { writeLoginFile } from "../login.mjs";
+
+// Isolate from the DEVELOPER's real ~/.chorus state (see the same block in the sibling
+// runDaemon suites): otherwise a machine with a configured daemon.json changes what
+// these preflight/completion tests observe.
+const REAL_HOME = process.env.HOME;
+const TMP_HOME = mkdtempSync(join(tmpdir(), "chorus-credcompletion-home-"));
+beforeAll(() => {
+  process.env.HOME = TMP_HOME;
+});
+afterAll(() => {
+  process.env.HOME = REAL_HOME;
+  rmSync(TMP_HOME, { recursive: true, force: true });
+});
 
 const NO_CREDS = () => {
   throw new Error(

--- a/cli/__tests__/daemon-integration.test.mjs
+++ b/cli/__tests__/daemon-integration.test.mjs
@@ -2,13 +2,25 @@
 // Full-chain integration: a task_assigned SSE event flows through the assembled
 // daemon (mock MCP + mock SSE + mock claude subprocess) all the way to the
 // spawn args. Covers the integration AC and "task-dispatch wakes Claude Code".
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EventEmitter } from "node:events";
 import { buildDaemon, runDaemon } from "../daemon.mjs";
 import { transcriptPath, SESSION_CONFLICT_FAILURE } from "../claude-spawner.mjs";
+
+// Isolate from the DEVELOPER's real ~/.chorus state (see the sibling runDaemon suites):
+// a machine with a configured daemon.json must not change this file's behavior.
+const REAL_HOME = process.env.HOME;
+const TMP_HOME = mkdtempSync(join(tmpdir(), "chorus-integration-home-"));
+beforeAll(() => {
+  process.env.HOME = TMP_HOME;
+});
+afterAll(() => {
+  process.env.HOME = REAL_HOME;
+  rmSync(TMP_HOME, { recursive: true, force: true });
+});
 
 const silent = { info() {}, warn() {}, error() {} };
 

--- a/cli/__tests__/daemon-lifecycle-dispatch.test.mjs
+++ b/cli/__tests__/daemon-lifecycle-dispatch.test.mjs
@@ -1,8 +1,23 @@
 // cli/__tests__/daemon-lifecycle-dispatch.test.mjs
 // Covers runDaemon's lifecycle-action dispatch (stop/status/restart/logs) and
 // the -d detach ordering (foreground preflight BEFORE detach; double-start guard).
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runDaemon, DETACHED_ENV } from "../daemon.mjs";
+
+// Isolate from the DEVELOPER's real ~/.chorus state (see the sibling runDaemon suites):
+// a machine with a configured daemon.json must not change this file's behavior.
+const REAL_HOME = process.env.HOME;
+const TMP_HOME = mkdtempSync(join(tmpdir(), "chorus-lifecycle-home-"));
+beforeAll(() => {
+  process.env.HOME = TMP_HOME;
+});
+afterAll(() => {
+  process.env.HOME = REAL_HOME;
+  rmSync(TMP_HOME, { recursive: true, force: true });
+});
 
 /** A fake lifecycle injected into runDaemon. */
 function fakeLifecycle(over = {}) {

--- a/cli/__tests__/daemon-permission-wiring.test.mjs
+++ b/cli/__tests__/daemon-permission-wiring.test.mjs
@@ -4,9 +4,24 @@
 // threaded into build(). Also covers recordYoloAck (preserve creds) and login
 // PRESERVING the ack via field-level merge (daemon-config-field-merge) — those
 // helpers still exist even though the daemon path no longer prompts/persists an ack.
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runDaemon } from "../daemon.mjs";
 import { recordYoloAck, writeLoginFile } from "../login.mjs";
+
+// Isolate from the DEVELOPER's real ~/.chorus state (see the sibling runDaemon suites):
+// a machine with a configured daemon.json must not change this file's behavior.
+const REAL_HOME = process.env.HOME;
+const TMP_HOME = mkdtempSync(join(tmpdir(), "chorus-permwiring-home-"));
+beforeAll(() => {
+  process.env.HOME = TMP_HOME;
+});
+afterAll(() => {
+  process.env.HOME = REAL_HOME;
+  rmSync(TMP_HOME, { recursive: true, force: true });
+});
 
 /** Minimal happy-path deps; per-test overrides merge on top. */
 function baseDeps(over = {}) {


### PR DESCRIPTION
Two ways the CLI suite depended on the *developer's* real `~/.chorus` state. Both are invisible in CI (where that directory does not exist), so they only surface once someone actually runs the daemon — i.e. the more the project is used, the more likely they are to bite.

## 1. The suite wrote the developer's real usage map

`codex-backend-integration.test.mjs` injected a temp path for the codex *session* map but let the *usage* map fall back to its default, so running the suite created (or overwrote) `~/.chorus/codex-usage.json` with fixture data — observed key `33333333-…`, thread `019f091a-…`. Three spawner constructions were affected.

Fix: every usage-map call in that file is pointed at an isolated temp file, so the real capture/normalize code path stays exercised. In addition the file now snapshots the **real** path's content in `beforeAll` and asserts it is unchanged in `afterAll` — comparing content rather than asserting absence, so a developer who legitimately has that file cannot get a false positive.

The guard was verified by removing one injection: the real file reappeared and the guard failed (`expected '{…33333333…' to be null`); restoring it turned the file green again.

## 2. Five `runDaemon` suites read the developer's real `daemon.json`

`daemon-claude-notfound-warning`, `daemon-credential-completion`, `daemon-integration`, `daemon-lifecycle-dispatch` and `daemon-permission-wiring` build their deps inline with no `loginPath` / `readJson` override, so `runDaemon` read the machine's real `~/.chorus/daemon.json`. Once that file contains an `agents[]` array, `hasConfiguredAgents()` sends them down the multi-agent branch and 14 assertions fail.

Fix: each of the five suites points `HOME` at its own temp dir (`beforeAll`/`afterAll`), which isolates every HOME-derived reader — `daemon.json`, the codex maps, `~/.claude/settings.json` — rather than patching one reader per test.

Measured on a pristine `origin/main` checkout with a real two-agent `daemon.json` present:

| | files | tests |
|---|---|---|
| before | 5 failed / 83 passed | 14 failed / 1504 passed |
| after | 89 passed | 1580 passed |

(Unrelated pre-existing failures in four `src/**` files in this environment — jsdom `localStorage` unavailable and a zh locale — reproduce identically on a pristine `origin/main` checkout and are not touched by this PR.)
