### PR TITLE
feat: adapt Tracker actions for mobile

### DIFF
--- a/openspec/specs/idea-tracker-actions-menu/spec.md
+++ b/openspec/specs/idea-tracker-actions-menu/spec.md
@@ -1,20 +1,20 @@
 # idea-tracker-actions-menu Specification
 
 ## Purpose
-TBD - created by archiving change consolidate-idea-tracker-actions. Update Purpose after archive.
+Provide a single, responsive and accessible entry point for Tracker idea operations while preserving every workflow gate and confirmation.
 ## Requirements
 ### Requirement: One Tracker action entry
-The Tracker idea sidebar SHALL expose a localized header Actions dropdown and independent Close, moving Derive, Move, Edit, Verify Elaborate, Start Development, Yolo and Delete into the menu. It SHALL remove the footer operation bar, retain inline edit Save/Cancel and leave other detail surfaces unchanged.
+The Tracker idea sidebar SHALL expose a localized header Actions entry and independent Close, moving Derive, Set parent idea, Move, Edit, Verify Elaborate, Start Development, Yolo and Delete into its action surface. The same Set parent idea operation SHALL handle both initial parent attachment and later parent changes. Actions SHALL open as a dropdown on desktop and as a bottom sheet on mobile. It SHALL remove the footer operation bar and the separate inline parent-control button, retain inline edit Save/Cancel and leave other detail surfaces unchanged.
 
 #### Scenario: View and edit an idea
 - **WHEN** a user opens the Tracker sidebar
-- **THEN** all seven operations are discoverable inside Actions and Close remains independent
+- **THEN** all eight operations are discoverable inside Actions and Close remains independent
 - **AND** no action footer is rendered
 - **WHEN** the user selects an enabled Edit operation
 - **THEN** Save and Cancel are available inside the edit form and Close preserves cancel-edit behavior
 
 ### Requirement: Availability and confirmation safety
-Operations SHALL preserve existing mutation eligibility, stage/presence checks, pin-then-wake routing, permissions and confirmations. Unavailable menu actions SHALL remain visible, non-executable and accompanied by localized reasons accessible with pointer and keyboard. Delete SHALL occupy a separated destructive group at the bottom and SHALL require confirmation.
+Operations SHALL preserve existing mutation eligibility, stage/presence checks, pin-then-wake routing, permissions and confirmations. Unavailable actions SHALL remain visible, non-executable and accompanied by localized reasons accessible with pointer and keyboard; mobile SHALL show those reasons inline. Delete SHALL occupy a separated destructive group at the bottom and SHALL require confirmation.
 
 #### Scenario: Unavailable actions
 - **WHEN** an action is unavailable due to incomplete elaboration, unsuitable stage, offline assignee, theme/container state, edit lock or an in-flight request
@@ -42,9 +42,10 @@ The menu SHALL copy the exact current idea UUID or its canonical absolute Tracke
 - **THEN** an error is shown, no success is shown, and the sidebar remains usable
 
 ### Requirement: Accessible localized presentation
-The menu SHALL use shadcn primitives, translated English/Chinese strings and theme-adaptive styling. Keyboard operation, focus return, narrow viewports and light/dark themes SHALL be verified.
+The action surface SHALL use shadcn primitives, translated English/Chinese strings and theme-adaptive styling. Verify Elaborate, Start Development and Yolo SHALL use distinct, theme-safe foreground colors. Keyboard operation, focus return, narrow viewports and light/dark themes SHALL be verified.
 
 #### Scenario: Keyboard and visual verification
 - **WHEN** a user opens Actions via keyboard in either locale and theme
-- **THEN** operations have readable labels, unavailable reasons are discoverable, Escape closes the menu and returns focus, and the sidebar/menu fit a narrow viewport
+- **THEN** operations have readable labels, AI-DLC actions remain visually distinguishable, unavailable reasons are discoverable, and Escape closes the surface and returns focus
+- **AND** a mobile viewport receives a bottom-anchored, scroll-contained sheet with touch-sized rows and safe-area padding
 - **AND** light and dark presentation remain legible without overflow

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-actions-menu.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-actions-menu.test.tsx
@@ -19,7 +19,7 @@ vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/stage-advance-action
 vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/[ideaUuid]/actions", () => ({ reassignIdeaInstanceNoWakeAction: mocks.reassign }));
 vi.mock("sonner", () => ({ toast: { success: mocks.success, error: mocks.error } }));
 
-const callbacks = { onVerify: vi.fn(), onDerive: vi.fn(), onMove: vi.fn(), onEdit: vi.fn(), onDelete: vi.fn(), onStarted: vi.fn() };
+const callbacks = { onVerify: vi.fn(), onDerive: vi.fn(), onSetParent: vi.fn(), onMove: vi.fn(), onEdit: vi.fn(), onDelete: vi.fn(), onStarted: vi.fn() };
 const base = {
   ideaUuid: "idea-1", projectUuid: "project-1", assignee: { type: "agent", uuid: "agent-1" },
   assigneeName: "Agent", proposals: [{ status: "approved" }], tasks: [{ status: "open" }], busy: false, ...callbacks,
@@ -41,6 +41,21 @@ function deferred<T>() {
   const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
   return { promise, resolve, reject };
 }
+function mockViewport(mobile: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(max-width: 639px)" ? mobile : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -49,6 +64,7 @@ beforeEach(() => {
   mocks.yolo.mockResolvedValue({ success: true });
   mocks.reassign.mockResolvedValue({ success: true });
   preview();
+  mockViewport(false);
   window.history.replaceState(null, "", "/projects/project-1/dashboard?panel=old&tab=tasks&search=noise#hash");
   globalThis.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} } as unknown as typeof ResizeObserver;
   Element.prototype.hasPointerCapture = () => false;
@@ -59,9 +75,61 @@ beforeEach(() => {
 async function open(user: ReturnType<typeof userEvent.setup>) { await user.click(screen.getByRole("button", { name: "Actions" })); }
 
 describe("Tracker Actions — real Radix interactions", () => {
+  it("uses a touch-sized bottom sheet on mobile with visible disabled reasons and safe-area padding", async () => {
+    mockViewport(true);
+    const user = userEvent.setup();
+    render(<Harness overrides={{ stageReason: en.ideaTracker.lineage.containerHint }} />);
+    const trigger = screen.getByRole("button", { name: "Actions" });
+    expect(trigger.className).toContain("h-11");
+    await user.click(trigger);
+
+    const sheet = screen.getByRole("dialog");
+    expect(sheet.getAttribute("data-slot")).toBe("sheet-content");
+    expect(sheet.className).toContain("rounded-t-2xl");
+    expect(sheet.className).toContain("safe-area-inset-bottom");
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(screen.getByRole("heading", { name: "Actions" })).toBeTruthy();
+
+    const start = screen.getByRole("button", { name: "Start Development" });
+    expect(start.className).toContain("min-h-12");
+    expect(start.getAttribute("aria-disabled")).toBe("true");
+    expect(start.textContent).toContain(en.ideaTracker.lineage.containerHint);
+    await user.click(start);
+    expect(mocks.start).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
+  it("closes the mobile sheet before running an action and restores trigger focus on Escape", async () => {
+    mockViewport(true);
+    const user = userEvent.setup();
+    render(<Harness />);
+    const trigger = screen.getByRole("button", { name: "Actions" });
+    await user.click(trigger);
+    await user.click(screen.getByRole("button", { name: "Verify Elaborate" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(callbacks.onVerify).toHaveBeenCalledOnce();
+
+    await user.click(trigger);
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("gives the AI-DLC actions distinct theme-safe foreground colors", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await open(user);
+    expect(screen.getByRole("menuitem", { name: "Verify Elaborate" }).className).toContain("text-[#1976D2]");
+    expect(screen.getByRole("menuitem", { name: "Verify Elaborate" }).className).toContain("dark:text-[#64B5F6]");
+    expect(screen.getByRole("menuitem", { name: "Start Development" }).className).toContain("text-[#2E7D32]");
+    expect(screen.getByRole("menuitem", { name: "Start Development" }).className).toContain("dark:text-[#72D572]");
+    expect(screen.getByRole("menuitem", { name: "Yolo" }).className).toContain("text-[#6A4FB6]");
+    expect(screen.getByRole("menuitem", { name: "Yolo" }).className).toContain("dark:text-[#B39DDB]");
+  });
+
   it("groups all actions with separated destructive Delete and no nested buttons", async () => {
     const user = userEvent.setup(); render(<Harness />); await open(user);
-    expect(screen.getAllByRole("menuitem")).toHaveLength(9);
+    expect(screen.getAllByRole("menuitem")).toHaveLength(10);
     expect(screen.getByRole("menuitem", { name: "Delete Idea" }).getAttribute("data-variant")).toBe("destructive");
     expect(screen.getByRole("menuitem", { name: "Delete Idea" }).previousElementSibling?.getAttribute("role")).toBe("separator");
     expect(document.querySelector("button button")).toBeNull();

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-detail-actions.test.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/__tests__/idea-detail-actions.test.tsx
@@ -28,7 +28,7 @@ vi.mock("../panels/activity-comments-view", () => ({ ActivityCommentsView: () =>
 vi.mock("@/app/(dashboard)/projects/[uuid]/tasks/task-detail-panel", () => ({ TaskDetailPanel: () => null }));
 vi.mock("../panels/document-panel", () => ({ DocumentPanel: () => null }));
 vi.mock("../panels/move-idea-dialog", () => ({ MoveIdeaDialog: ({ open }: { open: boolean }) => open ? <div role="dialog">Move</div> : null }));
-vi.mock("../panels/set-parent-dialog", () => ({ SetParentDialog: () => null }));
+vi.mock("../panels/set-parent-dialog", () => ({ SetParentDialog: ({ open }: { open: boolean }) => open ? <div role="dialog">Set parent</div> : null }));
 vi.mock("../new-idea-dialog", () => ({ NewIdeaDialog: ({ open }: { open: boolean }) => open ? <div role="dialog">Derive</div> : null }));
 vi.mock("@/app/(dashboard)/projects/[uuid]/ideas/assign-idea-modal", () => ({ AssignIdeaModal: () => null }));
 vi.mock("@/components/references-section", () => ({ ReferencesSection: () => null }));
@@ -118,6 +118,17 @@ describe("Tracker panel action integration", () => {
     expect(screen.getByRole("menuitem", { name: en.ideas.actions.move }).getAttribute("aria-disabled")).toBe("false");
     await user.click(screen.getByRole("menuitem", { name: en.ideaTracker.lineage.deriveIdea }));
     expect(screen.getByRole("dialog").textContent).toBe("Derive");
+  });
+
+  it("opens one consistently named parent action from Actions and removes the old inline button", async () => {
+    const user = userEvent.setup();
+    render(<Panel />);
+    expect(screen.queryByRole("button", { name: en.ideaTracker.lineage.setParent })).toBeNull();
+    expect(screen.queryByRole("button", { name: en.ideaTracker.lineage.changeParent })).toBeNull();
+    await open(user);
+    await user.click(screen.getByRole("menuitem", { name: en.ideaTracker.lineage.setParentTitle }));
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(screen.getByRole("dialog").textContent).toBe("Set parent");
   });
 
   it("keeps the elaborated edit lock visible and blocks mutations during a container update", async () => {

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-actions-menu.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-actions-menu.tsx
@@ -1,22 +1,51 @@
 "use client";
 
-import { useId, useState, type ReactNode, type RefObject } from "react";
+import { Fragment, useId, useState, useSyncExternalStore, type ReactNode, type RefObject } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
-import { ArrowRightLeft, CheckCircle2, ChevronDown, Copy, GitFork, Link, Pencil, Play, Rocket, Trash2 } from "lucide-react";
+import { ArrowRightLeft, CheckCircle2, ChevronDown, Copy, CornerLeftUp, GitFork, Link, Pencil, Play, Rocket, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { StartDevelopmentButton } from "@/components/start-development-button";
 import { YoloButton } from "@/components/yolo-button";
 import type { StartDevelopmentAssignee } from "@/lib/start-development";
 import { isImeComposing } from "@/lib/ime";
+import { cn } from "@/lib/utils";
+
+type ActionTone = "default" | "verify" | "develop" | "yolo" | "destructive";
+
+const toneClasses: Record<ActionTone, string> = {
+  default: "",
+  verify: "text-[#1976D2] focus:text-[#155FA0] focus:bg-[#E3F2FD] dark:text-[#64B5F6] dark:focus:text-[#90CAF9] dark:focus:bg-[#102A43]",
+  develop: "text-[#2E7D32] focus:text-[#256628] focus:bg-[#E8F5E9] dark:text-[#72D572] dark:focus:text-[#9AE69A] dark:focus:bg-[#17351D]",
+  yolo: "text-[#6A4FB6] focus:text-[#584098] focus:bg-[#F1ECFA] dark:text-[#B39DDB] dark:focus:text-[#D1C4E9] dark:focus:bg-[#2A2040]",
+  destructive: "text-destructive focus:text-destructive focus:bg-destructive/10",
+};
+
+const mobileQuery = "(max-width: 639px)";
+
+function subscribeToMobileQuery(onChange: () => void) {
+  if (typeof window === "undefined" || !window.matchMedia) return () => {};
+  const query = window.matchMedia(mobileQuery);
+  query.addEventListener?.("change", onChange);
+  return () => query.removeEventListener?.("change", onChange);
+}
+
+function getMobileSnapshot() {
+  return typeof window !== "undefined" && !!window.matchMedia?.(mobileQuery).matches;
+}
+
+function useIsMobile() {
+  return useSyncExternalStore(subscribeToMobileQuery, getMobileSnapshot, () => false);
+}
 
 /** aria-disabled rather than Radix disabled: unavailable operations remain in
  * the roving focus order so keyboard users can discover the explanation. */
-function ActionItem({ label, icon, reason, onSelect, onTooltipEscape, destructive = false }: {
+function ActionItem({ label, icon, reason, onSelect, onTooltipEscape, tone = "default" }: {
   label: string; icon: ReactNode; reason?: string; onSelect: () => void;
-  onTooltipEscape: () => void; destructive?: boolean;
+  onTooltipEscape: () => void; tone?: ActionTone;
 }) {
   const id = useId();
   const item = (
@@ -24,8 +53,8 @@ function ActionItem({ label, icon, reason, onSelect, onTooltipEscape, destructiv
       aria-label={label}
       aria-disabled={!!reason}
       aria-describedby={reason ? id : undefined}
-      variant={destructive ? "destructive" : "default"}
-      className={reason ? "text-muted-foreground cursor-default" : undefined}
+      variant={tone === "destructive" ? "destructive" : "default"}
+      className={cn(toneClasses[tone], reason && "cursor-default text-muted-foreground focus:bg-accent focus:text-muted-foreground dark:focus:bg-accent dark:text-muted-foreground dark:focus:text-muted-foreground")}
       onKeyDown={(event) => {
         if (event.key === "Enter" && isImeComposing(event)) event.preventDefault();
       }}
@@ -52,6 +81,38 @@ function ActionItem({ label, icon, reason, onSelect, onTooltipEscape, destructiv
   ) : item;
 }
 
+function MobileActionItem({ label, icon, reason, onSelect, tone = "default" }: {
+  label: string; icon: ReactNode; reason?: string; onSelect: () => void; tone?: ActionTone;
+}) {
+  const id = useId();
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-disabled={!!reason}
+      aria-describedby={reason ? id : undefined}
+      className={cn(
+        "focus-visible:ring-ring flex min-h-12 w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm outline-none transition-colors",
+        "hover:bg-accent focus-visible:ring-2 [&_svg]:size-5 [&_svg]:shrink-0",
+        toneClasses[tone],
+        reason && "cursor-default text-muted-foreground hover:bg-transparent focus:bg-accent focus:text-muted-foreground dark:focus:bg-accent dark:text-muted-foreground dark:focus:text-muted-foreground",
+      )}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" && isImeComposing(event)) event.preventDefault();
+      }}
+      onClick={() => {
+        if (!reason) onSelect();
+      }}
+    >
+      {icon}
+      <span className="min-w-0 flex-1">
+        <span className="block font-medium">{label}</span>
+        {reason && <span id={id} className="mt-0.5 block text-xs leading-4 text-muted-foreground">{reason}</span>}
+      </span>
+    </button>
+  );
+}
+
 interface IdeaActionsMenuProps {
   ideaUuid: string;
   projectUuid: string;
@@ -67,6 +128,7 @@ interface IdeaActionsMenuProps {
   editReason?: string;
   onVerify: () => void;
   onDerive: () => void;
+  onSetParent: () => void;
   onMove: () => void;
   onEdit: () => void;
   onDelete: () => void;
@@ -77,7 +139,8 @@ interface IdeaActionsMenuProps {
 export function IdeaActionsMenu(props: IdeaActionsMenuProps) {
   const t = useTranslations();
   const ta = useTranslations("ideaTracker.panel.actions");
-  const [menuOpen, setMenuOpen] = useState(false);
+  const [actionsOpen, setActionsOpen] = useState(false);
+  const isMobile = useIsMobile();
   const busyReason = props.busy ? ta("busy") : undefined;
   const stageReason = busyReason || props.stageReason || props.stageDataReason;
   const copy = async (link: boolean) => {
@@ -103,27 +166,90 @@ export function IdeaActionsMenu(props: IdeaActionsMenuProps) {
     <StartDevelopmentButton {...shared} renderAction={(start) => (
       <YoloButton {...shared} disabledReason={stageReason || (start.busy ? ta("busy") : undefined)} renderAction={(yolo) => {
         const mutationReason = busyReason || (start.busy || yolo.busy ? ta("busy") : undefined);
+        const groups = [
+          [
+            { label: t("elaboration.verifyButton"), icon: <CheckCircle2 />, reason: mutationReason || props.stageReason || props.verifyReason, onSelect: props.onVerify, tone: "verify" as const },
+            { label: start.label, icon: <Play />, reason: mutationReason || start.disabledReason, onSelect: start.onSelect, tone: "develop" as const },
+            { label: yolo.label, icon: <Rocket />, reason: mutationReason || yolo.disabledReason, onSelect: yolo.onSelect, tone: "yolo" as const },
+          ],
+          [
+            { label: t("ideaTracker.lineage.deriveIdea"), icon: <GitFork />, reason: mutationReason, onSelect: props.onDerive, tone: "default" as const },
+            { label: t("ideaTracker.lineage.setParentTitle"), icon: <CornerLeftUp />, reason: mutationReason, onSelect: props.onSetParent, tone: "default" as const },
+            { label: t("ideas.actions.move"), icon: <ArrowRightLeft />, reason: mutationReason, onSelect: props.onMove, tone: "default" as const },
+            { label: t("ideas.editIdea"), icon: <Pencil />, reason: mutationReason || props.editReason, onSelect: props.onEdit, tone: "default" as const },
+          ],
+          [
+            { label: ta("copyLink"), icon: <Link />, onSelect: () => { void copy(true); }, tone: "default" as const },
+            { label: ta("copyUuid"), icon: <Copy />, onSelect: () => { void copy(false); }, tone: "default" as const },
+          ],
+          [
+            { label: t("ideas.deleteIdea"), icon: <Trash2 />, reason: mutationReason, onSelect: props.onDelete, tone: "destructive" as const },
+          ],
+        ];
+
+        if (isMobile) {
+          return (
+            <Sheet open={actionsOpen} onOpenChange={setActionsOpen}>
+              <SheetTrigger asChild>
+                <Button ref={props.triggerRef} variant="outline" size="sm" className="h-11 gap-1.5 border-border px-3">
+                  {t("common.actions")}<ChevronDown className="size-4" aria-hidden />
+                </Button>
+              </SheetTrigger>
+              <SheetContent
+                side="bottom"
+                className="max-h-[min(82svh,44rem)] gap-0 overflow-hidden rounded-t-2xl pb-[max(1rem,env(safe-area-inset-bottom))]"
+                onCloseAutoFocus={props.onCloseAutoFocus}
+              >
+                <div className="mx-auto mt-2 h-1 w-10 shrink-0 rounded-full bg-muted-foreground/25" aria-hidden />
+                <SheetHeader className="border-b px-4 pt-3 pb-3 text-left">
+                  <SheetTitle>{t("common.actions")}</SheetTitle>
+                  <SheetDescription className="sr-only">{t("common.actions")}</SheetDescription>
+                </SheetHeader>
+                <div className="overflow-y-auto overscroll-contain px-2 py-2">
+                  {groups.map((group, groupIndex) => (
+                    <div
+                      key={groupIndex}
+                      className={cn(groupIndex > 0 && "mt-1 border-t pt-1")}
+                    >
+                      {group.map((action) => (
+                        <MobileActionItem
+                          key={action.label}
+                          {...action}
+                          onSelect={() => {
+                            setActionsOpen(false);
+                            action.onSelect();
+                          }}
+                        />
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              </SheetContent>
+            </Sheet>
+          );
+        }
+
         return (
           <TooltipProvider delayDuration={300}>
-            <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+            <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
               <DropdownMenuTrigger asChild>
                 <Button ref={props.triggerRef} variant="outline" size="sm" className="h-8 gap-1.5 border-border px-2.5">
                   {t("common.actions")}<ChevronDown className="h-3.5 w-3.5" aria-hidden />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="z-[100] w-64 max-w-[calc(100vw-1rem)] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto">
-                <ActionItem label={t("elaboration.verifyButton")} icon={<CheckCircle2 />} reason={mutationReason || props.stageReason || props.verifyReason} onSelect={props.onVerify} onTooltipEscape={() => setMenuOpen(false)} />
-                <ActionItem label={start.label} icon={<Play />} reason={mutationReason || start.disabledReason} onSelect={start.onSelect} onTooltipEscape={() => setMenuOpen(false)} />
-                <ActionItem label={yolo.label} icon={<Rocket />} reason={mutationReason || yolo.disabledReason} onSelect={yolo.onSelect} onTooltipEscape={() => setMenuOpen(false)} />
-                <DropdownMenuSeparator />
-                <ActionItem label={t("ideaTracker.lineage.deriveIdea")} icon={<GitFork />} reason={mutationReason} onSelect={props.onDerive} onTooltipEscape={() => setMenuOpen(false)} />
-                <ActionItem label={t("ideas.actions.move")} icon={<ArrowRightLeft />} reason={mutationReason} onSelect={props.onMove} onTooltipEscape={() => setMenuOpen(false)} />
-                <ActionItem label={t("ideas.editIdea")} icon={<Pencil />} reason={mutationReason || props.editReason} onSelect={props.onEdit} onTooltipEscape={() => setMenuOpen(false)} />
-                <DropdownMenuSeparator />
-                <ActionItem label={ta("copyLink")} icon={<Link />} onSelect={() => { void copy(true); }} onTooltipEscape={() => setMenuOpen(false)} />
-                <ActionItem label={ta("copyUuid")} icon={<Copy />} onSelect={() => { void copy(false); }} onTooltipEscape={() => setMenuOpen(false)} />
-                <DropdownMenuSeparator />
-                <ActionItem label={t("ideas.deleteIdea")} icon={<Trash2 />} reason={mutationReason} onSelect={props.onDelete} onTooltipEscape={() => setMenuOpen(false)} destructive />
+                {groups.map((group, groupIndex) => (
+                  <Fragment key={groupIndex}>
+                    {groupIndex > 0 && <DropdownMenuSeparator />}
+                    {group.map((action) => (
+                      <ActionItem
+                        key={action.label}
+                        {...action}
+                        onTooltipEscape={() => setActionsOpen(false)}
+                      />
+                    ))}
+                  </Fragment>
+                ))}
               </DropdownMenuContent>
             </DropdownMenu>
           </TooltipProvider>

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-actions-menu.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-actions-menu.tsx
@@ -86,8 +86,9 @@ function MobileActionItem({ label, icon, reason, onSelect, tone = "default" }: {
 }) {
   const id = useId();
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
       aria-label={label}
       aria-disabled={!!reason}
       aria-describedby={reason ? id : undefined}
@@ -109,7 +110,7 @@ function MobileActionItem({ label, icon, reason, onSelect, tone = "default" }: {
         <span className="block font-medium">{label}</span>
         {reason && <span id={id} className="mt-0.5 block text-xs leading-4 text-muted-foreground">{reason}</span>}
       </span>
-    </button>
+    </Button>
   );
 }
 

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/idea-detail-panel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "@/hooks/use-progress-router";
 import { toast } from "sonner";
-import { X, Loader2, Pencil, GitFork, CornerLeftUp, CornerDownRight, Link as LinkIcon } from "lucide-react";
+import { X, Loader2, GitFork, CornerLeftUp, CornerDownRight, Link as LinkIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
@@ -744,6 +744,7 @@ function IdeaDetailPanelContent({
                 editReason={idea.status === "elaborated" ? tTracker("panel.actions.editUnavailable") : undefined}
                 onVerify={handleVerify}
                 onDerive={() => setShowDeriveDialog(true)}
+                onSetParent={() => setShowSetParentDialog(true)}
                 onMove={() => setShowMoveDialog(true)}
                 onEdit={handleStartEdit}
                 onDelete={() => setShowDeleteDialog(true)}
@@ -892,22 +893,14 @@ function IdeaDetailPanelContent({
                         onSelectTask={openTask}
                       />
 
-                      {/* Lineage section — parent breadcrumb + set-parent + derived children */}
+                      {/* Lineage section — parent breadcrumb + derived children.
+                          Parent assignment lives in the unified Actions surface. */}
                       <div className="mt-5 space-y-2">
-                        <div className="flex items-center justify-between">
+                        <div className="flex items-center">
                           <div className="flex items-center gap-1.5">
                             <GitFork className="h-3.5 w-3.5 text-primary" />
                             <span className="text-[12px] font-semibold text-foreground/80">{tLineage("title")}</span>
                           </div>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="h-7 gap-1 border-border px-2 text-[11px] text-muted-foreground"
-                            onClick={() => setShowSetParentDialog(true)}
-                          >
-                            <Pencil className="h-3 w-3" />
-                            {idea.parentUuid ? tLineage("changeParent") : tLineage("setParent")}
-                          </Button>
                         </div>
 
                         {/* Parent breadcrumb */}
@@ -1102,6 +1095,7 @@ function IdeaDetailPanelContent({
           currentParentUuid={idea.parentUuid ?? null}
           descendantUuids={idea.descendantUuids ?? []}
           onChanged={fetchIdea}
+          onCloseAutoFocus={returnFocusToActions}
         />
       )}
 

--- a/src/app/(dashboard)/projects/[uuid]/dashboard/panels/set-parent-dialog.tsx
+++ b/src/app/(dashboard)/projects/[uuid]/dashboard/panels/set-parent-dialog.tsx
@@ -37,6 +37,8 @@ interface SetParentDialogProps {
   descendantUuids: string[];
   /** Called after a successful parent change so the panel can refresh. */
   onChanged: () => void;
+  /** Return focus to the Actions trigger after this menu-owned dialog closes. */
+  onCloseAutoFocus?: (event: Event) => void;
 }
 
 interface PickerIdea {
@@ -53,6 +55,7 @@ export function SetParentDialog({
   currentParentUuid,
   descendantUuids,
   onChanged,
+  onCloseAutoFocus,
 }: SetParentDialogProps) {
   const t = useTranslations("ideaTracker.lineage");
   const tCommon = useTranslations("common");
@@ -112,7 +115,7 @@ export function SetParentDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent onCloseAutoFocus={onCloseAutoFocus}>
         <DialogHeader>
           <DialogTitle>{t("setParentTitle")}</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Summary
- render Tracker Actions as a bottom sheet on mobile while preserving the desktop dropdown
- restore distinct theme-aware text colors for AI-DLC actions
- move the unified Set parent idea operation into Actions and preserve focus restoration

## Verification
- `pnpm exec vitest run src/app/\(dashboard\)/projects/\[uuid\]/dashboard/__tests__/idea-actions-menu.test.tsx src/app/\(dashboard\)/projects/\[uuid\]/dashboard/__tests__/idea-detail-actions.test.tsx` (45 passed)
- `pnpm exec tsc --noEmit`
- changed-file ESLint
- `pnpm build`
- Playwright mobile acceptance at 390x844: bottom sheet, parent picker, focus restoration, 0 console errors