### PR TITLE
fix(proposal): serialize draft updates under a proposal row lock

### DIFF
--- a/src/__tests__/integration/acceptance-criteria-enforcement.integration.test.ts
+++ b/src/__tests__/integration/acceptance-criteria-enforcement.integration.test.ts
@@ -35,6 +35,8 @@ const { mockPrisma, mockEventBus, mockFormatCreatedBy, mockFormatReview, mockIsA
       createMany: vi.fn(),
       deleteMany: vi.fn(),
     },
+    $queryRaw: vi.fn(async () => []),
+    $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(mockPrisma)),
   };
   return {
     mockPrisma,

--- a/src/services/__tests__/proposal-draft-concurrency.test.ts
+++ b/src/services/__tests__/proposal-draft-concurrency.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Concurrent draft updates on one proposal must not lose each other (#555).
+ *
+ * `documentDrafts` / `taskDrafts` are whole JSON columns. Each mutator reads
+ * the list, changes one element and writes the whole list back; two in-flight
+ * calls that read the same snapshot let the last write win. The mutators now
+ * run inside a transaction that locks the proposal row first, so the second
+ * caller reads the first caller's result.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma, state, calls, mockEventBus } = vi.hoisted(() => {
+  const state: { proposal: Record<string, unknown> | null } = { proposal: null };
+  const calls: string[] = [];
+  // A transaction runner that serializes like a row lock would: the next
+  // callback starts only after the previous transaction finished.
+  let chain: Promise<unknown> = Promise.resolve();
+  const mockPrisma = {
+    proposal: {
+      findFirst: vi.fn(async () => {
+        calls.push("findFirst");
+        return state.proposal;
+      }),
+      update: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+        calls.push("update");
+        state.proposal = { ...state.proposal, ...data };
+        return { ...state.proposal, project: { uuid: "project-1", name: "Project" } };
+      }),
+    },
+    $queryRaw: vi.fn(async (strings: TemplateStringsArray, ...values: unknown[]) => {
+      calls.push(`lock:${strings.join("?")}:${values.join(",")}`);
+      return [];
+    }),
+    $transaction: vi.fn((fn: (tx: unknown) => Promise<unknown>) => {
+      const run = chain.then(() => {
+        calls.push("tx:begin");
+        return fn(mockPrisma).finally(() => calls.push("tx:end"));
+      });
+      chain = run.catch(() => undefined);
+      return run;
+    }),
+  };
+  const mockEventBus = { emitChange: vi.fn() };
+  return { mockPrisma, state, calls, mockEventBus };
+});
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/event-bus", () => ({ eventBus: mockEventBus }));
+vi.mock("@/generated/prisma/client", () => ({
+  Prisma: { JsonNull: Symbol("JsonNull") },
+}));
+vi.mock("@/lib/uuid-resolver", () => ({
+  formatCreatedBy: vi.fn().mockResolvedValue(null),
+  formatReview: vi.fn().mockResolvedValue(null),
+  resolveAssigneeAgentUuid: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("@/services/document.service", () => ({ createDocumentFromProposal: vi.fn() }));
+vi.mock("@/services/task.service", () => ({ createTasksFromProposal: vi.fn() }));
+
+import { addDocumentDraft, updateDocumentDraft, updateTaskDraft } from "@/services/proposal.service";
+
+const baseProposal = () => ({
+  uuid: "proposal-1",
+  companyUuid: "company-1",
+  projectUuid: "project-1",
+  status: "draft",
+  title: "Draft",
+  documentDrafts: [
+    { uuid: "doc-a", type: "spec", title: "A", content: "a" },
+    { uuid: "doc-b", type: "spec", title: "B", content: "b" },
+  ],
+  taskDrafts: [
+    { uuid: "task-a", title: "Task A", description: "", storyPoints: 1, priority: "medium", acceptanceCriteriaItems: [{ description: "done" }] },
+    { uuid: "task-b", title: "Task B", description: "", storyPoints: 1, priority: "medium", acceptanceCriteriaItems: [{ description: "done" }] },
+  ],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+describe("proposal draft mutators under concurrency (#555)", () => {
+  beforeEach(() => {
+    state.proposal = baseProposal();
+    calls.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("locks the proposal row before reading the drafts", async () => {
+    await updateDocumentDraft("proposal-1", "company-1", "doc-a", { title: "A2" });
+
+    const lock = calls.find((c) => c.startsWith("lock:"));
+    expect(lock).toBeDefined();
+    expect(lock).toContain("FOR UPDATE");
+    expect(lock).toContain("proposal-1");
+    expect(calls.indexOf("tx:begin")).toBeLessThan(calls.indexOf(lock!));
+    expect(calls.indexOf(lock!)).toBeLessThan(calls.indexOf("findFirst"));
+    expect(calls.indexOf("update")).toBeLessThan(calls.indexOf("tx:end"));
+  });
+
+  it("keeps both of two concurrent sibling document-draft updates", async () => {
+    await Promise.all([
+      updateDocumentDraft("proposal-1", "company-1", "doc-a", { title: "A updated" }),
+      updateDocumentDraft("proposal-1", "company-1", "doc-b", { title: "B updated" }),
+    ]);
+
+    const drafts = state.proposal!.documentDrafts as Array<{ uuid: string; title: string }>;
+    expect(drafts.map((d) => d.title)).toEqual(["A updated", "B updated"]);
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a concurrent add and update on task drafts", async () => {
+    await Promise.all([
+      updateTaskDraft("proposal-1", "company-1", "task-a", { title: "Task A updated" }),
+      addDocumentDraft("proposal-1", "company-1", { type: "spec", title: "C", content: "c" }),
+    ]);
+
+    const tasks = state.proposal!.taskDrafts as Array<{ uuid: string; title: string }>;
+    const docs = state.proposal!.documentDrafts as Array<{ uuid: string; title: string }>;
+    expect(tasks.map((t) => t.title)).toEqual(["Task A updated", "Task B"]);
+    expect(docs.map((d) => d.title)).toEqual(["A", "B", "C"]);
+  });
+
+  it("still reports a proposal that is not in draft status", async () => {
+    state.proposal = null;
+    await expect(
+      updateTaskDraft("proposal-1", "company-1", "task-a", { title: "x" }),
+    ).rejects.toThrow("Proposal not found or not in draft status");
+    expect(mockPrisma.proposal.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/proposal-draft-concurrency.test.ts
+++ b/src/services/__tests__/proposal-draft-concurrency.test.ts
@@ -57,7 +57,12 @@ vi.mock("@/lib/uuid-resolver", () => ({
 vi.mock("@/services/document.service", () => ({ createDocumentFromProposal: vi.fn() }));
 vi.mock("@/services/task.service", () => ({ createTasksFromProposal: vi.fn() }));
 
-import { addDocumentDraft, updateDocumentDraft, updateTaskDraft } from "@/services/proposal.service";
+import {
+  addTaskDraft,
+  removeDocumentDraft,
+  updateDocumentDraft,
+  updateTaskDraft,
+} from "@/services/proposal.service";
 
 const baseProposal = () => ({
   uuid: "proposal-1",
@@ -107,16 +112,29 @@ describe("proposal draft mutators under concurrency (#555)", () => {
     expect(mockPrisma.$transaction).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps a concurrent add and update on task drafts", async () => {
+  it("keeps a concurrent add and update on the same task-draft list", async () => {
     await Promise.all([
       updateTaskDraft("proposal-1", "company-1", "task-a", { title: "Task A updated" }),
-      addDocumentDraft("proposal-1", "company-1", { type: "spec", title: "C", content: "c" }),
+      addTaskDraft("proposal-1", "company-1", {
+        title: "Task C",
+        acceptanceCriteriaItems: [{ description: "done" }],
+      }),
     ]);
 
     const tasks = state.proposal!.taskDrafts as Array<{ uuid: string; title: string }>;
-    const docs = state.proposal!.documentDrafts as Array<{ uuid: string; title: string }>;
-    expect(tasks.map((t) => t.title)).toEqual(["Task A updated", "Task B"]);
-    expect(docs.map((d) => d.title)).toEqual(["A", "B", "C"]);
+    expect(tasks.map((t) => t.title)).toEqual(["Task A updated", "Task B", "Task C"]);
+  });
+
+  it("keeps a concurrent update and removal on the same document-draft list", async () => {
+    await Promise.all([
+      updateDocumentDraft("proposal-1", "company-1", "doc-a", { title: "A updated" }),
+      removeDocumentDraft("proposal-1", "company-1", "doc-b"),
+    ]);
+
+    const drafts = state.proposal!.documentDrafts as Array<{ uuid: string; title: string }>;
+    expect(drafts).toEqual([
+      expect.objectContaining({ uuid: "doc-a", title: "A updated" }),
+    ]);
   });
 
   it("still reports a proposal that is not in draft status", async () => {

--- a/src/services/__tests__/proposal-draft-concurrency.test.ts
+++ b/src/services/__tests__/proposal-draft-concurrency.test.ts
@@ -19,7 +19,7 @@ const { mockPrisma, state, calls, mockEventBus } = vi.hoisted(() => {
     proposal: {
       findFirst: vi.fn(async () => {
         calls.push("findFirst");
-        return state.proposal;
+        return state.proposal ? structuredClone(state.proposal) : null;
       }),
       update: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
         calls.push("update");

--- a/src/services/__tests__/proposal.service.test.ts
+++ b/src/services/__tests__/proposal.service.test.ts
@@ -51,7 +51,10 @@ const { mockPrisma, mockEventBus, mockFormatCreatedBy, mockFormatReview, mockRes
     comment: {
       deleteMany: vi.fn(),
     },
-    $transaction: vi.fn(),
+    // Draft mutators run inside prisma.$transaction with a row lock (#555); the
+    // transaction client is this same mock so their reads/writes stay observable.
+    $queryRaw: vi.fn(async () => []),
+    $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(mockPrisma)),
   };
   const mockEventBus = { emitChange: vi.fn() };
   const mockFormatCreatedBy = vi.fn().mockResolvedValue({ type: "agent", uuid: "actor-uuid", name: "Agent" });

--- a/src/services/proposal.service.ts
+++ b/src/services/proposal.service.ts
@@ -4,7 +4,7 @@
 // Container Model: Proposal contains documentDrafts and taskDrafts
 
 import { randomUUID } from "crypto";
-import { prisma, TransactionClient } from "@/lib/prisma";
+import { prisma } from "@/lib/prisma";
 import { Prisma } from "@/generated/prisma/client";
 import { formatCreatedBy, formatReview, resolveAssigneeAgentUuid } from "@/lib/uuid-resolver";
 import { eventBus } from "@/lib/event-bus";
@@ -15,6 +15,11 @@ import {
   hasNonEmptyAcceptanceCriteria,
   normalizeAcceptanceCriteria,
 } from "@/lib/acceptance-criteria";
+
+type ExtendedTransactionClient = Omit<
+  typeof prisma,
+  "$connect" | "$disconnect" | "$on" | "$transaction" | "$extends"
+>;
 
 // ===== UUID Helper Functions =====
 
@@ -1139,7 +1144,7 @@ async function withLockedDraftProposal<T>(
   proposalUuid: string,
   companyUuid: string,
   mutate: (
-    tx: TransactionClient,
+    tx: ExtendedTransactionClient,
     proposal: Prisma.ProposalGetPayload<Record<string, never>>
   ) => Promise<T>
 ): Promise<T> {

--- a/src/services/proposal.service.ts
+++ b/src/services/proposal.service.ts
@@ -1127,35 +1127,61 @@ export async function submitProposal(
   return formatProposalResponse(updated);
 }
 
+/**
+ * Run a read-modify-write of a draft proposal's JSON draft lists under a row
+ * lock. `documentDrafts` / `taskDrafts` are whole JSON columns: two concurrent
+ * updates that read the same snapshot and each write back "their" array lose
+ * the other's change with the last write winning (#555). `SELECT ... FOR
+ * UPDATE` serializes them on the proposal row for the length of the
+ * transaction, so the second caller reads the first caller's result.
+ */
+async function withLockedDraftProposal<T>(
+  proposalUuid: string,
+  companyUuid: string,
+  mutate: (
+    tx: Prisma.TransactionClient,
+    proposal: Prisma.ProposalGetPayload<Record<string, never>>
+  ) => Promise<T>
+): Promise<T> {
+  return prisma.$transaction(async (tx) => {
+    await tx.$queryRaw`SELECT "uuid" FROM "Proposal" WHERE "uuid" = ${proposalUuid} FOR UPDATE`;
+    const proposal = await tx.proposal.findFirst({
+      where: { uuid: proposalUuid, companyUuid, status: "draft" },
+    });
+    if (!proposal) {
+      throw new Error("Proposal not found or not in draft status");
+    }
+    return mutate(tx, proposal);
+  });
+}
+
 // Add document draft to Proposal
 export async function addDocumentDraft(
   proposalUuid: string,
   companyUuid: string,
   draft: Omit<DocumentDraft, "uuid"> & { uuid?: string }
 ): Promise<ProposalResponse> {
-  const proposal = await prisma.proposal.findFirst({
-    where: { uuid: proposalUuid, companyUuid, status: "draft" },
-  });
+  const { updated, projectUuid } = await withLockedDraftProposal(
+    proposalUuid,
+    companyUuid,
+    async (tx, proposal) => {
+      const existingDrafts = (proposal.documentDrafts as unknown as DocumentDraft[]) || [];
+      const newDraft = ensureDocumentDraftUuid(draft);
+      const updatedDrafts = [...existingDrafts, newDraft];
+      const updated = await tx.proposal.update({
+        where: { uuid: proposalUuid },
+        data: {
+          documentDrafts: updatedDrafts as unknown as Prisma.InputJsonValue,
+        },
+        include: {
+          project: { select: { uuid: true, name: true } },
+        },
+      });
+      return { updated, projectUuid: proposal.projectUuid };
+    }
+  );
 
-  if (!proposal) {
-    throw new Error("Proposal not found or not in draft status");
-  }
-
-  const existingDrafts = (proposal.documentDrafts as unknown as DocumentDraft[]) || [];
-  const newDraft = ensureDocumentDraftUuid(draft);
-  const updatedDrafts = [...existingDrafts, newDraft];
-
-  const updated = await prisma.proposal.update({
-    where: { uuid: proposalUuid },
-    data: {
-      documentDrafts: updatedDrafts as unknown as Prisma.InputJsonValue,
-    },
-    include: {
-      project: { select: { uuid: true, name: true } },
-    },
-  });
-
-  eventBus.emitChange({ companyUuid, projectUuid: proposal.projectUuid, entityType: "proposal", entityUuid: proposalUuid, action: "updated" });
+  eventBus.emitChange({ companyUuid, projectUuid, entityType: "proposal", entityUuid: proposalUuid, action: "updated" });
   return formatProposalResponse(updated);
 }
 
@@ -1165,38 +1191,36 @@ export async function addTaskDraft(
   companyUuid: string,
   draft: Omit<TaskDraft, "uuid"> & { uuid?: string }
 ): Promise<ProposalResponse> {
-  const proposal = await prisma.proposal.findFirst({
-    where: { uuid: proposalUuid, companyUuid, status: "draft" },
-  });
+  const { updated, projectUuid } = await withLockedDraftProposal(
+    proposalUuid,
+    companyUuid,
+    async (tx, proposal) => {
+      // Acceptance criteria are mandatory on creation: a task draft must carry at
+      // least one criterion with a non-blank description.
+      if (!hasNonEmptyAcceptanceCriteria(draft.acceptanceCriteriaItems)) {
+        throw new Error(ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE);
+      }
 
-  if (!proposal) {
-    throw new Error("Proposal not found or not in draft status");
-  }
+      const existingDrafts = (proposal.taskDrafts as unknown as TaskDraft[]) || [];
+      const newDraft = ensureTaskDraftUuid({
+        ...draft,
+        acceptanceCriteriaItems: normalizeAcceptanceCriteria(draft.acceptanceCriteriaItems),
+      });
+      const updatedDrafts = [...existingDrafts, newDraft];
+      const updated = await tx.proposal.update({
+        where: { uuid: proposalUuid },
+        data: {
+          taskDrafts: updatedDrafts as unknown as Prisma.InputJsonValue,
+        },
+        include: {
+          project: { select: { uuid: true, name: true } },
+        },
+      });
+      return { updated, projectUuid: proposal.projectUuid };
+    }
+  );
 
-  // Acceptance criteria are mandatory on creation: a task draft must carry at
-  // least one criterion with a non-blank description.
-  if (!hasNonEmptyAcceptanceCriteria(draft.acceptanceCriteriaItems)) {
-    throw new Error(ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE);
-  }
-
-  const existingDrafts = (proposal.taskDrafts as unknown as TaskDraft[]) || [];
-  const newDraft = ensureTaskDraftUuid({
-    ...draft,
-    acceptanceCriteriaItems: normalizeAcceptanceCriteria(draft.acceptanceCriteriaItems),
-  });
-  const updatedDrafts = [...existingDrafts, newDraft];
-
-  const updated = await prisma.proposal.update({
-    where: { uuid: proposalUuid },
-    data: {
-      taskDrafts: updatedDrafts as unknown as Prisma.InputJsonValue,
-    },
-    include: {
-      project: { select: { uuid: true, name: true } },
-    },
-  });
-
-  eventBus.emitChange({ companyUuid, projectUuid: proposal.projectUuid, entityType: "proposal", entityUuid: proposalUuid, action: "updated" });
+  eventBus.emitChange({ companyUuid, projectUuid, entityType: "proposal", entityUuid: proposalUuid, action: "updated" });
   return formatProposalResponse(updated);
 }
 
@@ -1207,34 +1231,32 @@ export async function updateDocumentDraft(
   draftUuid: string,
   updates: Partial<Omit<DocumentDraft, "uuid">>
 ): Promise<ProposalResponse> {
-  const proposal = await prisma.proposal.findFirst({
-    where: { uuid: proposalUuid, companyUuid, status: "draft" },
-  });
+  const { updated, projectUuid } = await withLockedDraftProposal(
+    proposalUuid,
+    companyUuid,
+    async (tx, proposal) => {
+      const existingDrafts = (proposal.documentDrafts as unknown as DocumentDraft[]) || [];
+      const draftIndex = existingDrafts.findIndex(d => d.uuid === draftUuid);
 
-  if (!proposal) {
-    throw new Error("Proposal not found or not in draft status");
-  }
+      if (draftIndex === -1) {
+        throw new Error("Document draft not found");
+      }
 
-  const existingDrafts = (proposal.documentDrafts as unknown as DocumentDraft[]) || [];
-  const draftIndex = existingDrafts.findIndex(d => d.uuid === draftUuid);
+      existingDrafts[draftIndex] = { ...existingDrafts[draftIndex], ...updates };
+      const updated = await tx.proposal.update({
+        where: { uuid: proposalUuid },
+        data: {
+          documentDrafts: existingDrafts as unknown as Prisma.InputJsonValue,
+        },
+        include: {
+          project: { select: { uuid: true, name: true } },
+        },
+      });
+      return { updated, projectUuid: proposal.projectUuid };
+    }
+  );
 
-  if (draftIndex === -1) {
-    throw new Error("Document draft not found");
-  }
-
-  existingDrafts[draftIndex] = { ...existingDrafts[draftIndex], ...updates };
-
-  const updated = await prisma.proposal.update({
-    where: { uuid: proposalUuid },
-    data: {
-      documentDrafts: existingDrafts as unknown as Prisma.InputJsonValue,
-    },
-    include: {
-      project: { select: { uuid: true, name: true } },
-    },
-  });
-
-  eventBus.emitChange({ companyUuid, projectUuid: proposal.projectUuid, entityType: "proposal", entityUuid: proposalUuid, action: "updated" });
+  eventBus.emitChange({ companyUuid, projectUuid, entityType: "proposal", entityUuid: proposalUuid, action: "updated" });
   return formatProposalResponse(updated);
 }
 
@@ -1245,45 +1267,43 @@ export async function updateTaskDraft(
   draftUuid: string,
   updates: Partial<Omit<TaskDraft, "uuid">>
 ): Promise<ProposalResponse> {
-  const proposal = await prisma.proposal.findFirst({
-    where: { uuid: proposalUuid, companyUuid, status: "draft" },
-  });
+  const { updated, projectUuid } = await withLockedDraftProposal(
+    proposalUuid,
+    companyUuid,
+    async (tx, proposal) => {
+      const existingDrafts = (proposal.taskDrafts as unknown as TaskDraft[]) || [];
+      const draftIndex = existingDrafts.findIndex(d => d.uuid === draftUuid);
 
-  if (!proposal) {
-    throw new Error("Proposal not found or not in draft status");
-  }
+      if (draftIndex === -1) {
+        throw new Error("Task draft not found");
+      }
 
-  const existingDrafts = (proposal.taskDrafts as unknown as TaskDraft[]) || [];
-  const draftIndex = existingDrafts.findIndex(d => d.uuid === draftUuid);
+      // Partial-update semantics for acceptance criteria: if the caller supplied the
+      // field (including an explicit empty array), it must be non-empty — the field
+      // cannot be used to clear AC. If the caller omitted it, existing AC are kept.
+      const appliedUpdates = { ...updates };
+      if ("acceptanceCriteriaItems" in updates) {
+        if (!hasNonEmptyAcceptanceCriteria(updates.acceptanceCriteriaItems)) {
+          throw new Error(ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE);
+        }
+        appliedUpdates.acceptanceCriteriaItems = normalizeAcceptanceCriteria(updates.acceptanceCriteriaItems);
+      }
 
-  if (draftIndex === -1) {
-    throw new Error("Task draft not found");
-  }
-
-  // Partial-update semantics for acceptance criteria: if the caller supplied the
-  // field (including an explicit empty array), it must be non-empty — the field
-  // cannot be used to clear AC. If the caller omitted it, existing AC are kept.
-  const appliedUpdates = { ...updates };
-  if ("acceptanceCriteriaItems" in updates) {
-    if (!hasNonEmptyAcceptanceCriteria(updates.acceptanceCriteriaItems)) {
-      throw new Error(ACCEPTANCE_CRITERIA_REQUIRED_MESSAGE);
+      existingDrafts[draftIndex] = { ...existingDrafts[draftIndex], ...appliedUpdates };
+      const updated = await tx.proposal.update({
+        where: { uuid: proposalUuid },
+        data: {
+          taskDrafts: existingDrafts as unknown as Prisma.InputJsonValue,
+        },
+        include: {
+          project: { select: { uuid: true, name: true } },
+        },
+      });
+      return { updated, projectUuid: proposal.projectUuid };
     }
-    appliedUpdates.acceptanceCriteriaItems = normalizeAcceptanceCriteria(updates.acceptanceCriteriaItems);
-  }
+  );
 
-  existingDrafts[draftIndex] = { ...existingDrafts[draftIndex], ...appliedUpdates };
-
-  const updated = await prisma.proposal.update({
-    where: { uuid: proposalUuid },
-    data: {
-      taskDrafts: existingDrafts as unknown as Prisma.InputJsonValue,
-    },
-    include: {
-      project: { select: { uuid: true, name: true } },
-    },
-  });
-
-  eventBus.emitChange({ companyUuid, projectUuid: proposal.projectUuid, entityType: "proposal", entityUuid: proposalUuid, action: "updated" });
+  eventBus.emitChange({ companyUuid, projectUuid, entityType: "proposal", entityUuid: proposalUuid, action: "updated" });
   return formatProposalResponse(updated);
 }
 
@@ -1293,30 +1313,28 @@ export async function removeDocumentDraft(
   companyUuid: string,
   draftUuid: string
 ): Promise<ProposalResponse> {
-  const proposal = await prisma.proposal.findFirst({
-    where: { uuid: proposalUuid, companyUuid, status: "draft" },
-  });
+  const { updated, projectUuid } = await withLockedDraftProposal(
+    proposalUuid,
+    companyUuid,
+    async (tx, proposal) => {
+      const existingDrafts = (proposal.documentDrafts as unknown as DocumentDraft[]) || [];
+      const updatedDrafts = existingDrafts.filter(d => d.uuid !== draftUuid);
+      const updated = await tx.proposal.update({
+        where: { uuid: proposalUuid },
+        data: {
+          documentDrafts: updatedDrafts.length > 0
+            ? (updatedDrafts as unknown as Prisma.InputJsonValue)
+            : Prisma.JsonNull,
+        },
+        include: {
+          project: { select: { uuid: true, name: true } },
+        },
+      });
+      return { updated, projectUuid: proposal.projectUuid };
+    }
+  );
 
-  if (!proposal) {
-    throw new Error("Proposal not found or not in draft status");
-  }
-
-  const existingDrafts = (proposal.documentDrafts as unknown as DocumentDraft[]) || [];
-  const updatedDrafts = existingDrafts.filter(d => d.uuid !== draftUuid);
-
-  const updated = await prisma.proposal.update({
-    where: { uuid: proposalUuid },
-    data: {
-      documentDrafts: updatedDrafts.length > 0
-        ? (updatedDrafts as unknown as Prisma.InputJsonValue)
-        : Prisma.JsonNull,
-    },
-    include: {
-      project: { select: { uuid: true, name: true } },
-    },
-  });
-
-  eventBus.emitChange({ companyUuid, projectUuid: proposal.projectUuid, entityType: "proposal", entityUuid: proposalUuid, action: "updated" });
+  eventBus.emitChange({ companyUuid, projectUuid, entityType: "proposal", entityUuid: proposalUuid, action: "updated" });
   return formatProposalResponse(updated);
 }
 
@@ -1326,35 +1344,33 @@ export async function removeTaskDraft(
   companyUuid: string,
   draftUuid: string
 ): Promise<ProposalResponse> {
-  const proposal = await prisma.proposal.findFirst({
-    where: { uuid: proposalUuid, companyUuid, status: "draft" },
-  });
+  const { updated, projectUuid } = await withLockedDraftProposal(
+    proposalUuid,
+    companyUuid,
+    async (tx, proposal) => {
+      const existingDrafts = (proposal.taskDrafts as unknown as TaskDraft[]) || [];
+      const updatedDrafts = existingDrafts
+        .filter(d => d.uuid !== draftUuid)
+        .map(d => ({
+          ...d,
+          dependsOnDraftUuids: d.dependsOnDraftUuids?.filter(uuid => uuid !== draftUuid),
+        }));
+      const updated = await tx.proposal.update({
+        where: { uuid: proposalUuid },
+        data: {
+          taskDrafts: updatedDrafts.length > 0
+            ? (updatedDrafts as unknown as Prisma.InputJsonValue)
+            : Prisma.JsonNull,
+        },
+        include: {
+          project: { select: { uuid: true, name: true } },
+        },
+      });
+      return { updated, projectUuid: proposal.projectUuid };
+    }
+  );
 
-  if (!proposal) {
-    throw new Error("Proposal not found or not in draft status");
-  }
-
-  const existingDrafts = (proposal.taskDrafts as unknown as TaskDraft[]) || [];
-  const updatedDrafts = existingDrafts
-    .filter(d => d.uuid !== draftUuid)
-    .map(d => ({
-      ...d,
-      dependsOnDraftUuids: d.dependsOnDraftUuids?.filter(uuid => uuid !== draftUuid),
-    }));
-
-  const updated = await prisma.proposal.update({
-    where: { uuid: proposalUuid },
-    data: {
-      taskDrafts: updatedDrafts.length > 0
-        ? (updatedDrafts as unknown as Prisma.InputJsonValue)
-        : Prisma.JsonNull,
-    },
-    include: {
-      project: { select: { uuid: true, name: true } },
-    },
-  });
-
-  eventBus.emitChange({ companyUuid, projectUuid: proposal.projectUuid, entityType: "proposal", entityUuid: proposalUuid, action: "updated" });
+  eventBus.emitChange({ companyUuid, projectUuid, entityType: "proposal", entityUuid: proposalUuid, action: "updated" });
   return formatProposalResponse(updated);
 }
 

--- a/src/services/proposal.service.ts
+++ b/src/services/proposal.service.ts
@@ -4,7 +4,7 @@
 // Container Model: Proposal contains documentDrafts and taskDrafts
 
 import { randomUUID } from "crypto";
-import { prisma } from "@/lib/prisma";
+import { prisma, TransactionClient } from "@/lib/prisma";
 import { Prisma } from "@/generated/prisma/client";
 import { formatCreatedBy, formatReview, resolveAssigneeAgentUuid } from "@/lib/uuid-resolver";
 import { eventBus } from "@/lib/event-bus";
@@ -1139,7 +1139,7 @@ async function withLockedDraftProposal<T>(
   proposalUuid: string,
   companyUuid: string,
   mutate: (
-    tx: Prisma.TransactionClient,
+    tx: TransactionClient,
     proposal: Prisma.ProposalGetPayload<Record<string, never>>
   ) => Promise<T>
 ): Promise<T> {


### PR DESCRIPTION
Fixes #555.

`documentDrafts` / `taskDrafts` are whole JSON columns, and every draft mutator in `src/services/proposal.service.ts` (`addDocumentDraft`, `addTaskDraft`, `updateDocumentDraft`, `updateTaskDraft`, `removeDocumentDraft`, `removeTaskDraft`) was a read-modify-write of the entire list with no lock or version check. Two in-flight `chorus_pm_update_*` calls on sibling drafts read the same snapshot, each wrote "its" array back, and the last write silently won while both reported success.

**Change**

- A small `withLockedDraftProposal(proposalUuid, companyUuid, mutate)` helper runs the mutation inside `prisma.$transaction`, takes `SELECT "uuid" FROM "Proposal" WHERE "uuid" = $1 FOR UPDATE` first, then does the `findFirst` (same `companyUuid` / `status: "draft"` scoping as before) and hands the fresh row to the mutator, which writes through the transaction client. Concurrent callers serialize on the row for the length of the transaction, so the second one reads the first one's result. Works the same on Postgres and PGlite (which already runs with a single connection).
- The six mutators keep their validation (acceptance-criteria rules, "draft not found"), their error messages, and emit the change event after the transaction as before. The diff looks larger than it is because each body moved into the callback.

**Tests**

- `src/services/__tests__/proposal-draft-concurrency.test.ts`: a state-backed prisma mock whose `$transaction` serializes callbacks like a row lock. Two concurrent sibling document-draft updates both land, a concurrent task update plus document add both land, the lock is taken inside the transaction before the read, and the not-in-draft error is unchanged. The first two cases fail on `develop`.
- `proposal.service.test.ts`: the prisma mock now implements `$transaction` by calling back with the same mock (and stubs `$queryRaw`), so the existing draft tests keep observing the reads/writes. 124 tests pass across both files.

`eslint` reports only the two pre-existing unused-import warnings in `proposal.service.ts`.
