### PR TITLE
feat: consolidate Tracker idea actions

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -50,6 +50,7 @@
     "currentAssignee": "Currently assigned to",
     "failedToAssign": "Failed to assign",
     "actions": "Actions",
+    "close": "Close",
     "genericError": "An error occurred. Please try again.",
     "unknown": "Unknown",
     "system": "System",
@@ -1003,6 +1004,7 @@
     "confirmCta": "Run Yolo",
     "starting": "Starting...",
     "startedHint": "Yolo started — the agent is driving this idea to done",
+    "completedHint": "This idea is already complete",
     "offlineHint": "Agent offline — enables on reconnect",
     "errorAgentOffline": "The assigned agent is offline. Run Yolo after it reconnects.",
     "errorInstanceOffline": "The idea is pinned to a daemon instance that is offline. Run Yolo after that instance reconnects.",
@@ -1374,6 +1376,17 @@
       "noActivity": "No recent activity"
     },
     "panel": {
+      "actions": {
+        "busy": "Wait for the current operation to finish",
+        "loadingStage": "Waiting for proposal and task data. If this persists, reopen the idea to retry.",
+        "verifyUnavailable": "Complete elaboration before verifying it",
+        "editUnavailable": "Elaborated ideas cannot be edited",
+        "copyLink": "Copy link",
+        "copyUuid": "Copy UUID",
+        "linkCopied": "Idea link copied",
+        "uuidCopied": "Idea UUID copied",
+        "copyFailed": "Could not copy. Check clipboard permissions and try again."
+      },
       "notFound": "Idea not found",
       "loadFailed": "Failed to load idea",
       "verifyingPlaceholder": "Verification in progress...",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -50,6 +50,7 @@
     "currentAssignee": "現在の担当者",
     "failedToAssign": "割り当てに失敗しました",
     "actions": "操作",
+    "close": "閉じる",
     "genericError": "エラーが発生しました。もう一度お試しください。",
     "unknown": "不明",
     "system": "システム",
@@ -1003,6 +1004,7 @@
     "confirmCta": "Yolo を実行",
     "starting": "開始中...",
     "startedHint": "Yolo を開始しました — エージェントがこの着想を完了まで進めています",
+    "completedHint": "この着想はすでに完了しています",
     "offlineHint": "エージェントオフライン — 再接続で有効化",
     "errorAgentOffline": "割り当てられたエージェントはオフラインです。再接続後に Yolo を実行してください。",
     "errorInstanceOffline": "この着想はオフラインのデーモンインスタンスに固定されています。そのインスタンスの再接続後に Yolo を実行してください。",
@@ -1374,6 +1376,17 @@
       "noActivity": "最近のアクティビティはありません"
     },
     "panel": {
+      "actions": {
+        "busy": "現在の操作が完了するまでお待ちください",
+        "loadingStage": "提案と課題のデータを待っています。読み込まれない場合は、着想を開き直して再試行してください。",
+        "verifyUnavailable": "要件詳細化を完了してから確認してください",
+        "editUnavailable": "要件詳細化が完了した着想は編集できません",
+        "copyLink": "リンクをコピー",
+        "copyUuid": "UUID をコピー",
+        "linkCopied": "着想のリンクをコピーしました",
+        "uuidCopied": "着想の UUID をコピーしました",
+        "copyFailed": "コピーできませんでした。クリップボードの権限を確認して再試行してください。"
+      },
       "notFound": "着想が見つかりません",
       "loadFailed": "着想の読み込みに失敗しました",
       "verifyingPlaceholder": "検証中...",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -50,6 +50,7 @@
     "currentAssignee": "현재 담당자",
     "failedToAssign": "배정에 실패했습니다",
     "actions": "작업",
+    "close": "닫기",
     "genericError": "오류가 발생했습니다. 다시 시도해 주세요.",
     "unknown": "알 수 없음",
     "system": "시스템",
@@ -1003,6 +1004,7 @@
     "confirmCta": "Yolo 실행",
     "starting": "시작 중...",
     "startedHint": "Yolo가 시작되었습니다 — 에이전트가 이 아이디어를 완료까지 진행시키고 있습니다",
+    "completedHint": "이 아이디어는 이미 완료되었습니다",
     "offlineHint": "에이전트 오프라인 — 재연결 시 사용 가능",
     "errorAgentOffline": "배정된 에이전트가 오프라인입니다. 다시 연결된 후 Yolo를 실행하세요.",
     "errorInstanceOffline": "이 아이디어는 오프라인 상태인 데몬 인스턴스에 고정되어 있습니다. 해당 인스턴스가 다시 연결된 후 Yolo를 실행하세요.",
@@ -1374,6 +1376,17 @@
       "noActivity": "최근 활동이 없습니다"
     },
     "panel": {
+      "actions": {
+        "busy": "현재 작업이 완료될 때까지 기다려 주세요",
+        "loadingStage": "제안과 작업 데이터를 기다리고 있습니다. 계속 로드되지 않으면 아이디어를 다시 열어 재시도하세요.",
+        "verifyUnavailable": "요구사항 구체화를 완료한 후 확인하세요",
+        "editUnavailable": "구체화가 완료된 아이디어는 편집할 수 없습니다",
+        "copyLink": "링크 복사",
+        "copyUuid": "UUID 복사",
+        "linkCopied": "아이디어 링크를 복사했습니다",
+        "uuidCopied": "아이디어 UUID를 복사했습니다",
+        "copyFailed": "복사하지 못했습니다. 클립보드 권한을 확인하고 다시 시도하세요."
+      },
       "notFound": "아이디어를 찾을 수 없습니다",
       "loadFailed": "아이디어를 불러오지 못했습니다",
       "verifyingPlaceholder": "검증이 진행 중입니다...",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -50,6 +50,7 @@
     "currentAssignee": "当前负责人",
     "failedToAssign": "分配失败",
     "actions": "操作",
+    "close": "关闭",
     "genericError": "发生错误，请重试。",
     "unknown": "未知",
     "system": "系统",
@@ -1003,6 +1004,7 @@
     "confirmCta": "执行 Yolo",
     "starting": "启动中...",
     "startedHint": "Yolo 已启动 —— agent 正在推进这个 idea 到完成",
+    "completedHint": "该想法已完成",
     "offlineHint": "Agent 离线，重连后可用",
     "errorAgentOffline": "该 agent 当前离线，请等它重新连接后再执行 Yolo。",
     "errorInstanceOffline": "该 idea 已固定到一个离线的 daemon 实例，请等该实例重新连接后再执行 Yolo。",
@@ -1374,6 +1376,17 @@
       "noActivity": "暂无活动"
     },
     "panel": {
+      "actions": {
+        "busy": "请等待当前操作完成",
+        "loadingStage": "正在等待方案和任务数据。如一直未加载，请重新打开想法重试。",
+        "verifyUnavailable": "完成需求澄清后才能确认",
+        "editUnavailable": "已完成澄清的想法无法编辑",
+        "copyLink": "复制链接",
+        "copyUuid": "复制 UUID",
+        "linkCopied": "已复制想法链接",
+        "uuidCopied": "已复制想法 UUID",
+        "copyFailed": "无法复制，请检查剪贴板权限后重试。"
+      },
       "notFound": "未找到想法",
       "loadFailed": "加载想法失败",
       "verifyingPlaceholder": "验证进行中...",

--- a/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-11

--- a/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/README.md
+++ b/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/README.md
@@ -1,0 +1,3 @@
+# consolidate-idea-tracker-actions
+
+Consolidate Idea Tracker sidebar actions into a header menu with clipboard utilities

--- a/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/design.md
+++ b/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/design.md
@@ -1,0 +1,34 @@
+## Context
+
+The Tracker panel owns edit, derive, move, delete and verify state. StartDevelopmentButton and YoloButton own stage/presence gating, errors, pin-then-wake cwd pickers and Yolo confirmation. The existing header/footer arrangement is being consolidated, not redesigned. The seven human answers are authoritative. The incumbent shadcn components, spacing and semantic theme tokens remain the visual system.
+
+## Goals / Non-Goals
+
+Goals: one header Actions entry plus Close; no permanent footer; visible disabled operations with reasons; link/UUID utilities; preserved mutation behavior, keyboard accessibility and confirmations.
+
+Non-goals: task/proposal/legacy ideas panel redesign, generic cross-panel action framework, new permissions or wake semantics, Markdown summary/new-tab utilities, changing assignment/lineage/content controls inside tabs.
+
+## Decisions
+
+1. Use shadcn DropdownMenu, right aligned, localized Actions label and chevron. Group progression, editing/organization, clipboard utilities, and destructive Delete last. Do not embed interactive buttons inside menu items. Let menu width fit localized labels within narrow viewports.
+2. Keep dialogs/pickers mounted outside the dropdown content lifecycle. Prefer an optional backwards-compatible trigger render adapter in existing stage-action components to reusing their logic; a local hook extraction is acceptable if default button behavior/tests remain unchanged. Selecting Yolo opens its existing confirmation; menu unmount must not destroy it or the cwd picker. Use explicit focus return to the Actions trigger after dialog close.
+3. Menu items remain present but disabled for stage, offline, pending mutation, theme/container and edit-lock reasons. Do not turn absent permission into permission. Verify uses canVerifyElaboration; Start Development and Yolo reuse their shared predicates/presence resolution. Theme progression remains non-executable with a derive-instead reason. Pending operations cannot double-fire. Show reasons with tooltip and accessible description; support keyboard discovery rather than relying only on disabled elements' pointer events.
+4. Edit Save/Cancel move into the form body. Hide the menu while editing, matching existing header editing behavior, and keep Close's existing cancel-edit semantics. Verify success/error feedback and container guidance move into the body/toasts, not a replacement footer.
+5. Copy a canonical absolute Tracker URL for the current project and idea: `/projects/<projectUuid>/dashboard?panel=<ideaUuid>`. Exclude incidental search filters, tab, hash and unrelated query values. Copy UUID exactly. Await clipboard writes, catch missing/rejected Clipboard API and show translated errors without false success. No insecure legacy clipboard fallback is required.
+6. Tests use actual Radix menu interactions where possible, plus shared control regression tests. Exercise tooltip accessibility, action availability, confirmation/cwd picker survival, clipboard success/failure, form controls and no footer. Browser verification covers English/Chinese, both themes, keyboard and narrow layouts.
+
+## Risks / Trade-offs
+
+- Radix focus and portal lifetimes can close a dialog accidentally → keep modal owners outside menu content and test keyboard activation/cancel.
+- Disabled native menu items are skipped by keyboard → provide discoverable reasons using accessible descriptions and a focusable aria-disabled pattern with explicit event guards if needed; do not trigger mutations on Enter/Space/click.
+- Reusing stage controls affects legacy consumers → optional rendering only; existing button mode retains visibility, purple Yolo styling and behavior.
+- Header width and Chinese labels → truncate title, shrink-proof controls, viewport-constrained menu.
+- Pencil MCP was not exposed in the headless environment; the owner explicitly waived design synchronization on 2026-09-11, so no encrypted `.pen` bytes are edited.
+
+## Migration Plan
+
+No schema or data migration. Deploy as frontend changes; rollback the scoped component/locale changes if necessary. No automatic PR push or merge. Archive OpenSpec only after all tasks are verified and mirror cumulative specs to Chorus.
+
+## Open Questions
+
+No remaining product decisions. The owner waiver removes Pencil synchronization from the delivery scope.

--- a/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/proposal.md
+++ b/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The Idea Tracker sidebar spreads seven functional actions across header and footer, competing with the idea content. A single discoverable Actions entry reduces noise and provides a home for copying the idea link and UUID. The owner selected all seven scope decisions in elaboration and requested YOLO execution.
+
+## What Changes
+
+- Replace the Tracker header action cluster with an Actions dropdown plus independent Close; move Derive, Move, Edit, Verify Elaborate, Start Development, Yolo and Delete into it.
+- Remove the action footer. Keep edit Save/Cancel inline in the edit form so editing remains usable.
+- Add Copy link and Copy UUID with localized success/error feedback.
+- Keep unavailable operations visible, disabled and explained; preserve business predicates, wake routing, theme restrictions and confirmations.
+- Keep destructive Delete separated at the menu bottom.
+- Verify keyboard, mobile, English/Chinese and light/dark behavior. The owner waived the Pencil design update on 2026-09-11.
+
+## Capabilities
+
+### New Capabilities
+- `idea-tracker-actions-menu`: Unified action entry, availability explanations, clipboard utilities and accessible interactions.
+
+### Modified Capabilities
+- `idea-panel-action-row`: Allow the Tracker Yolo action to use a menu item while preserving its visible label and confirmation; standalone shared buttons retain their appearance.
+
+## Impact
+
+Main surface: `src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx`. Shared start-development/yolo controls may gain a backwards-compatible rendering adapter to reuse their wake logic; default consumers remain unchanged. Locales and component tests are affected. No database, REST/MCP API, task/proposal panel, plugin, design artifact or dependency changes are intended.

--- a/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/specs/idea-panel-action-row/spec.md
+++ b/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/specs/idea-panel-action-row/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Yolo button shows icon and label
+
+The Yolo stage-advance action SHALL render a rocket icon followed by the visible localized Yolo text label and SHALL NOT rely on a tooltip to convey its label.
+
+In the dashboard Idea Tracker detail panel it SHALL appear as a menu item inside the header Actions dropdown, using the menu's theme-adaptive styling. In other consumers the shared Yolo button SHALL retain its purple button styling. Both presentations SHALL retain the existing two-step confirmation dialog and wake semantics.
+
+#### Scenario: Yolo button renders icon and text
+- **WHEN** the standalone Yolo button is shown for an eligible idea outside the Tracker menu
+- **THEN** it displays a rocket icon and visible Yolo text with its existing purple styling
+- **AND** it does not depend on a tooltip to reveal its label
+
+#### Scenario: Tracker Yolo menu item
+- **WHEN** the user opens Actions in the Tracker sidebar
+- **THEN** Yolo is a labeled icon menu item instead of a footer button
+- **AND** if unavailable it is disabled and explained
+
+#### Scenario: Confirmation dialog is preserved
+- **WHEN** a user activates an enabled Yolo button or menu item
+- **THEN** a confirmation dialog is shown before the yolo run is requested

--- a/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/specs/idea-tracker-actions-menu/spec.md
+++ b/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/specs/idea-tracker-actions-menu/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: One Tracker action entry
+The Tracker idea sidebar SHALL expose a localized header Actions dropdown and independent Close, moving Derive, Move, Edit, Verify Elaborate, Start Development, Yolo and Delete into the menu. It SHALL remove the footer operation bar, retain inline edit Save/Cancel and leave other detail surfaces unchanged.
+
+#### Scenario: View and edit an idea
+- **WHEN** a user opens the Tracker sidebar
+- **THEN** all seven operations are discoverable inside Actions and Close remains independent
+- **AND** no action footer is rendered
+- **WHEN** the user selects an enabled Edit operation
+- **THEN** Save and Cancel are available inside the edit form and Close preserves cancel-edit behavior
+
+### Requirement: Availability and confirmation safety
+Operations SHALL preserve existing mutation eligibility, stage/presence checks, pin-then-wake routing, permissions and confirmations. Unavailable menu actions SHALL remain visible, non-executable and accompanied by localized reasons accessible with pointer and keyboard. Delete SHALL occupy a separated destructive group at the bottom and SHALL require confirmation.
+
+#### Scenario: Unavailable actions
+- **WHEN** an action is unavailable due to incomplete elaboration, unsuitable stage, offline assignee, theme/container state, edit lock or an in-flight request
+- **THEN** its menu item is disabled with an explanatory tooltip/accessible description
+- **AND** mouse or keyboard activation cannot invoke its mutation
+
+#### Scenario: Confirm or cancel a mutation
+- **WHEN** the user selects Yolo or Delete
+- **THEN** the existing confirmation survives menu closure
+- **AND** cancel causes no mutation and returns focus to Actions
+- **WHEN** a stage advance requires selecting a cwd
+- **THEN** the existing picker survives menu closure and wake executes only through the original pin-then-wake flow
+
+### Requirement: Copy idea identifiers
+The menu SHALL copy the exact current idea UUID or its canonical absolute Tracker URL and report localized success only after clipboard success. Failure or unavailable Clipboard API SHALL result in localized error feedback.
+
+#### Scenario: Successful copy
+- **WHEN** the user selects Copy link or Copy UUID
+- **THEN** clipboard receives respectively the current-origin `/projects/<projectUuid>/dashboard?panel=<ideaUuid>` URL or the exact idea UUID
+- **AND** incidental tab/filter/query/hash state is excluded from the link
+- **AND** the copied link opens the intended Tracker idea
+
+#### Scenario: Clipboard denied
+- **WHEN** clipboard is missing or rejects the write
+- **THEN** an error is shown, no success is shown, and the sidebar remains usable
+
+### Requirement: Accessible localized presentation
+The menu SHALL use shadcn primitives, translated English/Chinese strings and theme-adaptive styling. Keyboard operation, focus return, narrow viewports and light/dark themes SHALL be verified.
+
+#### Scenario: Keyboard and visual verification
+- **WHEN** a user opens Actions via keyboard in either locale and theme
+- **THEN** operations have readable labels, unavailable reasons are discoverable, Escape closes the menu and returns focus, and the sidebar/menu fit a narrow viewport
+- **AND** light and dark presentation remain legible without overflow

--- a/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/tasks.md
+++ b/openspec/changes/archive/2026-09-11-consolidate-idea-tracker-actions/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation and automated coverage
+
+- [x] 1.1 Implement the Tracker Actions menu, disabled reasons, preserved wake/dialog flows, inline edit controls, copy link/UUID and bilingual feedback; add regression tests and run typecheck/lint/focused tests.
+
+## 2. Visual acceptance
+
+- [x] 2.1 Verify the finished surface in browser across locales/themes, keyboard and narrow layout, and record evidence. The owner explicitly waived the Pencil synchronization requirement on 2026-09-11.

--- a/openspec/changes/consolidate-idea-tracker-actions/tasks.md
+++ b/openspec/changes/consolidate-idea-tracker-actions/tasks.md
@@ -1,7 +1,0 @@
-## 1. Implementation and automated coverage
-
-- [x] 1.1 Implement the Tracker Actions menu, disabled reasons, preserved wake/dialog flows, inline edit controls, copy link/UUID and bilingual feedback; add regression tests and run typecheck/lint/focused tests.
-
-## 2. Visual acceptance and design synchronization
-
-- [ ] 2.1 Verify the finished surface in browser across locales/themes, keyboard and narrow layout; update docs/design.pen through Pencil tools and record evidence. Do not claim this item complete if the required tools are unavailable.

--- a/openspec/changes/consolidate-idea-tracker-actions/tasks.md
+++ b/openspec/changes/consolidate-idea-tracker-actions/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation and automated coverage
+
+- [x] 1.1 Implement the Tracker Actions menu, disabled reasons, preserved wake/dialog flows, inline edit controls, copy link/UUID and bilingual feedback; add regression tests and run typecheck/lint/focused tests.
+
+## 2. Visual acceptance and design synchronization
+
+- [ ] 2.1 Verify the finished surface in browser across locales/themes, keyboard and narrow layout; update docs/design.pen through Pencil tools and record evidence. Do not claim this item complete if the required tools are unavailable.

--- a/openspec/specs/idea-panel-action-row/spec.md
+++ b/openspec/specs/idea-panel-action-row/spec.md
@@ -30,18 +30,21 @@ The `/ideas` idea-detail panel is out of scope for this change and keeps its own
 
 ### Requirement: Yolo button shows icon and label
 
-The Yolo stage-advance button SHALL render as a rocket icon followed by the "Yolo" text label, and SHALL NOT rely on a tooltip to convey its label.
+The Yolo stage-advance action SHALL render a rocket icon followed by the visible localized Yolo text label and SHALL NOT rely on a tooltip to convey its label.
 
-The button retains its purple styling and its two-step confirmation dialog. Because the Yolo button is a shared component rendered by both idea-detail panels, the icon+label presentation applies wherever the Yolo button appears.
+In the dashboard Idea Tracker detail panel it SHALL appear as a menu item inside the header Actions dropdown, using the menu's theme-adaptive styling. In other consumers the shared Yolo button SHALL retain its purple button styling. Both presentations SHALL retain the existing two-step confirmation dialog and wake semantics.
 
 #### Scenario: Yolo button renders icon and text
+- **WHEN** the standalone Yolo button is shown for an eligible idea outside the Tracker menu
+- **THEN** it displays a rocket icon and visible Yolo text with its existing purple styling
+- **AND** it does not depend on a tooltip to reveal its label
 
-- **WHEN** the Yolo button is shown on an idea-detail panel for an eligible idea
-- **THEN** it displays a rocket icon together with the visible text "Yolo"
-- **AND** it does not depend on a hover tooltip to reveal its label
+#### Scenario: Tracker Yolo menu item
+- **WHEN** the user opens Actions in the Tracker sidebar
+- **THEN** Yolo is a labeled icon menu item instead of a footer button
+- **AND** if unavailable it is disabled and explained
 
 #### Scenario: Confirmation dialog is preserved
-
-- **WHEN** a user clicks the Yolo button
+- **WHEN** a user activates an enabled Yolo button or menu item
 - **THEN** a confirmation dialog is shown before the yolo run is requested
 

--- a/openspec/specs/idea-tracker-actions-menu/spec.md
+++ b/openspec/specs/idea-tracker-actions-menu/spec.md
@@ -1,0 +1,50 @@
+# idea-tracker-actions-menu Specification
+
+## Purpose
+TBD - created by archiving change consolidate-idea-tracker-actions. Update Purpose after archive.
+## Requirements
+### Requirement: One Tracker action entry
+The Tracker idea sidebar SHALL expose a localized header Actions dropdown and independent Close, moving Derive, Move, Edit, Verify Elaborate, Start Development, Yolo and Delete into the menu. It SHALL remove the footer operation bar, retain inline edit Save/Cancel and leave other detail surfaces unchanged.
+
+#### Scenario: View and edit an idea
+- **WHEN** a user opens the Tracker sidebar
+- **THEN** all seven operations are discoverable inside Actions and Close remains independent
+- **AND** no action footer is rendered
+- **WHEN** the user selects an enabled Edit operation
+- **THEN** Save and Cancel are available inside the edit form and Close preserves cancel-edit behavior
+
+### Requirement: Availability and confirmation safety
+Operations SHALL preserve existing mutation eligibility, stage/presence checks, pin-then-wake routing, permissions and confirmations. Unavailable menu actions SHALL remain visible, non-executable and accompanied by localized reasons accessible with pointer and keyboard. Delete SHALL occupy a separated destructive group at the bottom and SHALL require confirmation.
+
+#### Scenario: Unavailable actions
+- **WHEN** an action is unavailable due to incomplete elaboration, unsuitable stage, offline assignee, theme/container state, edit lock or an in-flight request
+- **THEN** its menu item is disabled with an explanatory tooltip/accessible description
+- **AND** mouse or keyboard activation cannot invoke its mutation
+
+#### Scenario: Confirm or cancel a mutation
+- **WHEN** the user selects Yolo or Delete
+- **THEN** the existing confirmation survives menu closure
+- **AND** cancel causes no mutation and returns focus to Actions
+- **WHEN** a stage advance requires selecting a cwd
+- **THEN** the existing picker survives menu closure and wake executes only through the original pin-then-wake flow
+
+### Requirement: Copy idea identifiers
+The menu SHALL copy the exact current idea UUID or its canonical absolute Tracker URL and report localized success only after clipboard success. Failure or unavailable Clipboard API SHALL result in localized error feedback.
+
+#### Scenario: Successful copy
+- **WHEN** the user selects Copy link or Copy UUID
+- **THEN** clipboard receives respectively the current-origin `/projects/<projectUuid>/dashboard?panel=<ideaUuid>` URL or the exact idea UUID
+- **AND** incidental tab/filter/query/hash state is excluded from the link
+- **AND** the copied link opens the intended Tracker idea
+
+#### Scenario: Clipboard denied
+- **WHEN** clipboard is missing or rejects the write
+- **THEN** an error is shown, no success is shown, and the sidebar remains usable
+
+### Requirement: Accessible localized presentation
+The menu SHALL use shadcn primitives, translated English/Chinese strings and theme-adaptive styling. Keyboard operation, focus return, narrow viewports and light/dark themes SHALL be verified.
+
+#### Scenario: Keyboard and visual verification
+- **WHEN** a user opens Actions via keyboard in either locale and theme
+- **THEN** operations have readable labels, unavailable reasons are discoverable, Escape closes the menu and returns focus, and the sidebar/menu fit a narrow viewport
+- **AND** light and dark presentation remain legible without overflow

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-actions-menu.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-actions-menu.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import React, { useRef } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import en from "../../../../../../../messages/en.json";
+import zh from "../../../../../../../messages/zh.json";
+import { IdeaActionsMenu } from "../panels/idea-actions-menu";
+
+const mocks = vi.hoisted(() => ({
+  start: vi.fn(), yolo: vi.fn(), reassign: vi.fn(), success: vi.fn(), error: vi.fn(),
+  connections: [{ agentUuid: "agent-1", effectiveStatus: "online" }],
+}));
+vi.mock("@/contexts/agent-presence-context", () => ({ useAgentPresenceOptional: () => ({ connections: mocks.connections }) }));
+vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/stage-advance-actions", () => ({
+  startDevelopmentAction: mocks.start, yoloRequestedAction: mocks.yolo,
+}));
+vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/actions", () => ({ reassignIdeaInstanceNoWakeAction: mocks.reassign }));
+vi.mock("sonner", () => ({ toast: { success: mocks.success, error: mocks.error } }));
+
+const callbacks = { onVerify: vi.fn(), onDerive: vi.fn(), onMove: vi.fn(), onEdit: vi.fn(), onDelete: vi.fn(), onStarted: vi.fn() };
+const base = {
+  ideaUuid: "idea-1", projectUuid: "project-1", assignee: { type: "agent", uuid: "agent-1" },
+  assigneeName: "Agent", proposals: [{ status: "approved" }], tasks: [{ status: "open" }], busy: false, ...callbacks,
+};
+type Overrides = Partial<React.ComponentProps<typeof IdeaActionsMenu>>;
+function Harness({ overrides = {}, locale = "en" }: { overrides?: Overrides; locale?: "en" | "zh" }) {
+  const ref = useRef<HTMLButtonElement>(null);
+  return <NextIntlClientProvider locale={locale} messages={locale === "en" ? en : zh}>
+    <IdeaActionsMenu {...base} triggerRef={ref} onCloseAutoFocus={(event) => { event.preventDefault(); ref.current?.focus(); }} {...overrides} />
+  </NextIntlClientProvider>;
+}
+const instances = [1, 2].map((n) => ({ connectionUuid: `c${n}`, agentInstanceUuid: `i${n}`, host: `host-${n}`, cwd: `/repo-${n}`, effectiveStatus: "online", isOnline: true }));
+function preview(outcome = "direct") {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, data: { outcome, assigneeAgentUuid: "agent-1", onlineInstances: outcome === "pick" ? instances : [] } }) }));
+}
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.connections = [{ agentUuid: "agent-1", effectiveStatus: "online" }];
+  mocks.start.mockResolvedValue({ success: true });
+  mocks.yolo.mockResolvedValue({ success: true });
+  mocks.reassign.mockResolvedValue({ success: true });
+  preview();
+  window.history.replaceState(null, "", "/projects/project-1/dashboard?panel=old&tab=tasks&search=noise#hash");
+  globalThis.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} } as unknown as typeof ResizeObserver;
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
+});
+async function open(user: ReturnType<typeof userEvent.setup>) { await user.click(screen.getByRole("button", { name: "Actions" })); }
+
+describe("Tracker Actions — real Radix interactions", () => {
+  it("groups all actions with separated destructive Delete and no nested buttons", async () => {
+    const user = userEvent.setup(); render(<Harness />); await open(user);
+    expect(screen.getAllByRole("menuitem")).toHaveLength(9);
+    expect(screen.getByRole("menuitem", { name: "Delete Idea" }).getAttribute("data-variant")).toBe("destructive");
+    expect(screen.getByRole("menuitem", { name: "Delete Idea" }).previousElementSibling?.getAttribute("role")).toBe("separator");
+    expect(document.querySelector("button button")).toBeNull();
+    await user.keyboard("{Escape}");
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Actions" }));
+  });
+
+  it("keeps unavailable actions focusable and explained; pointer/Enter/Space cannot run them", async () => {
+    const user = userEvent.setup();
+    render(<Harness overrides={{ stageReason: en.ideaTracker.lineage.containerHint, editReason: en.ideaTracker.panel.actions.editUnavailable }} />);
+    await open(user);
+    const item = screen.getByRole("menuitem", { name: "Start Development" });
+    expect(item.getAttribute("aria-disabled")).toBe("true");
+    const id = item.getAttribute("aria-describedby")!;
+    expect(document.getElementById(id)?.textContent).toBe(en.ideaTracker.lineage.containerHint);
+    act(() => item.focus());
+    expect(await screen.findByRole("tooltip")).toBeTruthy();
+    await user.click(item);
+    act(() => item.focus()); await user.keyboard("{Enter} ");
+    expect(mocks.start).not.toHaveBeenCalled();
+    expect(mocks.reassign).not.toHaveBeenCalled();
+    expect(screen.getByRole("menu")).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Edit Idea" }).getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it.each([
+    { overrides: { assignee: null }, label: "Yolo", reason: en.yolo.errorAssigneeNotAgent },
+    { overrides: { proposals: [] }, label: "Start Development", reason: en.startDevelopment.errorNoApprovedProposal },
+    { overrides: { tasks: [{ status: "done" }] }, label: "Yolo", reason: en.yolo.completedHint },
+    { overrides: { busy: true }, label: en.ideaTracker.lineage.deriveIdea, reason: en.ideaTracker.panel.actions.busy },
+  ])("explains gate $reason", async ({ overrides, label, reason }) => {
+    const user = userEvent.setup(); render(<Harness overrides={overrides} />); await open(user);
+    const item = screen.getByRole("menuitem", { name: label });
+    expect(item.getAttribute("aria-disabled")).toBe("true");
+    expect(item.textContent).toContain(reason);
+  });
+
+  it("responds to late stage data and presence updates without stale eligibility", async () => {
+    const user = userEvent.setup();
+    const view = render(<Harness overrides={{ stageReason: en.ideaTracker.panel.actions.loadingStage }} />);
+    await open(user);
+    expect(screen.getByRole("menuitem", { name: "Yolo" }).getAttribute("aria-disabled")).toBe("true");
+    view.rerender(<Harness overrides={{ tasks: [{ status: "done" }] }} />);
+    expect(screen.getByRole("menuitem", { name: "Yolo" }).textContent).toContain(en.yolo.completedHint);
+    mocks.connections = [];
+    view.rerender(<Harness />);
+    expect(screen.getByRole("menuitem", { name: "Yolo" }).textContent).toContain(en.yolo.offlineHint);
+    mocks.connections = [{ agentUuid: "agent-1", effectiveStatus: "online" }];
+    view.rerender(<Harness />);
+    expect(screen.getByRole("menuitem", { name: "Yolo" }).getAttribute("aria-disabled")).toBe("false");
+  });
+
+  it("copies canonical absolute link and exact UUID only after clipboard resolves", async () => {
+    const user = userEvent.setup();
+    let resolve!: () => void;
+    const write = vi.spyOn(navigator.clipboard, "writeText").mockImplementationOnce(() => new Promise<void>((r) => { resolve = r; })).mockResolvedValue(undefined);
+    render(<Harness />); await open(user);
+    await user.click(screen.getByRole("menuitem", { name: "Copy link" }));
+    expect(write).toHaveBeenCalledWith(`${window.location.origin}/projects/project-1/dashboard?panel=idea-1`);
+    expect(mocks.success).not.toHaveBeenCalled(); await act(async () => resolve());
+    await waitFor(() => expect(mocks.success).toHaveBeenCalledWith(en.ideaTracker.panel.actions.linkCopied));
+    await open(user); await user.click(screen.getByRole("menuitem", { name: "Copy UUID" }));
+    expect(write).toHaveBeenLastCalledWith("idea-1");
+    expect(mocks.success).toHaveBeenLastCalledWith(en.ideaTracker.panel.actions.uuidCopied);
+  });
+
+  it.each(["missing", "rejected"])("reports %s clipboard without false success", async (mode) => {
+    const user = userEvent.setup();
+    if (mode === "missing") Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
+    else vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(new Error("denied"));
+    render(<Harness />); await open(user); await user.click(screen.getByRole("menuitem", { name: "Copy UUID" }));
+    expect(mocks.error).toHaveBeenCalledWith(en.ideaTracker.panel.actions.copyFailed);
+    expect(mocks.success).not.toHaveBeenCalled(); await open(user); expect(screen.getByRole("menu")).toBeTruthy();
+  });
+
+  it("Yolo keyboard confirmation survives menu closure; cancel restores focus without wake", async () => {
+    const user = userEvent.setup(); render(<Harness />);
+    act(() => screen.getByRole("button", { name: "Actions" }).focus()); await user.keyboard("{Enter}");
+    act(() => screen.getByRole("menuitem", { name: "Yolo" }).focus()); await user.keyboard("{Enter}");
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+    expect(screen.getByRole("alertdialog").contains(document.activeElement)).toBe(true);
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mocks.yolo).not.toHaveBeenCalled(); expect(mocks.reassign).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Actions" }));
+  });
+
+  it.each(["Start Development", "Yolo"])("%s picker survives menu closure and pins before waking", async (label) => {
+    preview("pick"); const user = userEvent.setup(); render(<Harness />); await open(user);
+    await user.click(screen.getByRole("menuitem", { name: label }));
+    if (label === "Yolo") await user.click(screen.getByRole("button", { name: en.yolo.confirmCta }));
+    expect(await screen.findByRole("dialog")).toBeTruthy();
+    expect(screen.getByRole("dialog").contains(document.activeElement)).toBe(true);
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(mocks.start).not.toHaveBeenCalled(); expect(mocks.yolo).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: en.wakeCwdPicker.confirm }));
+    await waitFor(() => expect(label === "Yolo" ? mocks.yolo : mocks.start).toHaveBeenCalledWith("idea-1"));
+    expect(mocks.reassign).toHaveBeenCalledWith("idea-1", "agent-1", "i1");
+    expect(mocks.reassign.mock.invocationCallOrder[0]).toBeLessThan((label === "Yolo" ? mocks.yolo : mocks.start).mock.invocationCallOrder[0]);
+  });
+
+  it("picker cancellation does not pin/wake and returns focus", async () => {
+    preview("pick"); const user = userEvent.setup(); render(<Harness />); await open(user);
+    await user.click(screen.getByRole("menuitem", { name: "Start Development" }));
+    await screen.findByRole("dialog"); await user.click(screen.getByRole("button", { name: en.wakeCwdPicker.cancel }));
+    expect(mocks.reassign).not.toHaveBeenCalled(); expect(mocks.start).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Actions" }));
+  });
+
+  it("uses Chinese menu, gate and clipboard feedback", async () => {
+    const user = userEvent.setup(); vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
+    render(<Harness locale="zh" overrides={{ busy: true }} />);
+    await user.click(screen.getByRole("button", { name: zh.common.actions }));
+    expect(screen.getByRole("menuitem", { name: zh.ideas.editIdea }).textContent).toContain(zh.ideaTracker.panel.actions.busy);
+    await user.click(screen.getByRole("menuitem", { name: zh.ideaTracker.panel.actions.copyLink }));
+    expect(mocks.success).toHaveBeenCalledWith(zh.ideaTracker.panel.actions.linkCopied);
+  });
+
+  it("keeps Yolo confirmation mounted if presence changes, but disables confirmation", async () => {
+    const user = userEvent.setup(); const view = render(<Harness />); await open(user);
+    await user.click(screen.getByRole("menuitem", { name: "Yolo" }));
+    mocks.connections = [];
+    view.rerender(<Harness />);
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+    expect(screen.getByRole<HTMLButtonElement>("button", { name: en.yolo.confirmCta }).disabled).toBe(true);
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mocks.yolo).not.toHaveBeenCalled();
+  });
+
+  it("blocks repeat and competing mutations while a wake is pending", async () => {
+    let resolve!: (value: unknown) => void;
+    mocks.start.mockImplementation(() => new Promise((r) => { resolve = r; }));
+    const user = userEvent.setup(); render(<Harness />); await open(user);
+    await user.click(screen.getByRole("menuitem", { name: "Start Development" }));
+    await waitFor(() => expect(mocks.start).toHaveBeenCalledOnce());
+    await open(user);
+    for (const name of ["Start Development", "Yolo", "Verify Elaborate", "Delete Idea", "Edit Idea"]) {
+      const item = screen.getByRole("menuitem", { name });
+      expect(item.getAttribute("aria-disabled")).toBe("true");
+      await user.click(item);
+    }
+    expect(mocks.start).toHaveBeenCalledOnce(); expect(callbacks.onDelete).not.toHaveBeenCalled();
+    expect(callbacks.onVerify).not.toHaveBeenCalled(); expect(mocks.yolo).not.toHaveBeenCalled();
+    await act(async () => resolve({ success: true }));
+    expect(callbacks.onStarted).toHaveBeenCalledOnce();
+  });
+
+  it("does not submit an IME-composing Enter selection", async () => {
+    const user = userEvent.setup(); render(<Harness />); await open(user);
+    fireEvent.keyDown(screen.getByRole("menuitem", { name: "Yolo" }), { key: "Enter", isComposing: true });
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+});

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-actions-menu.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-actions-menu.test.tsx
@@ -33,8 +33,15 @@ function Harness({ overrides = {}, locale = "en" }: { overrides?: Overrides; loc
 }
 const instances = [1, 2].map((n) => ({ connectionUuid: `c${n}`, agentInstanceUuid: `i${n}`, host: `host-${n}`, cwd: `/repo-${n}`, effectiveStatus: "online", isOnline: true }));
 function preview(outcome = "direct") {
-  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, data: { outcome, assigneeAgentUuid: "agent-1", onlineInstances: outcome === "pick" ? instances : [] } }) }));
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, data: { outcome, assigneeAgentUuid: "agent-1", onlineInstances: outcome === "pick" ? instances : outcome === "auto_pin" ? instances.slice(0, 1) : [] } }) }));
 }
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.connections = [{ agentUuid: "agent-1", effectiveStatus: "online" }];
@@ -156,12 +163,22 @@ describe("Tracker Actions — real Radix interactions", () => {
     expect(mocks.reassign.mock.invocationCallOrder[0]).toBeLessThan((label === "Yolo" ? mocks.yolo : mocks.start).mock.invocationCallOrder[0]);
   });
 
-  it("picker cancellation does not pin/wake and returns focus", async () => {
+  it.each(["Start Development", "Yolo"])("%s picker cancellation releases the gate without pin/wake", async (label) => {
     preview("pick"); const user = userEvent.setup(); render(<Harness />); await open(user);
-    await user.click(screen.getByRole("menuitem", { name: "Start Development" }));
+    await user.click(screen.getByRole("menuitem", { name: label }));
+    if (label === "Yolo") await user.click(screen.getByRole("button", { name: en.yolo.confirmCta }));
     await screen.findByRole("dialog"); await user.click(screen.getByRole("button", { name: en.wakeCwdPicker.cancel }));
-    expect(mocks.reassign).not.toHaveBeenCalled(); expect(mocks.start).not.toHaveBeenCalled();
+    expect(mocks.reassign).not.toHaveBeenCalled(); expect(mocks.start).not.toHaveBeenCalled(); expect(mocks.yolo).not.toHaveBeenCalled();
     expect(document.activeElement).toBe(screen.getByRole("button", { name: "Actions" }));
+    await open(user);
+    for (const name of ["Start Development", "Yolo", "Delete Idea"]) {
+      expect(screen.getByRole("menuitem", { name }).getAttribute("aria-disabled")).toBe("false");
+    }
+    await user.click(screen.getByRole("menuitem", { name: label }));
+    if (label === "Yolo") await user.click(screen.getByRole("button", { name: en.yolo.confirmCta }));
+    await screen.findByRole("dialog");
+    await user.click(screen.getByRole("button", { name: en.wakeCwdPicker.confirm }));
+    await waitFor(() => expect(label === "Yolo" ? mocks.yolo : mocks.start).toHaveBeenCalledOnce());
   });
 
   it("uses Chinese menu, gate and clipboard feedback", async () => {
@@ -200,6 +217,77 @@ describe("Tracker Actions — real Radix interactions", () => {
     expect(callbacks.onVerify).not.toHaveBeenCalled(); expect(mocks.yolo).not.toHaveBeenCalled();
     await act(async () => resolve({ success: true }));
     expect(callbacks.onStarted).toHaveBeenCalledOnce();
+  });
+
+  describe.each(["auto_pin", "pick"])("deferred %s flow", (outcome) => {
+    it.each([
+      ["Start Development", "success"], ["Yolo", "success"],
+      ["Start Development", "failure"], ["Yolo", "failure"],
+      ["Start Development", "throw"], ["Yolo", "throw"],
+    ])("locks %s through pin+wake and releases after %s", async (label, result) => {
+      preview(outcome);
+      const pin = deferred<{ success: boolean }>();
+      const wake = deferred<{ success: boolean }>();
+      mocks.reassign.mockReturnValueOnce(pin.promise);
+      const action = label === "Yolo" ? mocks.yolo : mocks.start;
+      action.mockReturnValueOnce(wake.promise);
+      const user = userEvent.setup(); render(<Harness />); await open(user);
+      await user.click(screen.getByRole("menuitem", { name: label }));
+      if (label === "Yolo") await user.click(screen.getByRole("button", { name: en.yolo.confirmCta }));
+      if (outcome === "pick") {
+        await screen.findByRole("dialog");
+        await user.click(screen.getByRole("button", { name: en.wakeCwdPicker.confirm }));
+      }
+      await waitFor(() => expect(mocks.reassign).toHaveBeenCalledOnce());
+      expect(mocks.reassign).toHaveBeenCalledWith("idea-1", "agent-1", "i1");
+      expect(action).not.toHaveBeenCalled();
+      expect(screen.queryByRole("dialog")).toBeNull();
+      await open(user);
+      const assertLocked = async () => {
+        for (const name of ["Start Development", "Yolo", "Verify Elaborate", "Delete Idea", "Edit Idea", en.ideaTracker.lineage.deriveIdea, en.ideas.actions.move]) {
+          const item = screen.getByRole("menuitem", { name });
+          expect(item.getAttribute("aria-disabled")).toBe("true");
+          await user.click(item);
+          act(() => item.focus()); await user.keyboard("{Enter} ");
+        }
+        expect(callbacks.onDelete).not.toHaveBeenCalled();
+        expect(callbacks.onVerify).not.toHaveBeenCalled();
+        expect(callbacks.onEdit).not.toHaveBeenCalled();
+        expect(callbacks.onDerive).not.toHaveBeenCalled();
+        expect(callbacks.onMove).not.toHaveBeenCalled();
+        expect(screen.queryByRole("alertdialog")).toBeNull();
+        expect(mocks.reassign).toHaveBeenCalledOnce();
+        expect(label === "Yolo" ? mocks.start : mocks.yolo).not.toHaveBeenCalled();
+      };
+      await assertLocked();
+      // Even a failed/thrown best-effort pin proceeds to exactly one wake,
+      // without an unlocked render between the two deferred requests.
+      await act(async () => {
+        if (result === "throw") pin.reject(new Error("pin failed"));
+        else pin.resolve({ success: result === "success" });
+      });
+      expect(action).toHaveBeenCalledOnce();
+      await assertLocked();
+      await act(async () => {
+        if (result === "throw") wake.reject(new Error("wake failed"));
+        else wake.resolve({ success: result === "success" });
+      });
+      expect(action).toHaveBeenCalledOnce();
+      expect(screen.getByRole("menuitem", { name: "Delete Idea" }).getAttribute("aria-disabled")).toBe("false");
+      if (result !== "success") {
+        expect(mocks.error).toHaveBeenCalledWith(label === "Yolo" ? en.yolo.errorGeneric : en.startDevelopment.errorGeneric);
+        expect(mocks.success).not.toHaveBeenCalled();
+        // Error releases both the hook and the surface's own pending flag.
+        expect(screen.getByRole("menuitem", { name: label }).getAttribute("aria-disabled")).toBe("false");
+        await user.click(screen.getByRole("menuitem", { name: label }));
+        if (label === "Yolo") await user.click(screen.getByRole("button", { name: en.yolo.confirmCta }));
+        if (outcome === "pick") {
+          await screen.findByRole("dialog");
+          await user.click(screen.getByRole("button", { name: en.wakeCwdPicker.confirm }));
+        }
+        await waitFor(() => expect(action).toHaveBeenCalledTimes(2));
+      }
+    });
   });
 
   it("does not submit an IME-composing Enter selection", async () => {

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-actions-menu.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-actions-menu.test.tsx
@@ -87,6 +87,18 @@ describe("Tracker Actions — real Radix interactions", () => {
     expect(screen.getByRole("menuitem", { name: "Edit Idea" }).getAttribute("aria-disabled")).toBe("true");
   });
 
+  it("closes the menu and restores trigger focus when Escape dismisses a disabled-item tooltip", async () => {
+    const user = userEvent.setup();
+    render(<Harness overrides={{ stageReason: en.ideaTracker.lineage.containerHint }} />);
+    await open(user);
+    const item = screen.getByRole("menuitem", { name: "Start Development" });
+    act(() => item.focus());
+    expect(await screen.findByRole("tooltip")).toBeTruthy();
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Actions" }));
+  });
+
   it.each([
     { overrides: { assignee: null }, label: "Yolo", reason: en.yolo.errorAssigneeNotAgent },
     { overrides: { proposals: [] }, label: "Start Development", reason: en.startDevelopment.errorNoApprovedProposal },

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-detail-actions.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-detail-actions.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import en from "../../../../../../../messages/en.json";
+import { IdeaDetailPanel } from "../panels/idea-detail-panel";
+
+const mocks = vi.hoisted(() => ({
+  getIdea: vi.fn(), proposals: vi.fn(), tasks: vi.fn(), elaboration: vi.fn(), verify: vi.fn(), update: vi.fn(), delete: vi.fn(),
+  refresh: vi.fn(), close: vi.fn(), reassign: vi.fn(), yolo: vi.fn(), start: vi.fn(),
+}));
+vi.mock("@/hooks/use-progress-router", () => ({ useRouter: () => ({ refresh: mocks.refresh }) }));
+vi.mock("@/contexts/realtime-context", () => ({ useRealtimeEntityTypeEvent: () => {} }));
+vi.mock("@/contexts/agent-presence-context", () => ({ useAgentPresenceOptional: () => null }));
+vi.mock("../panels/actions", () => ({ getIdeaAction: mocks.getIdea, getTaskAction: vi.fn(), getProposalsForIdeaAction: mocks.proposals, getTasksForProposalAction: mocks.tasks }));
+vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/actions", () => ({ updateIdeaAction: mocks.update, deleteIdeaAction: mocks.delete }));
+vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/actions", () => ({ reassignIdeaInstanceNoWakeAction: mocks.reassign }));
+vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/elaboration-actions", () => ({ getElaborationAction: mocks.elaboration, verifyElaborationAction: mocks.verify }));
+vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/stage-advance-actions", () => ({ startDevelopmentAction: mocks.start, yoloRequestedAction: mocks.yolo }));
+vi.mock("../panels/elaboration-view", () => ({ ElaborationView: () => null }));
+vi.mock("../panels/proposal-view", () => ({ ProposalView: () => null }));
+vi.mock("../panels/overview-timeline", () => ({ OverviewTimeline: () => null }));
+vi.mock("../panels/reports-list", () => ({ ReportsList: () => null }));
+vi.mock("../panels/task-list-view", () => ({ TaskListView: () => null }));
+vi.mock("../panels/activity-comments-view", () => ({ ActivityCommentsView: () => null }));
+vi.mock("@/app/(dashboard)/projects/[uuid]/tasks/task-detail-panel", () => ({ TaskDetailPanel: () => null }));
+vi.mock("../panels/document-panel", () => ({ DocumentPanel: () => null }));
+vi.mock("../panels/move-idea-dialog", () => ({ MoveIdeaDialog: ({ open }: { open: boolean }) => open ? <div role="dialog">Move</div> : null }));
+vi.mock("../panels/set-parent-dialog", () => ({ SetParentDialog: () => null }));
+vi.mock("../new-idea-dialog", () => ({ NewIdeaDialog: ({ open }: { open: boolean }) => open ? <div role="dialog">Derive</div> : null }));
+vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/assign-idea-modal", () => ({ AssignIdeaModal: () => null }));
+vi.mock("@/components/references-section", () => ({ ReferencesSection: () => null }));
+vi.mock("@/components/active-session-indicator", () => ({ ActiveSessionIndicator: () => null }));
+
+const idea = { uuid: "idea-1", title: "Test idea", content: "Body", status: "elaborating", derivedStatus: "researching", badgeHint: null, createdAt: "2026-09-01T00:00:00Z", assignee: { type: "agent", uuid: "agent-1", name: "Agent" }, elaborationStatus: "validating", isContainer: false };
+function Panel({ uuid = "idea-1" }: { uuid?: string }) {
+  return <NextIntlClientProvider locale="en" messages={en}>
+    <IdeaDetailPanel ideaUuid={uuid} projectUuid="project-1" currentUserUuid="user-1" onClose={mocks.close} />
+  </NextIntlClientProvider>;
+}
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getIdea.mockImplementation(async (uuid: string) => ({ success: true, data: { ...idea, uuid } }));
+  mocks.proposals.mockResolvedValue({ success: true, data: [] });
+  mocks.tasks.mockResolvedValue({ success: true, data: [] });
+  mocks.elaboration.mockResolvedValue({ success: true, data: { rounds: [{ status: "validating" }] } });
+  mocks.update.mockResolvedValue({ success: true }); mocks.delete.mockResolvedValue({ success: true });
+  mocks.verify.mockResolvedValue({ success: true }); mocks.reassign.mockResolvedValue({ success: true });
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, data: { outcome: "direct", onlineInstances: [] } }) }));
+  window.history.replaceState(null, "", "/projects/project-1/dashboard?panel=idea-1");
+  window.matchMedia = vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() });
+  globalThis.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} } as unknown as typeof ResizeObserver;
+  Element.prototype.hasPointerCapture = () => false; Element.prototype.setPointerCapture = () => {}; Element.prototype.releasePointerCapture = () => {}; Element.prototype.scrollIntoView = () => {};
+});
+async function open(user: ReturnType<typeof userEvent.setup>) { await user.click(await screen.findByRole("button", { name: "Actions" })); }
+
+describe("Tracker panel action integration", () => {
+  it("has independent Close, no footer, and inline Save/Cancel while editing", async () => {
+    const user = userEvent.setup(); const view = render(<Panel />); await open(user);
+    expect(view.container.querySelector(".border-t")).toBeNull();
+    await user.click(screen.getByRole("menuitem", { name: "Edit Idea" }));
+    expect(screen.queryByRole("button", { name: "Actions" })).toBeNull();
+    const title = screen.getByRole("textbox", { name: en.ideas.titleLabel });
+    await user.clear(title); await user.type(title, "Updated");
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.closest('[data-slot="scroll-area"]')).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" }).closest('[data-slot="scroll-area"]')).toBeTruthy();
+    await user.click(save);
+    await waitFor(() => expect(mocks.update).toHaveBeenCalledWith({ ideaUuid: "idea-1", projectUuid: "project-1", title: "Updated", content: "Body" }));
+    await open(user); await user.click(screen.getByRole("menuitem", { name: "Edit Idea" }));
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(mocks.close).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Actions" })).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Close" })); expect(mocks.close).toHaveBeenCalledOnce();
+  });
+
+  it("Delete confirmation survives menu closure, cancels without mutation, and restores focus", async () => {
+    const user = userEvent.setup(); render(<Panel />); await open(user);
+    await user.click(screen.getByRole("menuitem", { name: "Delete Idea" }));
+    expect(screen.queryByRole("menu")).toBeNull(); expect(screen.getByRole("alertdialog")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mocks.delete).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Actions" }));
+    await open(user); await user.click(screen.getByRole("menuitem", { name: "Delete Idea" }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    expect(mocks.delete).toHaveBeenCalledWith("idea-1", "project-1"); expect(mocks.close).toHaveBeenCalledOnce();
+  });
+
+  it("Verify uses shared elaboration gates, waits for late answers, then runs original wake", async () => {
+    let resolve!: (value: unknown) => void;
+    mocks.elaboration.mockImplementation(() => new Promise((r) => { resolve = r; }));
+    const user = userEvent.setup(); render(<Panel />); await open(user);
+    const verify = screen.getByRole("menuitem", { name: "Verify Elaborate" });
+    expect(verify.getAttribute("aria-disabled")).toBe("true");
+    await act(async () => resolve({ success: true, data: { rounds: [{ status: "pending_answers" }] } }));
+    await waitFor(() => expect(verify.textContent).toContain(en.ideaTracker.panel.actions.verifyUnavailable));
+    await user.click(verify); expect(mocks.verify).not.toHaveBeenCalled();
+  });
+
+  it("Verify enabled path wakes and shows inline feedback", async () => {
+    const user = userEvent.setup(); render(<Panel />); await open(user);
+    await waitFor(() => expect(screen.getByRole("menuitem", { name: "Verify Elaborate" }).getAttribute("aria-disabled")).toBe("false"));
+    await user.click(screen.getByRole("menuitem", { name: "Verify Elaborate" }));
+    await waitFor(() => expect(mocks.verify).toHaveBeenCalledWith("idea-1"));
+    expect(await screen.findByRole("status")).toBeTruthy();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("container progression stays visible but disabled; derive and move remain usable", async () => {
+    mocks.getIdea.mockResolvedValue({ success: true, data: { ...idea, isContainer: true } });
+    const user = userEvent.setup(); render(<Panel />); await open(user);
+    for (const name of ["Verify Elaborate", "Start Development", "Yolo"]) {
+      expect(screen.getByRole("menuitem", { name }).getAttribute("aria-disabled")).toBe("true");
+      expect(screen.getByRole("menuitem", { name }).textContent).toContain(en.ideaTracker.lineage.containerHint);
+    }
+    expect(screen.getByRole("menuitem", { name: en.ideas.actions.move }).getAttribute("aria-disabled")).toBe("false");
+    await user.click(screen.getByRole("menuitem", { name: en.ideaTracker.lineage.deriveIdea }));
+    expect(screen.getByRole("dialog").textContent).toBe("Derive");
+  });
+
+  it("keeps the elaborated edit lock visible and blocks mutations during a container update", async () => {
+    let resolve!: (value: unknown) => void;
+    mocks.getIdea.mockResolvedValue({ success: true, data: { ...idea, status: "elaborated" } });
+    mocks.update.mockImplementation(() => new Promise((r) => { resolve = r; }));
+    const user = userEvent.setup(); render(<Panel />); await open(user);
+    expect(screen.getByRole("menuitem", { name: "Edit Idea" }).textContent).toContain(en.ideaTracker.panel.actions.editUnavailable);
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("switch"));
+    await open(user);
+    for (const item of screen.getAllByRole("menuitem").filter((item) => !item.textContent?.startsWith("Copy"))) {
+      expect(item.getAttribute("aria-disabled")).toBe("true");
+      expect(item.textContent).toContain(en.ideaTracker.panel.actions.busy);
+    }
+    await act(async () => resolve({ success: true }));
+  });
+
+  it("Verify picker remains mounted after menu selection; cancel never verifies", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, data: {
+      outcome: "pick", assigneeAgentUuid: "agent-1", onlineInstances: [1, 2].map((n) => ({ connectionUuid: `c${n}`, agentInstanceUuid: `i${n}`, host: `h${n}`, cwd: `/repo${n}`, effectiveStatus: "online" })),
+    } }) }));
+    const user = userEvent.setup(); render(<Panel />); await open(user);
+    await user.click(screen.getByRole("menuitem", { name: "Verify Elaborate" }));
+    expect(await screen.findByRole("dialog")).toBeTruthy(); expect(screen.queryByRole("menu")).toBeNull();
+    await user.click(screen.getByRole("button", { name: en.wakeCwdPicker.cancel }));
+    expect(mocks.verify).not.toHaveBeenCalled(); expect(mocks.reassign).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Actions" }));
+  });
+
+  it("waits for proposals AND tasks before trusting Yolo's completion gate", async () => {
+    let resolveProposals!: (value: unknown) => void;
+    let resolveTasks!: (value: unknown) => void;
+    mocks.proposals.mockImplementation(() => new Promise((r) => { resolveProposals = r; }));
+    mocks.tasks.mockImplementation(() => new Promise((r) => { resolveTasks = r; }));
+    const user = userEvent.setup(); render(<Panel />); await open(user);
+    expect(screen.getByRole("menuitem", { name: "Yolo" }).textContent).toContain(en.ideaTracker.panel.actions.loadingStage);
+    await act(async () => resolveProposals({ success: true, data: [{ uuid: "p1", status: "approved" }] }));
+    await waitFor(() => expect(mocks.tasks).toHaveBeenCalled());
+    expect(screen.getByRole("menuitem", { name: "Yolo" }).textContent).toContain(en.ideaTracker.panel.actions.loadingStage);
+    await act(async () => resolveTasks({ success: true, data: [{ uuid: "t1", title: "Done", status: "done" }] }));
+    await waitFor(() => expect(screen.getByRole("menuitem", { name: "Yolo" }).textContent).toContain(en.yolo.completedHint));
+  });
+
+  it("resets modal/edit state when the URL selects another idea, ignoring late old data", async () => {
+    const user = userEvent.setup(); const view = render(<Panel />); await open(user);
+    await user.click(screen.getByRole("menuitem", { name: "Delete Idea" }));
+    view.rerender(<Panel uuid="idea-2" />);
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    await open(user);
+    await user.click(screen.getByRole("menuitem", { name: "Delete Idea" }));
+    await user.click(within(screen.getByRole("alertdialog")).getByRole("button", { name: "Delete" }));
+    expect(mocks.delete).toHaveBeenCalledWith("idea-2", "project-1");
+  });
+});

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/new-idea-dialog.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/new-idea-dialog.tsx
@@ -49,6 +49,7 @@ import type { SessionView } from "@/services/daemon-session.service";
 interface NewIdeaDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onCloseAutoFocus?: (event: Event) => void;
   projectUuid: string;
   onCreated?: (uuid: string) => void;
   /** When set, the new idea is derived as a child of this idea (single-parent
@@ -67,6 +68,7 @@ type EntryMode = "form" | "conversation";
 export function NewIdeaDialog({
   open,
   onOpenChange,
+  onCloseAutoFocus,
   projectUuid,
   onCreated,
   parentUuid,
@@ -333,7 +335,7 @@ export function NewIdeaDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[480px]">
+      <DialogContent className="sm:max-w-[480px]" onCloseAutoFocus={onCloseAutoFocus}>
         <DialogHeader>
           <DialogTitle>{isDerive ? tLineage("deriveIdea") : t("newIdea.title")}</DialogTitle>
           {isDerive && parentTitle && (

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/idea-detail-verify.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/__tests__/idea-detail-verify.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 //
-// UI tests for the dashboard idea-tracker IdeaDetailPanel footer "Verify
-// Elaborate" button (task: Frontend Verify Elaborate button). Covers:
+// UI tests for the dashboard idea-tracker IdeaDetailPanel Actions menu's Verify
+// Elaborate action (task: Frontend Verify Elaborate button). Covers:
 //  - the button is gated by the shared canVerifyElaboration predicate,
 //  - clicking calls verifyElaborationAction and shows the queued hint on success,
 //  - the failure path surfaces an inline error.
-// Heavy tab/child views are stubbed so the test focuses on the footer contract.
+// Heavy tab/child views are stubbed so the test focuses on the verify contract.
 
 import React from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -179,6 +179,11 @@ function renderPanel() {
 }
 
 beforeEach(() => {
+  globalThis.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} } as unknown as typeof ResizeObserver;
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
   vi.clearAllMocks();
   getIdeaActionMock.mockResolvedValue(ideaResponse());
   getProposalsForIdeaActionMock.mockResolvedValue({ success: true, data: [] });
@@ -201,7 +206,7 @@ beforeEach(() => {
   );
 });
 
-describe("dashboard IdeaDetailPanel — Verify Elaborate footer button", () => {
+describe("dashboard IdeaDetailPanel — Verify Elaborate menu action", () => {
   it.each(["open", "elaborating", "elaborated"])(
     "keeps the assignee control interactive for %s Ideas",
     async (status) => {
@@ -213,34 +218,36 @@ describe("dashboard IdeaDetailPanel — Verify Elaborate footer button", () => {
     },
   );
 
-  it("renders an enabled Verify Elaborate button when every round is answered", async () => {
+  it("renders an enabled Verify Elaborate action when every round is answered", async () => {
+    const user = userEvent.setup();
     renderPanel();
-    const btn = (await screen.findByRole("button", { name: "Verify Elaborate" })) as HTMLButtonElement;
-    expect(btn.disabled).toBe(false);
+    await user.click(await screen.findByRole("button", { name: "Actions" }));
+    expect(screen.getByRole("menuitem", { name: "Verify Elaborate" }).getAttribute("aria-disabled")).toBe("false");
   });
 
-  it("does not render the button while a round is still pending", async () => {
+  it("disables the action while a round is still pending", async () => {
     getElaborationActionMock.mockResolvedValue(elaborationResponse("pending_answers"));
+    const user = userEvent.setup();
     renderPanel();
-    // The idea loads (the stubbed elaboration view proves the panel body
-    // rendered — reassign now lives inside that view, not the footer) but no
-    // verify button.
     await screen.findByTestId("elaboration-view");
-    expect(screen.queryByRole("button", { name: "Verify Elaborate" })).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Actions" }));
+    expect(screen.getByRole("menuitem", { name: "Verify Elaborate" }).getAttribute("aria-disabled")).toBe("true");
   });
 
-  it("does not render the button once elaboration is resolved", async () => {
+  it("disables the action once elaboration is resolved", async () => {
     getIdeaActionMock.mockResolvedValue(ideaResponse({ elaborationStatus: "resolved" }));
+    const user = userEvent.setup();
     renderPanel();
     await screen.findByTestId("elaboration-view");
-    expect(screen.queryByRole("button", { name: "Verify Elaborate" })).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Actions" }));
+    expect(screen.getByRole("menuitem", { name: "Verify Elaborate" }).getAttribute("aria-disabled")).toBe("true");
   });
 
   it("calls verifyElaborationAction on click and shows the queued hint on success", async () => {
     const user = userEvent.setup();
     renderPanel();
-    const btn = await screen.findByRole("button", { name: "Verify Elaborate" });
-    await user.click(btn);
+    await user.click(await screen.findByRole("button", { name: "Actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Verify Elaborate" }));
 
     await waitFor(() => {
       expect(verifyElaborationActionMock).toHaveBeenCalledWith(IDEA_UUID);
@@ -252,14 +259,16 @@ describe("dashboard IdeaDetailPanel — Verify Elaborate footer button", () => {
     expect(screen.queryByRole("button", { name: "Create Proposal" })).toBeNull();
   });
 
-  it("surfaces an inline error and keeps the button when verify fails", async () => {
+  it("surfaces an inline error and keeps the action when verify fails", async () => {
     verifyElaborationActionMock.mockResolvedValueOnce({ success: false, error: "boom" });
     const user = userEvent.setup();
     renderPanel();
-    const btn = await screen.findByRole("button", { name: "Verify Elaborate" });
-    await user.click(btn);
+    await user.click(await screen.findByRole("button", { name: "Actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Verify Elaborate" }));
 
     await waitFor(() => expect(verifyElaborationActionMock).toHaveBeenCalled());
     expect(await screen.findByText("boom")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Actions" }));
+    expect(screen.getByRole("menuitem", { name: "Verify Elaborate" }).getAttribute("aria-disabled")).toBe("false");
   });
 });

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-actions-menu.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-actions-menu.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useId, type ReactNode, type RefObject } from "react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+import { ArrowRightLeft, CheckCircle2, ChevronDown, Copy, GitFork, Link, Pencil, Play, Rocket, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { StartDevelopmentButton } from "@/components/start-development-button";
+import { YoloButton } from "@/components/yolo-button";
+import type { StartDevelopmentAssignee } from "@/lib/start-development";
+import { isImeComposing } from "@/lib/ime";
+
+/** aria-disabled rather than Radix disabled: unavailable operations remain in
+ * the roving focus order so keyboard users can discover the explanation. */
+function ActionItem({ label, icon, reason, onSelect, destructive = false }: {
+  label: string; icon: ReactNode; reason?: string; onSelect: () => void; destructive?: boolean;
+}) {
+  const id = useId();
+  const item = (
+    <DropdownMenuItem
+      aria-label={label}
+      aria-disabled={!!reason}
+      aria-describedby={reason ? id : undefined}
+      variant={destructive ? "destructive" : "default"}
+      className={reason ? "text-muted-foreground cursor-default" : undefined}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" && isImeComposing(event)) event.preventDefault();
+      }}
+      onSelect={(event) => {
+        if (reason) event.preventDefault();
+        else onSelect();
+      }}
+    >
+      {icon}<span>{label}</span>
+      {reason && <span id={id} className="sr-only">{reason}</span>}
+    </DropdownMenuItem>
+  );
+  return reason ? (
+    <Tooltip>
+      <TooltipTrigger asChild>{item}</TooltipTrigger>
+      <TooltipContent side="left" className="z-[120] max-w-64">{reason}</TooltipContent>
+    </Tooltip>
+  ) : item;
+}
+
+interface IdeaActionsMenuProps {
+  ideaUuid: string;
+  projectUuid: string;
+  assignee: StartDevelopmentAssignee | null | undefined;
+  assigneeName?: string;
+  proposals: { status: string }[];
+  tasks: { status: string }[];
+  triggerRef: RefObject<HTMLButtonElement | null>;
+  busy: boolean;
+  stageReason?: string;
+  stageDataReason?: string;
+  verifyReason?: string;
+  editReason?: string;
+  onVerify: () => void;
+  onDerive: () => void;
+  onMove: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  onStarted: () => void;
+  onCloseAutoFocus: (event: Event) => void;
+}
+
+export function IdeaActionsMenu(props: IdeaActionsMenuProps) {
+  const t = useTranslations();
+  const ta = useTranslations("ideaTracker.panel.actions");
+  const busyReason = props.busy ? ta("busy") : undefined;
+  const stageReason = busyReason || props.stageReason || props.stageDataReason;
+  const copy = async (link: boolean) => {
+    try {
+      const value = link
+        ? new URL(`/projects/${props.projectUuid}/dashboard?panel=${props.ideaUuid}`, window.location.origin).href
+        : props.ideaUuid;
+      await navigator.clipboard.writeText(value);
+      toast.success(ta(link ? "linkCopied" : "uuidCopied"));
+    } catch {
+      toast.error(ta("copyFailed"));
+    }
+  };
+  const shared = {
+    ideaUuid: props.ideaUuid, assignee: props.assignee, assigneeName: props.assigneeName,
+    proposals: props.proposals, tasks: props.tasks, onStarted: props.onStarted,
+    disabledReason: stageReason, onCloseAutoFocus: props.onCloseAutoFocus,
+  };
+
+  // These owners deliberately wrap the menu, NOT its content. Radix unmounts
+  // content on selection; confirmation/picker state must survive that unmount.
+  return (
+    <StartDevelopmentButton {...shared} renderAction={(start) => (
+      <YoloButton {...shared} disabledReason={stageReason || (start.busy ? ta("busy") : undefined)} renderAction={(yolo) => {
+        const mutationReason = busyReason || (start.busy || yolo.busy ? ta("busy") : undefined);
+        return (
+          <TooltipProvider delayDuration={300}>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button ref={props.triggerRef} variant="outline" size="sm" className="h-8 gap-1.5 border-border px-2.5">
+                  {t("common.actions")}<ChevronDown className="h-3.5 w-3.5" aria-hidden />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="z-[100] w-64 max-w-[calc(100vw-1rem)] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto">
+                <ActionItem label={t("elaboration.verifyButton")} icon={<CheckCircle2 />} reason={mutationReason || props.stageReason || props.verifyReason} onSelect={props.onVerify} />
+                <ActionItem label={start.label} icon={<Play />} reason={mutationReason || start.disabledReason} onSelect={start.onSelect} />
+                <ActionItem label={yolo.label} icon={<Rocket />} reason={mutationReason || yolo.disabledReason} onSelect={yolo.onSelect} />
+                <DropdownMenuSeparator />
+                <ActionItem label={t("ideaTracker.lineage.deriveIdea")} icon={<GitFork />} reason={mutationReason} onSelect={props.onDerive} />
+                <ActionItem label={t("ideas.actions.move")} icon={<ArrowRightLeft />} reason={mutationReason} onSelect={props.onMove} />
+                <ActionItem label={t("ideas.editIdea")} icon={<Pencil />} reason={mutationReason || props.editReason} onSelect={props.onEdit} />
+                <DropdownMenuSeparator />
+                <ActionItem label={ta("copyLink")} icon={<Link />} onSelect={() => { void copy(true); }} />
+                <ActionItem label={ta("copyUuid")} icon={<Copy />} onSelect={() => { void copy(false); }} />
+                <DropdownMenuSeparator />
+                <ActionItem label={t("ideas.deleteIdea")} icon={<Trash2 />} reason={mutationReason} onSelect={props.onDelete} destructive />
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </TooltipProvider>
+        );
+      }} />
+    )} />
+  );
+}

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-actions-menu.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-actions-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId, type ReactNode, type RefObject } from "react";
+import { useId, useState, type ReactNode, type RefObject } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { ArrowRightLeft, CheckCircle2, ChevronDown, Copy, GitFork, Link, Pencil, Play, Rocket, Trash2 } from "lucide-react";
@@ -14,8 +14,9 @@ import { isImeComposing } from "@/lib/ime";
 
 /** aria-disabled rather than Radix disabled: unavailable operations remain in
  * the roving focus order so keyboard users can discover the explanation. */
-function ActionItem({ label, icon, reason, onSelect, destructive = false }: {
-  label: string; icon: ReactNode; reason?: string; onSelect: () => void; destructive?: boolean;
+function ActionItem({ label, icon, reason, onSelect, onTooltipEscape, destructive = false }: {
+  label: string; icon: ReactNode; reason?: string; onSelect: () => void;
+  onTooltipEscape: () => void; destructive?: boolean;
 }) {
   const id = useId();
   const item = (
@@ -40,7 +41,13 @@ function ActionItem({ label, icon, reason, onSelect, destructive = false }: {
   return reason ? (
     <Tooltip>
       <TooltipTrigger asChild>{item}</TooltipTrigger>
-      <TooltipContent side="left" className="z-[120] max-w-64">{reason}</TooltipContent>
+      <TooltipContent
+        side="left"
+        className="z-[120] max-w-64"
+        onEscapeKeyDown={onTooltipEscape}
+      >
+        {reason}
+      </TooltipContent>
     </Tooltip>
   ) : item;
 }
@@ -70,6 +77,7 @@ interface IdeaActionsMenuProps {
 export function IdeaActionsMenu(props: IdeaActionsMenuProps) {
   const t = useTranslations();
   const ta = useTranslations("ideaTracker.panel.actions");
+  const [menuOpen, setMenuOpen] = useState(false);
   const busyReason = props.busy ? ta("busy") : undefined;
   const stageReason = busyReason || props.stageReason || props.stageDataReason;
   const copy = async (link: boolean) => {
@@ -97,25 +105,25 @@ export function IdeaActionsMenu(props: IdeaActionsMenuProps) {
         const mutationReason = busyReason || (start.busy || yolo.busy ? ta("busy") : undefined);
         return (
           <TooltipProvider delayDuration={300}>
-            <DropdownMenu>
+            <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
               <DropdownMenuTrigger asChild>
                 <Button ref={props.triggerRef} variant="outline" size="sm" className="h-8 gap-1.5 border-border px-2.5">
                   {t("common.actions")}<ChevronDown className="h-3.5 w-3.5" aria-hidden />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="z-[100] w-64 max-w-[calc(100vw-1rem)] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto">
-                <ActionItem label={t("elaboration.verifyButton")} icon={<CheckCircle2 />} reason={mutationReason || props.stageReason || props.verifyReason} onSelect={props.onVerify} />
-                <ActionItem label={start.label} icon={<Play />} reason={mutationReason || start.disabledReason} onSelect={start.onSelect} />
-                <ActionItem label={yolo.label} icon={<Rocket />} reason={mutationReason || yolo.disabledReason} onSelect={yolo.onSelect} />
+                <ActionItem label={t("elaboration.verifyButton")} icon={<CheckCircle2 />} reason={mutationReason || props.stageReason || props.verifyReason} onSelect={props.onVerify} onTooltipEscape={() => setMenuOpen(false)} />
+                <ActionItem label={start.label} icon={<Play />} reason={mutationReason || start.disabledReason} onSelect={start.onSelect} onTooltipEscape={() => setMenuOpen(false)} />
+                <ActionItem label={yolo.label} icon={<Rocket />} reason={mutationReason || yolo.disabledReason} onSelect={yolo.onSelect} onTooltipEscape={() => setMenuOpen(false)} />
                 <DropdownMenuSeparator />
-                <ActionItem label={t("ideaTracker.lineage.deriveIdea")} icon={<GitFork />} reason={mutationReason} onSelect={props.onDerive} />
-                <ActionItem label={t("ideas.actions.move")} icon={<ArrowRightLeft />} reason={mutationReason} onSelect={props.onMove} />
-                <ActionItem label={t("ideas.editIdea")} icon={<Pencil />} reason={mutationReason || props.editReason} onSelect={props.onEdit} />
+                <ActionItem label={t("ideaTracker.lineage.deriveIdea")} icon={<GitFork />} reason={mutationReason} onSelect={props.onDerive} onTooltipEscape={() => setMenuOpen(false)} />
+                <ActionItem label={t("ideas.actions.move")} icon={<ArrowRightLeft />} reason={mutationReason} onSelect={props.onMove} onTooltipEscape={() => setMenuOpen(false)} />
+                <ActionItem label={t("ideas.editIdea")} icon={<Pencil />} reason={mutationReason || props.editReason} onSelect={props.onEdit} onTooltipEscape={() => setMenuOpen(false)} />
                 <DropdownMenuSeparator />
-                <ActionItem label={ta("copyLink")} icon={<Link />} onSelect={() => { void copy(true); }} />
-                <ActionItem label={ta("copyUuid")} icon={<Copy />} onSelect={() => { void copy(false); }} />
+                <ActionItem label={ta("copyLink")} icon={<Link />} onSelect={() => { void copy(true); }} onTooltipEscape={() => setMenuOpen(false)} />
+                <ActionItem label={ta("copyUuid")} icon={<Copy />} onSelect={() => { void copy(false); }} onTooltipEscape={() => setMenuOpen(false)} />
                 <DropdownMenuSeparator />
-                <ActionItem label={t("ideas.deleteIdea")} icon={<Trash2 />} reason={mutationReason} onSelect={props.onDelete} destructive />
+                <ActionItem label={t("ideas.deleteIdea")} icon={<Trash2 />} reason={mutationReason} onSelect={props.onDelete} onTooltipEscape={() => setMenuOpen(false)} destructive />
               </DropdownMenuContent>
             </DropdownMenu>
           </TooltipProvider>

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
@@ -1085,6 +1085,7 @@ function IdeaDetailPanelContent({
       <MoveIdeaDialog
         open={showMoveDialog}
         onOpenChange={setShowMoveDialog}
+        onCloseAutoFocus={returnFocusToActions}
         ideaUuid={ideaUuid}
         projectUuid={projectUuid}
         onMoved={() => onClose()}
@@ -1109,6 +1110,7 @@ function IdeaDetailPanelContent({
         <NewIdeaDialog
           open={showDeriveDialog}
           onOpenChange={setShowDeriveDialog}
+          onCloseAutoFocus={returnFocusToActions}
           projectUuid={projectUuid}
           parentUuid={idea.uuid}
           parentTitle={idea.title}

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "@/hooks/use-progress-router";
 import { toast } from "sonner";
-import { X, Loader2, Trash2, ArrowRightLeft, Pencil, GitFork, CornerLeftUp, CornerDownRight, CheckCircle2, Link as LinkIcon } from "lucide-react";
+import { X, Loader2, Pencil, GitFork, CornerLeftUp, CornerDownRight, Link as LinkIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
@@ -21,7 +21,6 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { useRealtimeEntityTypeEvent } from "@/contexts/realtime-context";
 import { ElaborationView } from "./elaboration-view";
@@ -42,8 +41,7 @@ import { AssignIdeaModal } from "@/app/(dashboard)/projects/[uuid]/ideas/assign-
 import type { IdeaResponse } from "@/services/idea.service";
 import type { ElaborationResponse } from "@/types/elaboration";
 import { canVerifyElaboration } from "@/lib/elaboration-verify";
-import { StartDevelopmentButton } from "@/components/start-development-button";
-import { YoloButton } from "@/components/yolo-button";
+import { IdeaActionsMenu } from "./idea-actions-menu";
 import { ReferencesSection } from "@/components/references-section";
 import { ActiveSessionIndicator } from "@/components/active-session-indicator";
 import { useAgentPresenceOptional } from "@/contexts/agent-presence-context";
@@ -160,7 +158,12 @@ interface IdeaDetailPanelProps {
   onNavigate?: (ideaUuid: string) => void;
 }
 
-export function IdeaDetailPanel({
+export function IdeaDetailPanel(props: IdeaDetailPanelProps) {
+  // A new URL-selected idea must not inherit another idea's gates or dialogs.
+  return <IdeaDetailPanelContent key={props.ideaUuid} {...props} />;
+}
+
+function IdeaDetailPanelContent({
   ideaUuid,
   projectUuid,
   currentUserUuid,
@@ -184,6 +187,10 @@ export function IdeaDetailPanel({
   // Top-level data: proposals and tasks
   const [proposals, setProposals] = useState<ProposalData[]>([]);
   const [tasks, setTasks] = useState<FlatTask[]>([]);
+  const [loadedProposalSource, setLoadedProposalSource] = useState<string | null>(null);
+  const [loadedTaskSource, setLoadedTaskSource] = useState<ProposalData[] | null>(null);
+  const proposalRequestRef = useRef(0);
+  const taskRequestRef = useRef(0);
 
   // Tab state
   const [activeTab, setActiveTab] = useState<TabId>("overview");
@@ -193,12 +200,18 @@ export function IdeaDetailPanel({
   // Comment count for activity badge
   const [commentCount, setCommentCount] = useState(0);
 
-  // Footer/modal state
+  // Modal owners live outside the Actions menu's unmounting content.
   const [showAssignModal, setShowAssignModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const actionsTriggerRef = useRef<HTMLButtonElement>(null);
+  const returnFocusToActions = useCallback((event: Event) => {
+    event.preventDefault();
+    actionsTriggerRef.current?.focus();
+  }, []);
 
   // Elaboration data — loaded once here and shared between the elaboration tab
-  // view and the footer's "Verify Elaborate" gate (no separate fetch each).
+  // view and the Actions menu's "Verify Elaborate" gate (no separate fetch each).
   const [elaboration, setElaboration] = useState<ElaborationResponse | null>(null);
   const [isLoadingElaboration, setIsLoadingElaboration] = useState(true);
 
@@ -306,20 +319,26 @@ export function IdeaDetailPanel({
   // ===== Lift data fetching: Proposals =====
   const ideaUuidForFetch = idea?.uuid;
   const ideaStatusForFetch = idea?.status;
+  const proposalSource = `${ideaUuidForFetch}:${ideaStatusForFetch}`;
   const fetchProposals = useCallback(async () => {
-    if (!ideaUuidForFetch || ideaStatusForFetch === "open") {
+    const request = ++proposalRequestRef.current;
+    setLoadedProposalSource(null);
+    if (!ideaUuidForFetch) return;
+    if (ideaStatusForFetch === "open") {
       setProposals([]);
+      setLoadedProposalSource(proposalSource);
       return;
     }
     try {
       const result = await getProposalsForIdeaAction(projectUuid, ideaUuidForFetch);
-      if (result.success) {
+      if (request === proposalRequestRef.current && result.success) {
         setProposals(result.data);
+        setLoadedProposalSource(proposalSource);
       }
     } catch (e) {
       clientLogger.error("Failed to fetch proposals:", e);
     }
-  }, [projectUuid, ideaUuidForFetch, ideaStatusForFetch]);
+  }, [projectUuid, ideaUuidForFetch, ideaStatusForFetch, proposalSource]);
 
   useEffect(() => {
     fetchProposals();
@@ -329,15 +348,19 @@ export function IdeaDetailPanel({
 
   // ===== Lift data fetching: Tasks (from approved proposals) =====
   const fetchTasks = useCallback(async () => {
+    const request = ++taskRequestRef.current;
+    setLoadedTaskSource(null);
     const approvedProposals = proposals.filter((p) => p.status === "approved");
     if (approvedProposals.length === 0) {
       setTasks([]);
+      setLoadedTaskSource(proposals);
       return;
     }
     try {
       const results = await Promise.all(
         approvedProposals.map((p) => getTasksForProposalAction(projectUuid, p.uuid))
       );
+      if (request !== taskRequestRef.current || results.some((result) => !result.success)) return;
       const allTasks: FlatTask[] = results.flatMap((result) =>
         result.success && result.data
           ? result.data.map((t) => {
@@ -361,6 +384,7 @@ export function IdeaDetailPanel({
           : []
       );
       setTasks(allTasks);
+      setLoadedTaskSource(proposals);
     } catch (e) {
       clientLogger.error("Failed to fetch tasks:", e);
     }
@@ -487,7 +511,7 @@ export function IdeaDetailPanel({
   }, [idea?.uuid, idea?.title, idea?.content]);
 
   const handleStartEdit = () => {
-    if (!idea) return;
+    if (!idea || idea.status === "elaborated") return;
     setEditTitle(idea.title);
     setEditContent(idea.content || "");
     setEditError(null);
@@ -539,7 +563,7 @@ export function IdeaDetailPanel({
   };
 
   const handleDelete = async () => {
-    if (!idea) return;
+    if (!idea || isDeleting) return;
     setIsDeleting(true);
     const result = await deleteIdeaAction(idea.uuid, projectUuid);
     setIsDeleting(false);
@@ -572,7 +596,7 @@ export function IdeaDetailPanel({
   };
 
   const handleVerify = () => {
-    if (!idea) return;
+    if (!idea || idea.isContainer || !canVerify || verified || isLoadingElaboration || isVerifying || isResolvingVerify || isTogglingContainer) return;
     // Route through pin-then-wake: `pick` opens the cwd picker before waking.
     startVerifyPinThenWake({ ideaUuid: idea.uuid, wake: runVerifyWake });
   };
@@ -702,48 +726,37 @@ export function IdeaDetailPanel({
             )}
           </div>
 
-          <div className="flex items-center gap-2 ml-4">
-            {idea && !isEditing && (
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-8 gap-1.5 border-border px-2.5"
-                onClick={() => setShowDeriveDialog(true)}
-                title={tLineage("deriveIdea")}
-                aria-label={tLineage("deriveIdea")}
-              >
-                <GitFork className="h-3.5 w-3.5 text-primary" />
-                <span className="text-[12px] font-medium text-primary">{tLineage("derive")}</span>
-              </Button>
-            )}
-            {idea && !isEditing && (
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-8 w-8 border-border"
-                onClick={() => setShowMoveDialog(true)}
-                title={t("ideas.actions.move")}
-                aria-label={t("ideas.actions.move")}
-              >
-                <ArrowRightLeft className="h-4 w-4 text-muted-foreground" />
-              </Button>
-            )}
-            {idea && idea.status !== "elaborated" && !isEditing && (
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-8 w-8 border-border"
-                onClick={handleStartEdit}
-                title={t("ideas.editIdea")}
-              >
-                <Pencil className="h-4 w-4 text-muted-foreground" />
-              </Button>
+          <div className="flex shrink-0 items-center gap-2 ml-3">
+            {idea && !isLoading && !isEditing && (
+              <IdeaActionsMenu
+                key={idea.uuid}
+                ideaUuid={idea.uuid}
+                projectUuid={projectUuid}
+                assignee={idea.assignee}
+                assigneeName={idea.assignee?.name}
+                proposals={proposals}
+                tasks={tasks}
+                triggerRef={actionsTriggerRef}
+                busy={isDeleting || isVerifying || isResolvingVerify || isSaving || isTogglingContainer || verifyPickerState !== null}
+                stageReason={isContainer ? tLineage("containerHint") : undefined}
+                stageDataReason={loadedProposalSource !== proposalSource || loadedTaskSource !== proposals ? tTracker("panel.actions.loadingStage") : undefined}
+                verifyReason={isLoadingElaboration ? tTracker("loading") : verified ? t("elaboration.verifiedQueuedHint") : !canVerify ? tTracker("panel.actions.verifyUnavailable") : undefined}
+                editReason={idea.status === "elaborated" ? tTracker("panel.actions.editUnavailable") : undefined}
+                onVerify={handleVerify}
+                onDerive={() => setShowDeriveDialog(true)}
+                onMove={() => setShowMoveDialog(true)}
+                onEdit={handleStartEdit}
+                onDelete={() => setShowDeleteDialog(true)}
+                onStarted={fetchIdea}
+                onCloseAutoFocus={returnFocusToActions}
+              />
             )}
             <Button
               variant="outline"
               size="icon"
               className="h-8 w-8 border-border"
               onClick={isEditing ? handleCancelEdit : onClose}
+              aria-label={t("common.close")}
             >
               <X className="h-4 w-4 text-muted-foreground" />
             </Button>
@@ -829,10 +842,22 @@ export function IdeaDetailPanel({
                       className="border-border text-sm resize-none focus-visible:ring-primary"
                     />
                   </div>
+                  <div className="flex items-center justify-end gap-3">
+                    <Button variant="outline" onClick={handleCancelEdit} disabled={isSaving}>
+                      {t("common.cancel")}
+                    </Button>
+                    <Button onClick={handleSaveEdit} disabled={isSaving || !editTitle.trim()}>
+                      {isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                      {t("common.save")}
+                    </Button>
+                  </div>
                 </div>
               ) : (
                 /* Tab Content with visitedTabs caching */
                 <>
+                  {verified && <p role="status" className="mb-4 text-xs text-muted-foreground">{t("elaboration.verifiedQueuedHint")}</p>}
+                  {verifyError && <p role="alert" className="mb-4 text-xs text-destructive">{verifyError}</p>}
+                  {isContainer && <p className="mb-4 text-xs text-muted-foreground">{tLineage("containerHint")}</p>}
                   {/* Overview Tab */}
                   {visitedTabs.has("overview") && (
                     <div style={{ display: activeTab === "overview" ? "block" : "none" }}>
@@ -1035,155 +1060,24 @@ export function IdeaDetailPanel({
           </div>
         </ScrollArea>
 
-        {/* Footer */}
-        {idea && !isLoading && (
-          <div className="border-t border-secondary px-6 py-4">
-            {isEditing ? (
-              <div className="flex items-center justify-end gap-3">
-                <Button
-                  variant="outline"
-                  className="border-border"
-                  onClick={handleCancelEdit}
-                  disabled={isSaving}
-                >
-                  {t("common.cancel")}
-                </Button>
-                <Button
-                  className="bg-primary hover:bg-[#B56A42] text-white"
-                  onClick={handleSaveEdit}
-                  disabled={isSaving || !editTitle.trim()}
-                >
-                  {isSaving ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      {t("common.save")}
-                    </>
-                  ) : (
-                    t("common.save")
-                  )}
-                </Button>
-              </div>
-            ) : (
-              <div className="flex items-center justify-between gap-3">
-                {/* Reassign moved onto the assignee block in the elaboration tab
-                    (see ElaborationView onReassign/canReassign) — the footer no
-                    longer carries a standalone reassign button, which frees room
-                    for Yolo to render as a full icon+label CTA. */}
-                <div className="flex-1 min-w-0 flex flex-wrap items-center gap-2">
-                  {/* Proposal-progression CTAs are hidden on a container idea:
-                      a container may elaborate + derive children but MUST NOT
-                      create a proposal, so Verify Elaborate / Start Development
-                      / Yolo are suppressed. "Derive child idea" (header GitFork
-                      button) is the primary progression path instead. */}
-                  {!isContainer && (
-                    <>
-                      {/* Verify Elaborate — human "elaboration confirmed, agent
-                          writes the proposal" action, gated by the shared
-                          predicate. No manual create-proposal fallback here. */}
-                      {canVerify && !verified && (
-                        <Button
-                          className="bg-primary hover:bg-[#B56A42] text-white"
-                          onClick={handleVerify}
-                          disabled={isVerifying || isResolvingVerify}
-                        >
-                          {isVerifying ? (
-                            <>
-                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                              {t("elaboration.verifying")}
-                            </>
-                          ) : (
-                            <>
-                              <CheckCircle2 className="mr-2 h-4 w-4" />
-                              {t("elaboration.verifyButton")}
-                            </>
-                          )}
-                        </Button>
-                      )}
-                      {verified && (
-                        <span className="text-[11px] text-[#00796B] dark:text-[#4FD1C0]">
-                          {t("elaboration.verifiedQueuedHint")}
-                        </span>
-                      )}
-                      {verifyError && (
-                        <span className="text-[11px] text-destructive">{verifyError}</span>
-                      )}
-                      {/* Start Development — human "the plan is approved, go build
-                          it" action (add-stage-advance-start-development). Same
-                          shared-predicate contract as Verify Elaborate; presence
-                          gating + per-error-code toasts live in the component. */}
-                      <StartDevelopmentButton
-                        ideaUuid={idea.uuid}
-                        assignee={idea.assignee}
-                        assigneeName={idea.assignee?.name}
-                        proposals={proposals}
-                        tasks={tasks}
-                        onStarted={() => {
-                          fetchIdea();
-                        }}
-                      />
-                      {/* Yolo — human "drive this whole idea to done via the yolo
-                          skill" action (add-stage-advance-yolo). Shows at any
-                          incomplete stage (relaxed predicate), so it can coexist
-                          with Start Development on a building-stage idea. */}
-                      <YoloButton
-                        ideaUuid={idea.uuid}
-                        assignee={idea.assignee}
-                        assigneeName={idea.assignee?.name}
-                        proposals={proposals}
-                        tasks={tasks}
-                        onStarted={() => {
-                          fetchIdea();
-                        }}
-                      />
-                    </>
-                  )}
-                  {/* Container hint — replaces the proposal CTAs so the footer
-                      is never empty and the "derive instead" affordance reads. */}
-                  {isContainer && (
-                    <span className="text-[11px] text-muted-foreground">
-                      {tLineage("containerHint")}
-                    </span>
-                  )}
-                </div>
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      className="shrink-0 h-8 w-8 border-border text-[#EF4444] dark:text-[#F0897E] hover:bg-[#FFEBEE] dark:hover:bg-[#331619] hover:text-[#EF4444] hover:border-[#EF4444]"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>{t("ideas.deleteIdea")}</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        {t("ideas.deleteIdeaConfirm", { title: idea.title })}
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
-                      <AlertDialogAction
-                        variant="destructive"
-                        onClick={handleDelete}
-                        disabled={isDeleting}
-                      >
-                        {isDeleting ? (
-                          <>
-                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            {t("common.delete")}
-                          </>
-                        ) : (
-                          t("common.delete")
-                        )}
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              </div>
-            )}
-          </div>
+        {/* Confirmation is owned by the panel, never the menu content. */}
+        {idea && (
+          <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+            <AlertDialogContent onCloseAutoFocus={returnFocusToActions}>
+              <AlertDialogHeader>
+                <AlertDialogTitle>{t("ideas.deleteIdea")}</AlertDialogTitle>
+                <AlertDialogDescription>
+                  {t("ideas.deleteIdeaConfirm", { title: idea.title })}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+                <AlertDialogAction variant="destructive" onClick={handleDelete} disabled={isDeleting}>
+                  {t("common.delete")}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         )}
       </div>
 
@@ -1244,6 +1138,7 @@ export function IdeaDetailPanel({
       {/* Verify Elaborate cwd picker — pin-then-wake `pick` outcome. */}
       <WakeCwdPickerDialog
         open={verifyPickerState !== null}
+        onCloseAutoFocus={returnFocusToActions}
         agentName={idea?.assignee?.name ?? ""}
         instances={verifyPickerState?.instances ?? []}
         onConfirm={confirmVerifyPick}

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/move-idea-dialog.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/move-idea-dialog.tsx
@@ -51,6 +51,7 @@ interface MoveCounts {
 interface MoveIdeaDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onCloseAutoFocus?: (event: Event) => void;
   ideaUuid: string;
   /** Current project — excluded from the target list. */
   projectUuid: string;
@@ -62,6 +63,7 @@ interface MoveIdeaDialogProps {
 export function MoveIdeaDialog({
   open,
   onOpenChange,
+  onCloseAutoFocus,
   ideaUuid,
   projectUuid,
   onMoved,
@@ -238,7 +240,7 @@ export function MoveIdeaDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent onCloseAutoFocus={onCloseAutoFocus}>
         <DialogHeader>
           <DialogTitle>{t("moveDialog.title")}</DialogTitle>
           <DialogDescription>{t("moveDialog.description")}</DialogDescription>

--- a/src/components/agent-presence/wake-cwd-picker-dialog.tsx
+++ b/src/components/agent-presence/wake-cwd-picker-dialog.tsx
@@ -57,6 +57,7 @@ export interface WakeCwdPickerDialogProps {
   }) => void;
   /** Fires when the human dismisses the dialog (Cancel / overlay / Esc). */
   onCancel: () => void;
+  onCloseAutoFocus?: (event: Event) => void;
 }
 
 /**
@@ -72,6 +73,7 @@ export function WakeCwdPickerDialog({
   agentUuid,
   onTemporaryConfirm,
   onCancel,
+  onCloseAutoFocus,
 }: WakeCwdPickerDialogProps) {
   const t = useTranslations("wakeCwdPicker");
   const [selected, setSelected] = useState<InstanceCandidate | null>(null);
@@ -113,6 +115,7 @@ export function WakeCwdPickerDialog({
           the only scroll region so the footer stays reachable under the mobile
           soft keyboard. Identical contract to MentionInstancePickerDialog. */}
       <DialogContent
+        onCloseAutoFocus={onCloseAutoFocus}
         className="z-[110] flex max-h-[85svh] flex-col gap-0 sm:max-w-md"
         overlayClassName="z-[110]"
       >

--- a/src/components/stage-action.ts
+++ b/src/components/stage-action.ts
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+/** Optional presentation adapter. The owner (and its dialogs) stays mounted
+ * outside the rendered trigger's lifecycle, including portalled menus. */
+export interface StageAction {
+  label: string;
+  disabledReason?: string;
+  busy: boolean;
+  onSelect: () => void;
+}
+
+export interface StageActionPresentation {
+  renderAction?: (action: StageAction) => ReactNode;
+  disabledReason?: string;
+  onCloseAutoFocus?: (event: Event) => void;
+}

--- a/src/components/start-development-button.tsx
+++ b/src/components/start-development-button.tsx
@@ -33,7 +33,9 @@ import { reassignIdeaInstanceNoWakeAction } from "@/app/(dashboard)/projects/[uu
 import { usePinThenWake } from "@/hooks/use-pin-then-wake";
 import { WakeCwdPickerDialog } from "@/components/agent-presence/wake-cwd-picker-dialog";
 
-interface StartDevelopmentButtonProps {
+import type { StageActionPresentation } from "@/components/stage-action";
+
+interface StartDevelopmentButtonProps extends StageActionPresentation {
   ideaUuid: string;
   assignee: StartDevelopmentAssignee | null | undefined;
   // Assignee agent display name — shown in the cwd picker subtitle when the
@@ -68,6 +70,9 @@ export function StartDevelopmentButton({
   proposals,
   tasks,
   onStarted,
+  renderAction,
+  disabledReason,
+  onCloseAutoFocus,
 }: StartDevelopmentButtonProps) {
   const t = useTranslations("startDevelopment");
   // Optional: a missing provider (isolated render) reads as no presence data →
@@ -125,7 +130,7 @@ export function StartDevelopmentButton({
   // The button renders only while the stage preconditions hold (approved
   // proposal + unfinished tasks + agent assignee); an offline agent keeps it
   // visible-but-disabled with a hint, matching the optimistic-display contract.
-  if (!preconditionsMet || started) {
+  if (!renderAction && (!preconditionsMet || started)) {
     return started ? (
       <span className="text-[11px] text-[#00796B] dark:text-[#4FD1C0]">{t("startedHint")}</span>
     ) : null;
@@ -153,7 +158,15 @@ export function StartDevelopmentButton({
     }
   };
 
+  const reason = disabledReason || (isStarting || isResolving ? t("starting")
+    : started ? t("startedHint")
+    : !owningAgentUuid ? t("errorAssigneeNotAgent")
+    : !proposals?.some((p) => p.status === "approved") ? t("errorNoApprovedProposal")
+    : !preconditionsMet ? t("errorNoUnfinishedTasks")
+    : !enabled ? t("offlineHint") : undefined);
+
   const handleClick = () => {
+    if (reason) return;
     // Route through the pin-then-wake flow: it fetches the preview and either
     // wakes immediately (direct/auto_pin) or opens the picker (pick), then calls
     // runWake once the cwd is resolved.
@@ -184,7 +197,7 @@ export function StartDevelopmentButton({
   // events, so the offline explanation rides a tooltip whose trigger is a
   // focusable wrapper span (tabIndex=0) around the button — reachable by both
   // hover and keyboard focus. Online: render the button as-is, no wrapper.
-  if (!agentOnline) {
+  if (!renderAction && !agentOnline) {
     return (
       <TooltipProvider delayDuration={300}>
         <Tooltip>
@@ -201,12 +214,17 @@ export function StartDevelopmentButton({
 
   return (
     <>
-      {button}
+      {renderAction ? renderAction({
+        label: t("button"), disabledReason: reason,
+        busy: isStarting || isResolving || pickerState !== null,
+        onSelect: handleClick,
+      }) : button}
       {/* Pin-then-wake cwd picker — mounted only on the online path (the offline
           path keeps the button disabled, so it never opens). Driven by the hook;
           on confirm it persists the pin then fires runWake. */}
       <WakeCwdPickerDialog
         open={pickerState !== null}
+        onCloseAutoFocus={onCloseAutoFocus}
         agentName={assigneeName ?? ""}
         instances={pickerState?.instances ?? []}
         agentUuid={pickerState?.agentUuid}

--- a/src/components/start-development-button.tsx
+++ b/src/components/start-development-button.tsx
@@ -83,9 +83,8 @@ export function StartDevelopmentButton({
   // Pin-then-wake: before firing the wake, consult the wake-target preview and
   // (pick) prompt for a cwd / (auto_pin) persist the sole cwd / (direct) wake
   // as-is. The picker dialog is mounted below, driven by pickerState.
-  // `isResolving` is true while the preview fetch is in flight — the button is
-  // disabled through it so a second click can't kick off a duplicate
-  // preview→wake before the first resolves.
+  // `isResolving` covers preview, picker, pin and wake so the button and any
+  // competing menu actions stay disabled until the entire flow settles.
   const {
     start: startPinThenWake,
     pickerState,
@@ -144,17 +143,21 @@ export function StartDevelopmentButton({
     validationRequestUuid: string;
   }) => {
     setIsStarting(true);
-    const result = temporary
-      ? await startDevelopmentAction(ideaUuid, temporary)
-      : await startDevelopmentAction(ideaUuid);
-    setIsStarting(false);
-
-    if (result.success) {
-      setStarted(true);
-      toast.success(t("startedHint"));
-      onStarted?.();
-    } else {
-      toast.error(t(ERROR_CODE_I18N_KEY[result.errorCode ?? "unknown"]));
+    try {
+      const result = temporary
+        ? await startDevelopmentAction(ideaUuid, temporary)
+        : await startDevelopmentAction(ideaUuid);
+      if (result.success) {
+        setStarted(true);
+        toast.success(t("startedHint"));
+        onStarted?.();
+      } else {
+        toast.error(t(ERROR_CODE_I18N_KEY[result.errorCode ?? "unknown"]));
+      }
+    } catch {
+      toast.error(t("errorGeneric"));
+    } finally {
+      setIsStarting(false);
     }
   };
 

--- a/src/components/yolo-button.tsx
+++ b/src/components/yolo-button.tsx
@@ -101,8 +101,8 @@ export function YoloButton({
   // Pin-then-wake: after the human confirms the Yolo run, consult the wake-target
   // preview and (pick) prompt for a cwd / (auto_pin) persist the sole cwd /
   // (direct) wake as-is. The picker dialog is mounted below, driven by pickerState.
-  // `isResolving` is true while the preview fetch is in flight — the confirm CTA
-  // is disabled through it so a double-tap can't fire two preview→wake runs.
+  // `isResolving` covers preview, picker, pin and wake so the trigger and any
+  // competing menu actions stay disabled until the entire flow settles.
   const {
     start: startPinThenWake,
     pickerState,
@@ -157,17 +157,21 @@ export function YoloButton({
     validationRequestUuid: string;
   }) => {
     setIsStarting(true);
-    const result = temporary
-      ? await yoloRequestedAction(ideaUuid, temporary)
-      : await yoloRequestedAction(ideaUuid);
-    setIsStarting(false);
-
-    if (result.success) {
-      setStarted(true);
-      toast.success(t("startedHint"));
-      onStarted?.();
-    } else {
-      toast.error(t(ERROR_CODE_I18N_KEY[result.errorCode ?? "unknown"]));
+    try {
+      const result = temporary
+        ? await yoloRequestedAction(ideaUuid, temporary)
+        : await yoloRequestedAction(ideaUuid);
+      if (result.success) {
+        setStarted(true);
+        toast.success(t("startedHint"));
+        onStarted?.();
+      } else {
+        toast.error(t(ERROR_CODE_I18N_KEY[result.errorCode ?? "unknown"]));
+      }
+    } catch {
+      toast.error(t("errorGeneric"));
+    } finally {
+      setIsStarting(false);
     }
   };
 
@@ -229,7 +233,7 @@ export function YoloButton({
         {!renderAction && <AlertDialogTrigger asChild>
           <Button
             className={YOLO_BUTTON_CLASS}
-            disabled={!enabled}
+            disabled={!enabled || isStarting || isResolving}
           >
             <Rocket className="mr-2 h-4 w-4" />
             {t("button")}

--- a/src/components/yolo-button.tsx
+++ b/src/components/yolo-button.tsx
@@ -47,7 +47,9 @@ import { reassignIdeaInstanceNoWakeAction } from "@/app/(dashboard)/projects/[uu
 import { usePinThenWake } from "@/hooks/use-pin-then-wake";
 import { WakeCwdPickerDialog } from "@/components/agent-presence/wake-cwd-picker-dialog";
 
-interface YoloButtonProps {
+import type { StageActionPresentation } from "@/components/stage-action";
+
+interface YoloButtonProps extends StageActionPresentation {
   ideaUuid: string;
   assignee: YoloAssignee | null | undefined;
   // Assignee agent display name — shown in the cwd picker subtitle when the
@@ -85,6 +87,9 @@ export function YoloButton({
   proposals,
   tasks,
   onStarted,
+  renderAction,
+  disabledReason,
+  onCloseAutoFocus,
 }: YoloButtonProps) {
   const t = useTranslations("yolo");
   // Optional: a missing provider (isolated render) reads as no presence data →
@@ -138,7 +143,7 @@ export function YoloButton({
   // The button renders only while the stage preconditions hold (agent assignee +
   // not-done idea); an offline agent keeps it visible-but-disabled with a hint,
   // matching the optimistic-display contract.
-  if (!preconditionsMet || started) {
+  if (!renderAction && (!preconditionsMet || started)) {
     return started ? (
       <span className="text-[11px] text-[#00796B] dark:text-[#4FD1C0]">{t("startedHint")}</span>
     ) : null;
@@ -166,7 +171,14 @@ export function YoloButton({
     }
   };
 
+  const reason = disabledReason || (isStarting || isResolving ? t("starting")
+    : started ? t("startedHint")
+    : !owningAgentUuid ? t("errorAssigneeNotAgent")
+    : !preconditionsMet ? t("completedHint")
+    : !enabled ? t("offlineHint") : undefined);
+
   const handleConfirm = () => {
+    if (reason) return;
     // The human has committed to the Yolo run (this IS the confirm step). Close
     // the confirm dialog, then route through pin-then-wake: it wakes immediately
     // (direct/auto_pin) or opens the cwd picker (pick) before firing runWake.
@@ -182,7 +194,7 @@ export function YoloButton({
   // AlertDialogTrigger would make two Radix primitives fight over one child.
   // Offline and interactive states are mutually exclusive, so each path owns a
   // single trigger.
-  if (!agentOnline) {
+  if (!renderAction && !agentOnline) {
     return (
       <TooltipProvider delayDuration={300}>
         <Tooltip>
@@ -205,11 +217,16 @@ export function YoloButton({
 
   return (
     <>
+      {renderAction?.({
+        label: t("button"), disabledReason: reason,
+        busy: isStarting || isResolving || pickerState !== null || dialogOpen,
+        onSelect: () => { if (!reason) setDialogOpen(true); },
+      })}
       <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
         {/* Icon + label: the footer now has room (the standalone reassign button
             moved onto the assignee block), so Yolo reads as a full text button
             like Start Development rather than an icon-only shortcut. */}
-        <AlertDialogTrigger asChild>
+        {!renderAction && <AlertDialogTrigger asChild>
           <Button
             className={YOLO_BUTTON_CLASS}
             disabled={!enabled}
@@ -217,8 +234,8 @@ export function YoloButton({
             <Rocket className="mr-2 h-4 w-4" />
             {t("button")}
           </Button>
-        </AlertDialogTrigger>
-        <AlertDialogContent>
+        </AlertDialogTrigger>}
+        <AlertDialogContent onCloseAutoFocus={onCloseAutoFocus}>
           <AlertDialogHeader>
             <AlertDialogTitle>{t("confirmTitle")}</AlertDialogTitle>
             <AlertDialogDescription>{t("confirmDescription")}</AlertDialogDescription>
@@ -233,7 +250,7 @@ export function YoloButton({
             <Button
               className={YOLO_BUTTON_CLASS}
               onClick={handleConfirm}
-              disabled={isStarting || isResolving}
+              disabled={!!reason}
             >
               {isStarting ? (
                 <>
@@ -252,6 +269,7 @@ export function YoloButton({
           runWake. */}
       <WakeCwdPickerDialog
         open={pickerState !== null}
+        onCloseAutoFocus={onCloseAutoFocus}
         agentName={assigneeName ?? ""}
         instances={pickerState?.instances ?? []}
         agentUuid={pickerState?.agentUuid}

--- a/src/hooks/__tests__/use-pin-then-wake.test.tsx
+++ b/src/hooks/__tests__/use-pin-then-wake.test.tsx
@@ -15,7 +15,7 @@
 
 import React from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {
@@ -117,6 +117,83 @@ beforeEach(() => {
 });
 
 describe("usePinThenWake", () => {
+  it.each(["auto_pin", "pick", "temporary"] as const)("guards same-tick and stale-handler reentry throughout %s", async (path) => {
+    let releasePin!: () => void;
+    let releaseWake!: () => void;
+    const reassignNoWake = vi.fn(() => new Promise<{ success: boolean }>((resolve) => {
+      releasePin = () => resolve({ success: true });
+    }));
+    const wake = vi.fn(() => new Promise<void>((resolve) => { releaseWake = resolve; }));
+    const fetchPreview = vi.fn().mockResolvedValue({
+      outcome: path === "auto_pin" ? "auto_pin" : "pick",
+      assigneeAgentUuid: AGENT, onlineInstances: [candidate()],
+    });
+    const { result } = renderHook(() => usePinThenWake({ fetchPreview, reassignNoWake }));
+    const stale = result.current;
+    let running!: Promise<void>;
+    await act(async () => {
+      running = stale.start({ ideaUuid: IDEA, wake });
+      void stale.start({ ideaUuid: IDEA, wake });
+    });
+    expect(fetchPreview).toHaveBeenCalledOnce();
+    expect(result.current.isResolving).toBe(true);
+    if (path !== "auto_pin") {
+      expect(result.current.pickerState).not.toBeNull();
+      const confirm = () => path === "pick"
+        ? stale.confirmPick(candidate())
+        : stale.confirmTemporary({ agentUuid: AGENT, validationRequestUuid: "request" });
+      act(() => {
+        running = confirm();
+        void confirm();
+        // The dialog's late close event cannot unlock a committed operation.
+        stale.cancelPick();
+        void stale.start({ ideaUuid: IDEA, wake });
+      });
+    }
+    expect(result.current.isResolving).toBe(true);
+    expect(result.current.pickerState).toBeNull();
+    if (path !== "temporary") {
+      expect(reassignNoWake).toHaveBeenCalledOnce();
+      expect(wake).not.toHaveBeenCalled();
+      await act(async () => releasePin());
+    } else expect(reassignNoWake).not.toHaveBeenCalled();
+    expect(wake).toHaveBeenCalledOnce();
+    act(() => { stale.cancelPick(); void stale.start({ ideaUuid: IDEA, wake }); });
+    expect(result.current.isResolving).toBe(true);
+    expect(fetchPreview).toHaveBeenCalledOnce();
+    await act(async () => { releaseWake(); await running; });
+    expect(result.current.isResolving).toBe(false);
+  });
+
+  it.each(["preview", "direct", "pick", "temporary"] as const)("releases the lock after a thrown %s and allows retry", async (path) => {
+    const fetchPreview = vi.fn().mockResolvedValue({
+      outcome: path === "pick" || path === "temporary" ? "pick" : "direct",
+      assigneeAgentUuid: AGENT, onlineInstances: [candidate()],
+    });
+    if (path === "preview") fetchPreview.mockRejectedValueOnce(new Error("preview failed"));
+    const wake = vi.fn().mockRejectedValueOnce(new Error("wake failed")).mockResolvedValue(undefined);
+    const reassignNoWake = vi.fn().mockResolvedValue({ success: true });
+    const { result } = renderHook(() => usePinThenWake({ fetchPreview, reassignNoWake }));
+    await act(async () => {
+      if (path === "preview" || path === "direct") {
+        await expect(result.current.start({ ideaUuid: IDEA, wake })).rejects.toThrow();
+      } else {
+        await result.current.start({ ideaUuid: IDEA, wake });
+        const promise = path === "pick" ? result.current.confirmPick(candidate())
+          : result.current.confirmTemporary({ agentUuid: AGENT, validationRequestUuid: "request" });
+        await expect(promise).rejects.toThrow("wake failed");
+      }
+    });
+    expect(result.current.isResolving).toBe(false);
+    expect(result.current.pickerState).toBeNull();
+    await act(async () => {
+      await result.current.start({ ideaUuid: IDEA, wake: async () => {} });
+      result.current.cancelPick();
+    });
+    expect(fetchPreview).toHaveBeenCalledTimes(2);
+    expect(result.current.isResolving).toBe(false);
+  });
+
   it("preloads a fixed target and clears it when selection behavior is restored", async () => {
     const reassign = vi.fn();
     const wake = vi.fn();

--- a/src/hooks/use-pin-then-wake.ts
+++ b/src/hooks/use-pin-then-wake.ts
@@ -28,7 +28,7 @@
 // or fail validation between preview and submission. A failed pin never blocks
 // the wake; the server falls back to its own wake-target resolution.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { clientLogger } from "@/lib/logger-client";
 import {
   filterOnlineInstances,
@@ -123,8 +123,8 @@ async function defaultFetchPreview(
  *    `<WakeCwdPickerDialog>`.
  *  - `confirmPick(instance)` — call from the dialog's onConfirm.
  *  - `cancelPick()` — call from the dialog's onCancel.
- *  - `isResolving` — true while the preview is being fetched (button can show a
- *    spinner). Independent of the surface's own wake-pending flag.
+ *  - `isResolving` — true for the entire preview → picker → pin → wake flow.
+ *    Existing consumers can use it to block competing actions until completion.
  */
 export function usePinThenWake({
   fetchPreview = defaultFetchPreview,
@@ -135,13 +135,18 @@ export function usePinThenWake({
   const [isResolving, setIsResolving] = useState(false);
   const [fixedTarget, setFixedTarget] =
     useState<ResolvedProjectAgentCwdTarget | null>(null);
-  // The wake bound to the currently-open picker, captured at `start` time so
-  // `confirmPick` fires the exact wake the user initiated.
-  const [pendingWake, setPendingWake] = useState<{
-    run: (temporary?: TemporaryCwdSelection) => void | Promise<void>;
-  } | null>(
-    null,
-  );
+  // Refs guard same-tick/stale-handler reentry before React commits state.
+  // Only the picker phase is cancellable; closing an already-confirmed picker
+  // must never release the lock while its pin/wake is still in flight.
+  const phase = useRef<"idle" | "running" | "picking">("idle");
+  const pendingPick = useRef<{
+    state: PickerState;
+    wake: StartPinThenWakeArgs["wake"];
+  } | null>(null);
+  const finish = useCallback(() => {
+    phase.current = "idle";
+    setIsResolving(false);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -185,89 +190,105 @@ export function usePinThenWake({
 
   const start = useCallback(
     async ({ ideaUuid, wake }: StartPinThenWakeArgs) => {
+      if (phase.current !== "idle") return;
+      phase.current = "running";
       setIsResolving(true);
-      let preview: WakeTargetPreview | null = null;
       try {
-        preview = await fetchPreview(ideaUuid);
+        const preview = await fetchPreview(ideaUuid);
         setFixedTarget(
           preview?.resolvedTarget?.source === "project_fixed"
             ? preview.resolvedTarget
             : null,
         );
-      } finally {
-        setIsResolving(false);
-      }
 
-      // No preview (endpoint hiccup / not-found) OR no assignee agent OR the
-      // `direct` outcome → wake immediately, exactly as before this change.
-      if (!preview || !preview.assigneeAgentUuid || preview.outcome === "direct") {
-        await wake();
-        return;
-      }
-
-      const agentUuid = preview.assigneeAgentUuid;
-      const online = filterOnlineInstances(preview.onlineInstances);
-
-      if (preview.outcome === "pick") {
-        // Defensive: `pick` implies >=2 online, but if the list somehow arrived
-        // empty just wake (nothing to prompt with).
-        if (online.length === 0) {
+        // No preview (endpoint hiccup / not-found) OR no assignee agent OR the
+        // `direct` outcome → wake immediately, exactly as before this change.
+        if (!preview || !preview.assigneeAgentUuid || preview.outcome === "direct") {
           await wake();
           return;
         }
-        setPendingWake({ run: wake });
-        setPickerState({ ideaUuid, agentUuid, instances: online });
-        return;
-      }
 
-      // auto_pin → persist the sole online instance (best-effort), then wake.
-      if (preview.outcome === "auto_pin") {
-        const sole = online[0];
-        if (sole?.agentInstanceUuid) {
-          await reassignBestEffort(ideaUuid, agentUuid, sole.agentInstanceUuid);
+        const agentUuid = preview.assigneeAgentUuid;
+        const online = filterOnlineInstances(preview.onlineInstances);
+
+        if (preview.outcome === "pick") {
+          // Defensive: `pick` implies >=2 online, but if the list somehow arrived
+          // empty just wake (nothing to prompt with).
+          if (online.length === 0) {
+            await wake();
+            return;
+          }
+          const state = { ideaUuid, agentUuid, instances: online };
+          pendingPick.current = { state, wake };
+          phase.current = "picking";
+          setPickerState(state);
+          return;
         }
-        await wake();
-        return;
+
+        // auto_pin → persist the sole online instance (best-effort), then wake.
+        if (preview.outcome === "auto_pin") {
+          const sole = online[0];
+          if (sole?.agentInstanceUuid) {
+            await reassignBestEffort(ideaUuid, agentUuid, sole.agentInstanceUuid);
+          }
+          await wake();
+          return;
+        }
+      } finally {
+        // The picker owns the lock until confirm/cancel. All other paths,
+        // including thrown previews/wakes, release it here.
+        if (phase.current !== "picking") finish();
       }
     },
-    [fetchPreview, reassignBestEffort],
+    [fetchPreview, reassignBestEffort, finish],
   );
 
   const confirmPick = useCallback(
     async (instance: InstanceCandidate) => {
-      const state = pickerState;
-      const wake = pendingWake;
-      // Close the dialog first so the UI feels responsive; the reassign+wake
-      // then run against the captured state.
+      if (phase.current !== "picking" || !pendingPick.current) return;
+      const { state, wake } = pendingPick.current;
+      phase.current = "running";
+      pendingPick.current = null;
+      // Close promptly, but retain the busy flag through BOTH pin and wake.
       setPickerState(null);
-      setPendingWake(null);
-      if (!state || !wake) return;
-      if (instance.agentInstanceUuid) {
-        await reassignBestEffort(
-          state.ideaUuid,
-          state.agentUuid,
-          instance.agentInstanceUuid,
-        );
+      try {
+        if (instance.agentInstanceUuid) {
+          await reassignBestEffort(
+            state.ideaUuid,
+            state.agentUuid,
+            instance.agentInstanceUuid,
+          );
+        }
+        await wake();
+      } finally {
+        finish();
       }
-      await wake.run();
     },
-    [pickerState, pendingWake, reassignBestEffort],
+    [reassignBestEffort, finish],
   );
 
   const cancelPick = useCallback(() => {
     // Dismissing the picker aborts the whole action — no reassign, no wake.
+    if (phase.current !== "picking") return;
+    pendingPick.current = null;
     setPickerState(null);
-    setPendingWake(null);
-  }, []);
+    finish();
+  }, [finish]);
 
   const confirmTemporary = useCallback(
     async (selection: TemporaryCwdSelection) => {
-      const wake = pendingWake;
+      if (phase.current !== "picking" || !pendingPick.current) return;
+      const { wake } = pendingPick.current;
+      phase.current = "running";
+      pendingPick.current = null;
       setPickerState(null);
-      setPendingWake(null);
-      if (wake) await wake.run(selection);
+      try {
+        await wake(selection);
+      } finally {
+        finish();
+      }
     },
-    [pendingWake],
+    [finish],
   );
 
   return {


### PR DESCRIPTION
## Summary

- consolidate Tracker idea actions into a localized header Actions menu while keeping Close independent
- add copy-link/copy-UUID utilities, disabled explanations, inline edit controls, and preserved confirmation/wake flows
- restore Tooltip Escape and Derive/Move focus behavior; archive and synchronize the approved OpenSpec change

## Verification

- 6,424 tests passed in aggregate review; focused Tracker verification: 55 tests passed
- `pnpm exec tsc --noEmit` passed
- scoped ESLint: 0 errors
- production `pnpm build` passed in an isolated worktree (61/61 static pages)
- EN/ZH × light/dark × 1440/390 browser matrix passed with no overflow or console errors
- Tooltip Escape and Derive/Move focus restoration passed
- OpenSpec validation: 135/135; Chorus spec round-trip matches byte-for-byte

## Chorus

- Idea: `2ea7b6c1-e173-415c-9e70-d201b7e48863`
- Proposal: `03a72596-6949-4fc4-9158-b84de67a6563`
- Aggregate code review Round 2: PASS
- Pencil synchronization was explicitly waived by the owner.
