### PR TITLE
docs(openspec): align the specs of record with pi being wakeable

### DIFF
--- a/cli/init/steps/credential-seed.mjs
+++ b/cli/init/steps/credential-seed.mjs
@@ -68,7 +68,7 @@ function nonEmpty(value) {
  * Whether an init selection id is the DeepSeek Harness (dsh). dsh needs a SECOND
  * credential sink beyond ~/.chorus/daemon.json — see {@link writeDshCredentialsEnv}.
  * We gate on the selection id, NOT the daemon agentType: dsh maps to the shared
- * "offline" agentType (agent-type-map.mjs) alongside opencode/openclaw/pi, so the
+ * "offline" agentType (agent-type-map.mjs) alongside opencode/openclaw, so the
  * agentType cannot single dsh out. The id can.
  * @param {string} id
  */

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -2,8 +2,9 @@
 
 The Chorus daemon is a local, long-lived client. It connects to a remote Chorus
 server, subscribes to the agent notification stream, and wakes a local headless
-Claude Code on task dispatch — so an assigned agent can act on work even when no
-one is at a terminal.
+coding agent on task dispatch — so an assigned agent can act on work even when no
+one is at a terminal. The backend is selectable per agent and defaults to
+Claude Code.
 
 ```bash
 npx @chorus-aidlc/chorus daemon          # foreground
@@ -194,7 +195,7 @@ agent **overrides** it for that agent only. Per-agent fields:
 |-------|---------|
 | `apiKey` | *(required)* the agent's `cho_` key — determines its identity |
 | `url` | Chorus server (may differ per agent — different server/company) |
-| `agentType` | `claude-code` \| `codex` \| `kiro` (backends may be mixed) |
+| `agentType` | `claude-code` \| `codex` \| `kiro` \| `pi` \| `dsh` \| `offline` (backends may be mixed; `offline` is never woken) |
 | `cwds` | working directories this agent serves (one connection each) |
 | `permissionMode` | `yolo` \| `chorus` |
 | `maxConcurrency` | this agent's own wake-concurrency cap (default `4`) |

--- a/openspec/changes/archive/2026-09-10-fix-pi-wakeable-spec-drift/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-fix-pi-wakeable-spec-drift/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-fix-pi-wakeable-spec-drift/README.md
+++ b/openspec/changes/archive/2026-09-10-fix-pi-wakeable-spec-drift/README.md
@@ -1,0 +1,3 @@
+# fix-pi-wakeable-spec-drift
+
+Align the older specs with `pi` being a wakeable daemon backend (spec/doc drift only).

--- a/openspec/changes/archive/2026-09-10-fix-pi-wakeable-spec-drift/proposal.md
+++ b/openspec/changes/archive/2026-09-10-fix-pi-wakeable-spec-drift/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`pi` became a first-class wakeable daemon backend in `add-daemon-pi-backend` — `cli/init/agent-type-map.mjs` maps `pi` → `"pi"` (not `"offline"`), `KNOWN_AGENTS` includes it, `selectSpawner` has an explicit `PiSpawner` branch, and `isWakeableAgentType("pi")` is true. That change updated the `pi-daemon-backend` capability but left **older statements in two other capabilities** describing `pi` as not wakeable, so the spec of record contradicts itself and contradicts the code:
+
+- `daemon-multi-agent`: the offline-classification requirement lists `pi` among the backends that map to `offline`, and the backend-selection requirement's example list omits `pi`.
+- `chorus-init`: two requirements (the init→`agentType` mapping and the init daemon-wake opt-in) list `pi` as a non-wakeable/`offline` selection — directly contradicting `pi-daemon-backend`'s "`pi` → `pi` (no longer `offline`)" requirement.
+
+A reader (or a future change) following the stale text would classify a pi agent as never-woken. This change is **documentation-of-record only**: no runtime behavior changes, no new requirement semantics — the corrected text states what the code already does.
+
+Found while implementing the per-agent `model`/`thinking` feature (#549): a code-review NOTE flagged one of the sentences, and an exhaustive grep then showed the other three.
+
+## What Changes
+
+- `daemon-multi-agent` — **Per-agent backend selection**: the example backend list gains `pi`, and a scenario pins the claude-code + pi pairing (the pairing that was verified live end-to-end).
+- `daemon-multi-agent` — **Offline agent type is a valid, never-woken agents[] entry**: the fail-closed list drops `pi` (it stays for `opencode`, `openclaw`, and `dsh` while its backend is de-advertised).
+- `chorus-init` — **Daemon backend agentType derived from the init selection…**: the mapping sentence states `pi` → `pi`, the fail-closed list drops `pi`, the "non-wakeable maps to offline" scenario no longer uses `pi` as its example, and a new scenario pins the pi mapping.
+- `chorus-init` — **Per-agent daemon-wake defaults off at init…**: the wakeable-backend list gains `pi`, and the "offline agent gets no daemonWake field" scenario no longer lists `pi`.
+- `docs/DAEMON.md` — the per-agent `agentType` row lists the full accepted set (including `pi`), and the intro line no longer says the daemon wakes "a local headless Claude Code" only (the backend is selectable and defaults to claude-code).
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None. -->
+
+### Modified Capabilities
+
+- `daemon-multi-agent`: backend-selection list + scenario, and the offline fail-closed classification list.
+- `chorus-init`: the init→`agentType` mapping requirement (text + one scenario + one new scenario) and the per-agent `daemonWake` opt-in requirement (text + one scenario).
+
+## Impact
+
+- **Spec/docs only** — no `cli/**`, `src/**`, `prisma/**` or test change; nothing to migrate.
+- The corrected statements are pinned by the existing tests for the code they describe (`cli/__tests__/init-agent-type-map.test.mjs`, `daemon-agent.test.mjs`, `spawner-select.test.mjs`, `pi-spawner.test.mjs`), which already assert `pi` → `pi` and `isWakeableAgentType("pi") === true`; this change makes the prose match those assertions.

--- a/openspec/changes/archive/2026-09-10-fix-pi-wakeable-spec-drift/specs/chorus-init/spec.md
+++ b/openspec/changes/archive/2026-09-10-fix-pi-wakeable-spec-drift/specs/chorus-init/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Daemon backend agentType derived from the init selection, not re-prompted
+
+The daemon-setup step SHALL derive each agent's `daemon.json` backend `agentType` from the agents already chosen in the `chorus agents add` selection step, and SHALL NOT render a separate "which agent backend?" selection prompt. The step-1 selection is the single point at which the agent set is chosen; the credential-seed and daemon-setup steps consume that same selection.
+
+The mapping from an init selection id to a `daemon.json` `agentType` SHALL be explicit and total: the init id `claude` maps to `agentType: "claude-code"`; `codex` → `codex`; `kiro` → `kiro`; `pi` → `pi`; and any selected agent whose backend is not daemon-wakeable (`opencode`, `openclaw`, and `dsh` while its daemon backend is de-advertised) maps to `agentType: "offline"`. The mapping MUST NOT pass an init id through verbatim when it differs from the daemon backend name (notably `claude` ≠ `claude-code`).
+
+#### Scenario: No second backend prompt
+- **WHEN** `chorus agents add` proceeds from agent selection into the daemon-setup step on a TTY
+- **THEN** the step derives each agent's `agentType` from the selection and does not display an agent-backend menu again
+
+#### Scenario: claude selection maps to the claude-code agentType
+- **WHEN** the init selection includes the `claude` adapter id
+- **THEN** its `agents[]` entry records `agentType: "claude-code"` (not `claude`), matching the daemon's `KNOWN_AGENTS` vocabulary
+
+#### Scenario: pi selection maps to the wakeable pi agentType
+- **WHEN** the init selection includes the `pi` adapter id
+- **THEN** its `agents[]` entry records `agentType: "pi"` — a wakeable backend, so `isWakeableAgentType("pi")` is true and the entry is eligible for daemon waking
+
+#### Scenario: Non-wakeable selection maps to offline
+- **WHEN** the init selection includes an agent with no daemon-wakeable backend (e.g. `opencode` or `openclaw`)
+- **THEN** its `agents[]` entry records `agentType: "offline"`
+
+### Requirement: Per-agent daemon-wake defaults off at init with explicit opt-in
+
+`chorus agents add` SHALL record a per-agent `daemonWake` boolean (defaulting to `false`) on the `agents[]` entry of each selected agent that maps to a daemon-wakeable backend (claude-code / codex / kiro / pi) — the agent is added (its key available to `chorus mcp`) but not woken by the daemon until the operator opts in. A selected agent that maps to
+`offline` (a backend that cannot be daemon-woken) SHALL NOT be given a `daemonWake` field
+(it can never wake). The opt-in SHALL be explicit: on a TTY the command asks, per
+daemon-wakeable selected agent, whether to enable daemon waking for that agent
+(defaulting to No); in a non-interactive run the agent is left `daemonWake: false` unless
+it is named by `--daemon-wake <ids>` or `--daemon-wake-all` is passed. init MUST write the
+resolved `daemonWake` value explicitly (true or false) on each wakeable agent's entry.
+
+#### Scenario: Wakeable agent added without opting in
+- **WHEN** a user selects a daemon-wakeable agent (e.g. kiro) and does not enable daemon waking for it
+- **THEN** its `agents[]` entry is written with `daemonWake: false` — the key is present for `chorus mcp`, but the daemon will not wake it
+
+#### Scenario: Wakeable agent opted in
+- **WHEN** the operator answers Yes to the daemon-waking prompt for a selected agent (or names it in `--daemon-wake` / passes `--daemon-wake-all`)
+- **THEN** its `agents[]` entry is written with `daemonWake: true`
+
+#### Scenario: Offline agent gets no daemonWake field
+- **WHEN** a selected agent maps to `offline` (opencode / openclaw / dormant dsh)
+- **THEN** its `agents[]` entry carries no `daemonWake` field, since it can never be woken
+
+#### Scenario: Non-interactive default is off
+- **WHEN** `chorus agents add --agents kiro --yes` runs with neither `--daemon-wake kiro` nor `--daemon-wake-all`
+- **THEN** the kiro entry is written `daemonWake: false` without prompting

--- a/openspec/changes/archive/2026-09-10-fix-pi-wakeable-spec-drift/specs/daemon-multi-agent/spec.md
+++ b/openspec/changes/archive/2026-09-10-fix-pi-wakeable-spec-drift/specs/daemon-multi-agent/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Per-agent backend selection
+
+Each agent SHALL select its own backend from its `agentType`, so a single daemon process MAY run agents on different backends (`claude-code`, `codex`, `kiro`, `pi`) at the same time. The daemon SHALL construct the appropriate spawner per agent and route each agent's wakes to its own spawner.
+
+#### Scenario: Claude and Kiro agents run in one daemon
+
+- **WHEN** one configured agent has `agentType: claude-code` and another has `agentType: kiro`
+- **THEN** the daemon wakes the first via a Claude Code subprocess and the second via a Kiro CLI subprocess, each with its own credentials
+
+#### Scenario: Claude and pi agents run in one daemon
+
+- **WHEN** one configured agent has `agentType: claude-code` and another has `agentType: pi`
+- **THEN** the daemon wakes the first via a Claude Code subprocess and the second via a `pi` subprocess, each with its own credentials
+
+### Requirement: Offline agent type is a valid, never-woken agents[] entry
+
+An agent's `agentType` MAY be `"offline"`, denoting an agent that is configured in `daemon.json` (with its own validated Chorus key) purely so the local `chorus mcp` proxy can act under that agent's identity, but that the daemon SHALL NOT wake. For an `offline` agent the daemon SHALL NOT construct a spawner, SHALL NOT dispatch wakes, and SHALL NOT register it as a wakeable connection; it remains a first-class credential entry for CLI/MCP proxying. The set of accepted `agentType` values SHALL include `"offline"` alongside the daemon-wakeable backends, and validation SHALL accept it. `"offline"` is the fail-closed classification for any selected agent whose coding-agent backend is not daemon-wakeable (opencode, openclaw, and dsh while its backend is de-advertised) — `pi` is NOT among them: it is a wakeable backend (see the `pi-daemon-backend` capability).
+
+#### Scenario: Offline agent is proxy-only, never woken
+- **WHEN** a configured agent has `agentType: "offline"`
+- **THEN** the daemon constructs no spawner and dispatches no wake for it, and `chorus mcp` can still resolve its key from `daemon.json` to proxy MCP calls under that agent's identity
+
+#### Scenario: Mixed wakeable and offline agents coexist
+- **WHEN** one configured agent is `agentType: claude-code` and another is `agentType: offline`
+- **THEN** the daemon wakes the claude-code agent normally and never attempts to wake the offline agent, and both keep independent credential entries
+
+#### Scenario: offline is an accepted agentType value
+- **WHEN** `agentType: "offline"` is written or validated
+- **THEN** it is accepted as a known value (not rejected as unknown), distinct from the wakeable backends

--- a/openspec/changes/archive/2026-09-10-fix-pi-wakeable-spec-drift/tasks.md
+++ b/openspec/changes/archive/2026-09-10-fix-pi-wakeable-spec-drift/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+> Spec/docs-only correction; no runtime change. Mirrored into Chorus as one task.
+
+- [ ] 1.1 Correct the four stale `pi` statements in the specs of record (`openspec/changes/fix-pi-wakeable-spec-drift/specs/{daemon-multi-agent,chorus-init}/spec.md`), keeping every scenario the modified requirements must retain.
+- [ ] 1.2 `docs/DAEMON.md`: list the full accepted `agentType` set in the per-agent field table and make the intro line backend-neutral.
+- [ ] 1.3 Verify with an exhaustive grep that no spec/doc still describes `pi` as non-wakeable/`offline`, then `openspec validate fix-pi-wakeable-spec-drift`, archive, and mirror the updated `daemon-multi-agent` spec back to its Chorus document.

--- a/openspec/specs/chorus-init/spec.md
+++ b/openspec/specs/chorus-init/spec.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 TBD - created by archiving change chorus-init-foundation. Update Purpose after archive.
+
 ## Requirements
+
 ### Requirement: Agent detection with dual signal and always-selectable list
 
 The command SHALL detect each supported agent using two signals — its CLI binary on `PATH` and its config directory presence — and treat an agent as detected when either signal holds. Detection MUST only drive the default pre-selection and status hints; an undetected agent MUST remain selectable so a user can configure it anyway.
@@ -172,7 +174,7 @@ On a TTY the command captures a key per selected agent (accepting `--api-key`/`C
 
 The daemon-setup step SHALL derive each agent's `daemon.json` backend `agentType` from the agents already chosen in the `chorus agents add` selection step, and SHALL NOT render a separate "which agent backend?" selection prompt. The step-1 selection is the single point at which the agent set is chosen; the credential-seed and daemon-setup steps consume that same selection.
 
-The mapping from an init selection id to a `daemon.json` `agentType` SHALL be explicit and total: the init id `claude` maps to `agentType: "claude-code"`; `codex` → `codex`; `kiro` → `kiro`; and any selected agent whose backend is not daemon-wakeable (`opencode`, `openclaw`, `pi`, and `dsh` while its daemon backend is de-advertised) maps to `agentType: "offline"`. The mapping MUST NOT pass an init id through verbatim when it differs from the daemon backend name (notably `claude` ≠ `claude-code`).
+The mapping from an init selection id to a `daemon.json` `agentType` SHALL be explicit and total: the init id `claude` maps to `agentType: "claude-code"`; `codex` → `codex`; `kiro` → `kiro`; `pi` → `pi`; and any selected agent whose backend is not daemon-wakeable (`opencode`, `openclaw`, and `dsh` while its daemon backend is de-advertised) maps to `agentType: "offline"`. The mapping MUST NOT pass an init id through verbatim when it differs from the daemon backend name (notably `claude` ≠ `claude-code`).
 
 #### Scenario: No second backend prompt
 - **WHEN** `chorus agents add` proceeds from agent selection into the daemon-setup step on a TTY
@@ -182,13 +184,17 @@ The mapping from an init selection id to a `daemon.json` `agentType` SHALL be ex
 - **WHEN** the init selection includes the `claude` adapter id
 - **THEN** its `agents[]` entry records `agentType: "claude-code"` (not `claude`), matching the daemon's `KNOWN_AGENTS` vocabulary
 
+#### Scenario: pi selection maps to the wakeable pi agentType
+- **WHEN** the init selection includes the `pi` adapter id
+- **THEN** its `agents[]` entry records `agentType: "pi"` — a wakeable backend, so `isWakeableAgentType("pi")` is true and the entry is eligible for daemon waking
+
 #### Scenario: Non-wakeable selection maps to offline
-- **WHEN** the init selection includes an agent with no daemon-wakeable backend (e.g. `opencode` or `pi`)
+- **WHEN** the init selection includes an agent with no daemon-wakeable backend (e.g. `opencode` or `openclaw`)
 - **THEN** its `agents[]` entry records `agentType: "offline"`
 
 ### Requirement: Per-agent daemon-wake defaults off at init with explicit opt-in
 
-`chorus agents add` SHALL record a per-agent `daemonWake` boolean (defaulting to `false`) on the `agents[]` entry of each selected agent that maps to a daemon-wakeable backend (claude-code / codex / kiro) — the agent is added (its key available to `chorus mcp`) but not woken by the daemon until the operator opts in. A selected agent that maps to
+`chorus agents add` SHALL record a per-agent `daemonWake` boolean (defaulting to `false`) on the `agents[]` entry of each selected agent that maps to a daemon-wakeable backend (claude-code / codex / kiro / pi) — the agent is added (its key available to `chorus mcp`) but not woken by the daemon until the operator opts in. A selected agent that maps to
 `offline` (a backend that cannot be daemon-woken) SHALL NOT be given a `daemonWake` field
 (it can never wake). The opt-in SHALL be explicit: on a TTY the command asks, per
 daemon-wakeable selected agent, whether to enable daemon waking for that agent
@@ -205,7 +211,7 @@ resolved `daemonWake` value explicitly (true or false) on each wakeable agent's 
 - **THEN** its `agents[]` entry is written with `daemonWake: true`
 
 #### Scenario: Offline agent gets no daemonWake field
-- **WHEN** a selected agent maps to `offline` (opencode / openclaw / pi / dormant dsh)
+- **WHEN** a selected agent maps to `offline` (opencode / openclaw / dormant dsh)
 - **THEN** its `agents[]` entry carries no `daemonWake` field, since it can never be woken
 
 #### Scenario: Non-interactive default is off
@@ -373,4 +379,3 @@ Because the key is now sourced from an env var, a daemon-woken Codex (whose spaw
 #### Scenario: No URL resolves — the MCP write is skipped, not failed
 - **WHEN** no Chorus URL can be resolved for the Codex agent (no `--url`, no `CHORUS_URL`)
 - **THEN** the `[mcp_servers.chorus]` write is skipped with a note and the plugin install still succeeds, rather than the command failing
-

--- a/openspec/specs/daemon-multi-agent/spec.md
+++ b/openspec/specs/daemon-multi-agent/spec.md
@@ -47,12 +47,17 @@ The daemon SHALL, when multiple agents are configured, run each agent as an inde
 
 ### Requirement: Per-agent backend selection
 
-Each agent SHALL select its own backend from its `agentType`, so a single daemon process MAY run agents on different backends (`claude-code`, `codex`, `kiro`) at the same time. The daemon SHALL construct the appropriate spawner per agent and route each agent's wakes to its own spawner.
+Each agent SHALL select its own backend from its `agentType`, so a single daemon process MAY run agents on different backends (`claude-code`, `codex`, `kiro`, `pi`) at the same time. The daemon SHALL construct the appropriate spawner per agent and route each agent's wakes to its own spawner.
 
 #### Scenario: Claude and Kiro agents run in one daemon
 
 - **WHEN** one configured agent has `agentType: claude-code` and another has `agentType: kiro`
 - **THEN** the daemon wakes the first via a Claude Code subprocess and the second via a Kiro CLI subprocess, each with its own credentials
+
+#### Scenario: Claude and pi agents run in one daemon
+
+- **WHEN** one configured agent has `agentType: claude-code` and another has `agentType: pi`
+- **THEN** the daemon wakes the first via a Claude Code subprocess and the second via a `pi` subprocess, each with its own credentials
 
 ### Requirement: Per-agent wake concurrency limit
 
@@ -112,7 +117,7 @@ The CLI SHALL let a user add additional agents without hand-editing being the on
 
 ### Requirement: Offline agent type is a valid, never-woken agents[] entry
 
-An agent's `agentType` MAY be `"offline"`, denoting an agent that is configured in `daemon.json` (with its own validated Chorus key) purely so the local `chorus mcp` proxy can act under that agent's identity, but that the daemon SHALL NOT wake. For an `offline` agent the daemon SHALL NOT construct a spawner, SHALL NOT dispatch wakes, and SHALL NOT register it as a wakeable connection; it remains a first-class credential entry for CLI/MCP proxying. The set of accepted `agentType` values SHALL include `"offline"` alongside the daemon-wakeable backends, and validation SHALL accept it. `"offline"` is the fail-closed classification for any selected agent whose coding-agent backend is not daemon-wakeable (opencode, openclaw, pi, and dsh while its backend is de-advertised).
+An agent's `agentType` MAY be `"offline"`, denoting an agent that is configured in `daemon.json` (with its own validated Chorus key) purely so the local `chorus mcp` proxy can act under that agent's identity, but that the daemon SHALL NOT wake. For an `offline` agent the daemon SHALL NOT construct a spawner, SHALL NOT dispatch wakes, and SHALL NOT register it as a wakeable connection; it remains a first-class credential entry for CLI/MCP proxying. The set of accepted `agentType` values SHALL include `"offline"` alongside the daemon-wakeable backends, and validation SHALL accept it. `"offline"` is the fail-closed classification for any selected agent whose coding-agent backend is not daemon-wakeable (opencode, openclaw, and dsh while its backend is de-advertised) — `pi` is NOT among them: it is a wakeable backend (see the `pi-daemon-backend` capability).
 
 #### Scenario: Offline agent is proxy-only, never woken
 - **WHEN** a configured agent has `agentType: "offline"`


### PR DESCRIPTION
`add-daemon-pi-backend` made `pi` a first-class wakeable backend (`agent-type-map.mjs` maps `pi` → `"pi"`, `KNOWN_AGENTS` includes it, `selectSpawner` has an explicit `PiSpawner` branch, `isWakeableAgentType("pi")` is true) and updated the `pi-daemon-backend` capability — but left four older statements describing `pi` as non-wakeable/`offline`. The spec of record therefore contradicted both itself and the code, and a reader (or a future change) following the stale text would classify a pi agent as never-woken.

Corrected (spec-only — no runtime change):

- `daemon-multi-agent` / **Per-agent backend selection** — the example backend list gains `pi`, plus a scenario pinning the claude-code + pi pairing.
- `daemon-multi-agent` / **Offline agent type is a valid, never-woken agents[] entry** — the fail-closed list drops `pi` (it stays for `opencode`, `openclaw`, and `dsh` while its backend is de-advertised) and says so explicitly.
- `chorus-init` / **Daemon backend agentType derived from the init selection** — states `pi` → `pi`, drops `pi` from the fail-closed list, stops using `pi` as the “non-wakeable” example, and gains a scenario pinning the pi mapping.
- `chorus-init` / **Per-agent daemon-wake defaults off at init** — the wakeable-backend list gains `pi`; the offline scenario no longer lists it.
- `docs/DAEMON.md` — the per-agent `agentType` row lists the full accepted set, and the intro no longer claims the daemon wakes only a headless Claude Code.

`MODIFIED` blocks carry the full requirement text plus every retained scenario, as OpenSpec requires.

## Verification

- Exhaustive grep for each stale phrasing across `openspec/specs` and `docs`: `opencode, openclaw, pi` → 0, `pi, and dsh` → 0, `opencode / openclaw / pi` → 0, `opencode`…`or`…`pi` → 0.
- `openspec validate fix-pi-wakeable-spec-drift` passed; the change is archived as `2026-09-10-fix-pi-wakeable-spec-drift` and merged into the cumulative specs (+2 requirements, ~2 modified).
- The corrected statements are already pinned by existing tests for the code they describe (`init-agent-type-map`, `daemon-agent`, `spawner-select`, `pi-spawner`), which assert `pi` → `pi` and `isWakeableAgentType("pi") === true`.
